### PR TITLE
feat: fase 8 — convergio-cli (pure HTTP client)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -324,6 +324,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "convergio-agents"
 version = "0.1.0"
 dependencies = [
@@ -340,12 +353,22 @@ dependencies = [
 name = "convergio-cli"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "convergio-types",
+ "dialoguer",
+ "dirs 5.0.1",
+ "futures-util",
+ "hostname",
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 1.0.69",
  "tokio",
+ "toml",
+ "url",
 ]
 
 [[package]]
@@ -503,7 +526,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -586,6 +609,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,11 +634,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -613,7 +670,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -627,6 +684,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -706,6 +769,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +799,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1559,6 +1634,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -1615,12 +1701,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1795,6 +1883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1901,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1836,6 +1946,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2092,6 +2208,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,10 +2431,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2443,6 +2625,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,9 +2739,27 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2567,6 +2780,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2604,6 +2832,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2616,6 +2850,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2625,6 +2865,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2652,6 +2898,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2661,6 +2913,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2676,6 +2934,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2688,6 +2952,12 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2697,6 +2967,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/daemon/crates/convergio-cli/Cargo.toml
+++ b/daemon/crates/convergio-cli/Cargo.toml
@@ -11,8 +11,20 @@ path = "src/main.rs"
 
 [dependencies]
 convergio-types = { path = "../convergio-types" }
-reqwest = { workspace = true }
-tokio = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
+tokio = { workspace = true, features = ["process"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+dirs = "5"
+dialoguer = "0.11"
+hostname = "0.4"
+toml = "0.8"
+url = "2"
+futures-util = "0.3"
+
+[dev-dependencies]
+tempfile = "3"
+serde_yaml = "0.9"

--- a/daemon/crates/convergio-cli/src/cli_agent.rs
+++ b/daemon/crates/convergio-cli/src/cli_agent.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Agent subcommands for the cvg CLI — delegates to daemon HTTP API via reqwest.
+// JSON output by default; --human flag for readable text.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum AgentCommands {
+    /// Transpile an agent from the catalog to a provider-specific format
+    Transpile {
+        /// Agent name (looked up via /api/agents/catalog)
+        name: String,
+        /// Target provider: claude-code, copilot-cli, generic-llm
+        #[arg(long, default_value = "claude-code")]
+        provider: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Start a new agent session
+    Start {
+        /// Agent name or type
+        name: String,
+        /// Task ID this agent is working on
+        #[arg(long)]
+        task_id: Option<i64>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Complete an active agent session
+    Complete {
+        /// Agent session ID
+        agent_id: String,
+        /// Completion summary
+        #[arg(long)]
+        summary: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List active agents
+    List {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Sync agent catalog from .agent.md files in a directory
+    Sync {
+        /// Directory containing .agent.md files
+        source_dir: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Enable an agent from catalog (write .agent.md to target dir)
+    Enable {
+        /// Agent name from catalog
+        name: String,
+        /// Directory to write the .agent.md file to
+        #[arg(long)]
+        target_dir: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Disable an agent (remove .agent.md from target dir)
+    Disable {
+        /// Agent name
+        name: String,
+        /// Directory containing the .agent.md file
+        #[arg(long)]
+        target_dir: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List agents in the catalog
+    Catalog {
+        /// Filter by category
+        #[arg(long)]
+        category: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Triage a problem — find the best agent for a given task
+    Triage {
+        /// Description of the problem to solve
+        description: String,
+        /// Optional domain filter (e.g. "technical", "core")
+        #[arg(long)]
+        domain: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show agent activity history (completed/failed sessions)
+    History {
+        /// ISO datetime lower bound (default: 7 days ago)
+        #[arg(long)]
+        since: Option<String>,
+        /// ISO datetime upper bound
+        #[arg(long)]
+        until: Option<String>,
+        /// Filter by status (completed, failed, running)
+        #[arg(long)]
+        status: Option<String>,
+        /// Filter by model name
+        #[arg(long)]
+        model: Option<String>,
+        /// Max rows (default 20, max 500)
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a new agent in the catalog
+    Create {
+        /// Agent name
+        name: String,
+        /// Agent category
+        #[arg(long, default_value = "")]
+        category: String,
+        /// Agent description
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Model to use
+        #[arg(long, default_value = "claude-sonnet-4-6")]
+        model: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+#[cfg(test)]
+#[path = "cli_agent_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_agent_format.rs
+++ b/daemon/crates/convergio-cli/src/cli_agent_format.rs
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Agent command dispatch + transpile logic — extracted from cli_agent.rs (Plan F, T4-02).
+
+use crate::cli_agent::AgentCommands;
+use crate::cli_error::CliError;
+
+pub(crate) async fn dispatch(cmd: AgentCommands) -> Result<(), CliError> {
+    match cmd {
+        AgentCommands::Transpile {
+            name,
+            provider,
+            api_url,
+        } => {
+            handle_transpile(&name, &provider, &api_url).await?;
+        }
+        AgentCommands::Start {
+            name,
+            task_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "agent_id": name,
+                "name": name,
+                "task_id": task_id,
+            });
+            crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/agent/start"),
+                &body,
+                human,
+            )
+            .await?;
+        }
+        AgentCommands::Complete {
+            agent_id,
+            summary,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "agent_id": agent_id,
+                "summary": summary,
+            });
+            crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/agent/complete"),
+                &body,
+                human,
+            )
+            .await?;
+        }
+        AgentCommands::List { human, api_url } => {
+            crate::cli_http::fetch_and_print(&format!("{api_url}/api/agents"), human).await?;
+        }
+        AgentCommands::Sync {
+            source_dir,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({"source_dir": source_dir});
+            crate::cli_http::post_and_print(&format!("{api_url}/api/agents/sync"), &body, human)
+                .await?;
+        }
+        AgentCommands::Enable {
+            name,
+            target_dir,
+            human,
+            api_url,
+        } => {
+            let dir = target_dir.unwrap_or_else(|| ".github/agents".to_string());
+            let body = serde_json::json!({"name": name, "target_dir": dir});
+            crate::cli_http::post_and_print(&format!("{api_url}/api/agents/enable"), &body, human)
+                .await?;
+        }
+        AgentCommands::Disable {
+            name,
+            target_dir,
+            human,
+            api_url,
+        } => {
+            let dir = target_dir.unwrap_or_else(|| ".github/agents".to_string());
+            let body = serde_json::json!({"name": name, "target_dir": dir});
+            crate::cli_http::post_and_print(&format!("{api_url}/api/agents/disable"), &body, human)
+                .await?;
+        }
+        AgentCommands::Catalog {
+            category,
+            human,
+            api_url,
+        } => {
+            let url = if let Some(cat) = category {
+                format!("{api_url}/api/agents/catalog?category={cat}")
+            } else {
+                format!("{api_url}/api/agents/catalog")
+            };
+            crate::cli_http::fetch_and_print(&url, human).await?;
+        }
+        AgentCommands::Triage {
+            description,
+            domain,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "problem_description": description,
+                "domain": domain,
+            });
+            crate::cli_http::post_and_print(&format!("{api_url}/api/agents/triage"), &body, human)
+                .await?;
+        }
+        AgentCommands::History {
+            since,
+            until,
+            status,
+            model,
+            limit,
+            api_url,
+        } => {
+            crate::cli_agent_history::handle_history(
+                &api_url, since, until, status, model, limit,
+            )
+            .await?;
+        }
+        AgentCommands::Create {
+            name,
+            category,
+            description,
+            model,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "name": name, "category": category,
+                "description": description, "model": model,
+            });
+            crate::cli_http::post_and_print(&format!("{api_url}/api/agents/create"), &body, human)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn handle_transpile(name: &str, provider: &str, api_url: &str) -> Result<(), CliError> {
+    let enc: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c.to_string()
+            } else {
+                format!("%{:02X}", c as u32)
+            }
+        })
+        .collect();
+    let url = format!("{api_url}/api/agents/catalog?name={enc}");
+    let resp = reqwest::get(&url)
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    let agent = if val.is_array() {
+        val.as_array().and_then(|a| a.first()).cloned()
+    } else {
+        Some(val)
+    };
+    let agent =
+        agent.ok_or_else(|| CliError::NotFound(format!("agent '{name}' not found in catalog")))?;
+    let desc = agent["description"].as_str().unwrap_or("");
+    let model = agent["model"].as_str().unwrap_or("claude-sonnet-4-6");
+    let tools = agent["tools"].as_str().unwrap_or("view,edit,bash");
+    let output = match provider {
+        "claude-code" => crate::transpiler::transpile_claude_code(name, desc, model, tools),
+        "copilot-cli" => crate::transpiler::transpile_copilot_cli(name, desc, model, tools),
+        "generic-llm" => crate::transpiler::transpile_generic_llm(name, desc, model),
+        other => {
+            return Err(CliError::InvalidInput(format!(
+                "unknown provider '{other}'; use: claude-code, copilot-cli, generic-llm"
+            )));
+        }
+    };
+    print!("{output}");
+    Ok(())
+}

--- a/daemon/crates/convergio-cli/src/cli_agent_history.rs
+++ b/daemon/crates/convergio-cli/src/cli_agent_history.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Agent history CLI handler — extracted from cli_agent_format.rs (250-line limit).
+
+use crate::cli_error::CliError;
+
+pub(crate) async fn handle_history(
+    api_url: &str,
+    since: Option<String>,
+    until: Option<String>,
+    status: Option<String>,
+    model: Option<String>,
+    limit: Option<u32>,
+) -> Result<(), CliError> {
+    // Default: 7 days for CLI (API defaults to 30)
+    let since_val = since.unwrap_or_else(|| {
+        let dt = chrono::Utc::now() - chrono::Duration::days(7);
+        dt.format("%Y-%m-%dT%H:%M:%S").to_string()
+    });
+    let lim = limit.unwrap_or(20).min(500);
+    let mut pairs = url::form_urlencoded::Serializer::new(String::new());
+    pairs.append_pair("since", &since_val);
+    if let Some(ref u) = until {
+        pairs.append_pair("until", u);
+    }
+    if let Some(ref s) = status {
+        pairs.append_pair("status", s);
+    }
+    if let Some(ref m) = model {
+        pairs.append_pair("model", m);
+    }
+    pairs.append_pair("limit", &lim.to_string());
+    let qs = pairs.finish();
+    let url = format!("{api_url}/api/agents/history?{qs}");
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let rows: Vec<serde_json::Value> = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    if rows.is_empty() {
+        println!("No agent history found.");
+        return Ok(());
+    }
+    print_history_table(&rows);
+    Ok(())
+}
+
+fn print_history_table(rows: &[serde_json::Value]) {
+    println!(
+        "{:<28} {:<18} {:<11} {:>8} {:>9} {:>8} {}",
+        "AGENT", "MODEL", "STATUS", "DURATION", "TOKENS", "COST", "STARTED"
+    );
+    for r in rows {
+        let agent = r["agent_id"].as_str().unwrap_or("-");
+        let mdl = r["model"].as_str().unwrap_or("-");
+        let st = r["status"].as_str().unwrap_or("-");
+        let dur = format_duration(r["duration_s"].as_f64());
+        let tok_in = r["tokens_in"].as_i64().unwrap_or(0);
+        let tok_out = r["tokens_out"].as_i64().unwrap_or(0);
+        let tokens = format!("{}/{}", tok_in, tok_out);
+        let cost = r["cost_usd"].as_f64().unwrap_or(0.0);
+        let cost_s = format!("${cost:.3}");
+        let started = r["started_at"].as_str().unwrap_or("-");
+        let agent_short = truncate(agent, 27);
+        let mdl_short = truncate(mdl, 17);
+        println!(
+            "{:<28} {:<18} {:<11} {:>8} {:>9} {:>8} {}",
+            agent_short, mdl_short, st, dur, tokens, cost_s, started
+        );
+    }
+    println!("\n{} record(s)", rows.len());
+}
+
+fn format_duration(secs: Option<f64>) -> String {
+    match secs {
+        Some(s) if s >= 3600.0 => format!("{:.0}h{:.0}m", s / 3600.0, (s % 3600.0) / 60.0),
+        Some(s) if s >= 60.0 => format!("{:.0}m{:.0}s", s / 60.0, s % 60.0),
+        Some(s) => format!("{:.0}s", s),
+        None => "-".to_string(),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}~", &s[..max - 1])
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_agent_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_agent_tests.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_agent module.
+
+use super::*;
+
+#[test]
+fn agent_commands_transpile_variant_exists() {
+    let cmd = AgentCommands::Transpile {
+        name: "code-reviewer".to_string(),
+        provider: "claude-code".to_string(),
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Transpile { .. }));
+}
+
+#[test]
+fn agent_commands_start_variant_exists() {
+    let cmd = AgentCommands::Start {
+        name: "task-executor".to_string(),
+        task_id: Some(8797),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Start { .. }));
+}
+
+#[test]
+fn agent_commands_complete_variant_exists() {
+    let cmd = AgentCommands::Complete {
+        agent_id: "abc-123".to_string(),
+        summary: Some("done".to_string()),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Complete { .. }));
+}
+
+#[test]
+fn agent_commands_list_variant_exists() {
+    let cmd = AgentCommands::List {
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::List { .. }));
+}
+
+#[test]
+fn agent_commands_triage_variant_exists() {
+    let cmd = AgentCommands::Triage {
+        description: "debugging a deployment issue".to_string(),
+        domain: Some("technical".to_string()),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Triage { .. }));
+}
+
+#[test]
+fn triage_builds_correct_body() {
+    let body = serde_json::json!({
+        "problem_description": "need help with debugging",
+        "domain": "technical",
+    });
+    assert_eq!(body["problem_description"], "need help with debugging");
+    assert_eq!(body["domain"], "technical");
+}
+
+#[test]
+fn agent_start_builds_correct_body() {
+    let body = serde_json::json!({
+        "name": "task-executor",
+        "task_id": 42_i64,
+    });
+    assert_eq!(body["name"], "task-executor");
+    assert_eq!(body["task_id"], 42);
+}
+
+#[test]
+fn agent_commands_sync_variant_exists() {
+    let cmd = AgentCommands::Sync {
+        source_dir: "/tmp/agents".to_string(),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Sync { .. }));
+}
+
+#[test]
+fn agent_commands_enable_variant_exists() {
+    let cmd = AgentCommands::Enable {
+        name: "baccio".to_string(),
+        target_dir: Some(".github/agents".to_string()),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Enable { .. }));
+}
+
+#[test]
+fn agent_commands_disable_variant_exists() {
+    let cmd = AgentCommands::Disable {
+        name: "baccio".to_string(),
+        target_dir: None,
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Disable { .. }));
+}
+
+#[test]
+fn agent_commands_catalog_variant_exists() {
+    let cmd = AgentCommands::Catalog {
+        category: Some("technical".to_string()),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Catalog { .. }));
+}
+
+#[test]
+fn agent_commands_create_variant_exists() {
+    let cmd = AgentCommands::Create {
+        name: "new-agent".to_string(),
+        category: "technical".to_string(),
+        description: "A new agent".to_string(),
+        model: "claude-sonnet-4-6".to_string(),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AgentCommands::Create { .. }));
+}
+
+#[test]
+fn catalog_url_with_category_filter() {
+    let cat = "technical";
+    let api_url = "http://localhost:8420";
+    let url = format!("{api_url}/api/agents/catalog?category={cat}");
+    assert_eq!(
+        url,
+        "http://localhost:8420/api/agents/catalog?category=technical"
+    );
+}
+
+#[test]
+fn enable_default_target_dir() {
+    let target_dir: Option<String> = None;
+    let dir = target_dir.unwrap_or_else(|| ".github/agents".to_string());
+    assert_eq!(dir, ".github/agents");
+}

--- a/daemon/crates/convergio-cli/src/cli_agents.rs
+++ b/daemon/crates/convergio-cli/src/cli_agents.rs
@@ -1,0 +1,4 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Agent, KB, and Run CLI module — groups the three agent-related handler modules.
+// Split per C-01 (250-line limit): cli_agent.rs, cli_kb.rs, cli_run.rs.
+// main.rs references each sub-module directly for handler dispatch.

--- a/daemon/crates/convergio-cli/src/cli_api_list.rs
+++ b/daemon/crates/convergio-cli/src/cli_api_list.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// `cvg api list` — print all daemon HTTP API endpoints grouped by domain.
+
+pub fn api_list_text() -> &'static str {
+    r#"Convergio Daemon API — all endpoints (port 8420)
+
+PLANS
+  GET  /api/plan-db/list[?status=&limit=]    List plans (all by default)
+  GET  /api/plan-db/json/:plan_id           Compact plan JSON
+  GET  /api/plan-db/execution-tree/:plan_id Execution tree (waves + tasks)
+  GET  /api/plan-db/context/:plan_id        Full plan context for execution
+  GET  /api/plan-db/execution-context/:plan_id  Next pending task + prompt
+  GET  /api/plan-db/drift-check/:plan_id    Plan staleness check
+  GET  /api/plan-db/readiness/:plan_id      Pre-execution readiness
+  POST /api/plan-db/create                  Create new plan
+  POST /api/plan-db/import                  Import spec YAML
+  POST /api/plan-db/start/:plan_id          Start plan execution
+  POST /api/plan-db/complete/:plan_id       Mark plan complete
+  POST /api/plan-db/cancel/:plan_id         Cancel plan
+  POST /api/plan-db/approve/:plan_id        Approve for execution
+  POST /api/plan-db/task/update             Update task status
+  POST /api/plan-db/set-worktree/:plan_id   Set plan worktree path
+  POST /api/plans/:plan_id/validate         Thor wave validation
+
+WAVES & KB
+  POST /api/plan-db/wave/create             Create wave
+  POST /api/plan-db/wave/update             Update wave
+  GET  /api/plan-db/kb-search               Search knowledge base
+  POST /api/plan-db/kb-write                Write KB entry
+
+AGENTS
+  GET  /api/agents/catalog                  List agent catalog
+  POST /api/agents/sync                     Sync agent catalog
+  POST /api/agents/enable                   Enable agent
+  POST /api/agents/disable                  Disable agent
+  POST /api/agents/create                   Create agent entry
+  POST /api/agent/interrupt                 Interrupt blocked agent
+  POST /api/task/reschedule                 Reschedule task to another node
+
+MESH & PEERS
+  GET  /api/peers                           List peers
+  POST /api/peers                           Create peer
+  GET  /api/peers/discover                  Discover Tailscale peers
+  POST /api/peers/ssh-check                 Check SSH connectivity
+  GET  /api/crdt/status                     CRDT sync status
+  POST /api/crdt/force-sync                 Force CRDT sync
+  GET  /api/crdt/peers                      CRDT peer list
+
+KERNEL & HEALTH
+  GET  /api/health                          Health check
+  GET  /api/health/deep                     Deep health check (all subsystems)
+  GET  /api/node/readiness                  Node readiness (10 checks)
+
+CHAT
+  GET  /api/chat/models                     Available chat models
+  GET  /api/chat/sessions                   List chat sessions
+  POST /api/chat/message                    Send chat message
+  POST /api/chat/approve                    Approve chat action
+  POST /api/chat/execute                    Execute chat command
+  PUT  /api/chat/requirement                Upsert requirement
+
+CHANNELS
+  GET  /api/channels                        List channels
+  POST /api/channels/:name/send             Send message to channel
+  GET  /api/channels/:name/health           Channel health
+
+CAPABILITIES
+  GET  /api/capabilities/list               List capabilities
+  POST /api/capabilities/invoke             Invoke capability
+  POST /api/capabilities/register           Register capability
+  GET  /api/capabilities/schema/:name       Get capability schema
+  PUT  /api/capabilities/permissions        Update permissions
+
+METRICS & TRACKING
+  GET  /api/metrics/summary                 Metrics summary
+  GET  /api/metrics/cost                    Cost breakdown
+  GET  /api/metrics/run/:id                 Run metrics
+  POST /api/tracking/tokens                 Track token usage
+  POST /api/tracking/agent-activity         Track agent activity
+  POST /api/tracking/session-state          Track session state
+  POST /api/tracking/compaction             Record compaction
+
+WORKSPACE
+  GET  /api/workspace/list                  List workspaces
+  POST /api/workspace/create                Create workspace
+
+AUDIT & REPOS
+  GET  /api/audit/project/:project_id       Project audit
+  GET  /api/repositories/:name              Show repository
+
+SSE & WEBSOCKET
+  GET  /api/chat/stream/:sid                Chat stream (SSE)
+  GET  /api/mesh/action/stream              Mesh action stream (SSE)
+  GET  /api/plan/preflight                  Plan preflight (SSE)
+  GET  /api/plan/delegate                   Plan delegate (SSE)
+  GET  /api/plan/start                      Plan start (SSE)
+  GET  /ws/brain                            Brain WebSocket
+  GET  /ws/dashboard                        Dashboard WebSocket
+  GET  /ws/pty                              PTY WebSocket
+
+OPENCLAW
+  GET  /api/openclaw/agents                 List OpenClaw agents
+  POST /api/openclaw/invoke                 Invoke OpenClaw agent
+"#
+}
+
+pub fn print_api_list() {
+    print!("{}", api_list_text());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_list_covers_major_domains() {
+        let text = api_list_text();
+        let domains = [
+            "PLANS", "AGENTS", "MESH & PEERS", "KERNEL & HEALTH",
+            "CHAT", "CHANNELS", "CAPABILITIES", "METRICS",
+        ];
+        for domain in domains {
+            assert!(text.contains(domain), "must cover domain '{domain}'");
+        }
+    }
+
+    #[test]
+    fn api_list_includes_methods() {
+        let text = api_list_text();
+        assert!(text.contains("GET "), "must include GET methods");
+        assert!(text.contains("POST"), "must include POST methods");
+        assert!(text.contains("PUT "), "must include PUT methods");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_ask.rs
+++ b/daemon/crates/convergio-cli/src/cli_ask.rs
@@ -1,0 +1,244 @@
+use crate::cli_error::CliError;
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+pub async fn handle(
+    alias: String,
+    message: Option<String>,
+    list: bool,
+    set_alias: Option<String>,
+    set_agent: Option<String>,
+    api_url: &str,
+) -> Result<(), CliError> {
+    if list {
+        return handle_list(api_url).await;
+    }
+    if let (Some(a), Some(agent)) = (set_alias, set_agent) {
+        return handle_set(&a, &agent);
+    }
+    let msg = message.ok_or_else(|| {
+        CliError::InvalidInput("Usage: cvg ask <alias> \"message\"".into())
+    })?;
+    let agent_name = resolve_alias(&alias, api_url).await?;
+    run_ask("user", &agent_name, &msg, DEFAULT_TIMEOUT_SECS, api_url).await;
+    Ok(())
+}
+
+fn aliases_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".convergio")
+        .join("aliases.toml")
+}
+
+fn load_aliases() -> std::collections::HashMap<String, String> {
+    let path = aliases_path();
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let table: toml::Value = match content.parse() {
+        Ok(v) => v,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let mut map = std::collections::HashMap::new();
+    if let Some(aliases) = table.get("aliases").and_then(|v| v.as_table()) {
+        for (k, v) in aliases {
+            if let Some(s) = v.as_str() {
+                map.insert(k.clone(), s.to_string());
+            }
+        }
+    }
+    map
+}
+
+async fn resolve_alias(alias: &str, api_url: &str) -> Result<String, CliError> {
+    let aliases = load_aliases();
+    if let Some(agent) = aliases.get(alias) {
+        return Ok(agent.clone());
+    }
+    // Try prefix match against agent catalog
+    if let Ok(agents) = fetch_catalog_agents(api_url).await {
+        for name in &agents {
+            if name.starts_with(alias) {
+                return Ok(name.clone());
+            }
+        }
+    }
+    // Fallback: use alias as-is (might be a full agent name)
+    Ok(alias.to_string())
+}
+
+async fn fetch_catalog_agents(api_url: &str) -> Result<Vec<String>, CliError> {
+    let client = reqwest::Client::new();
+    let url = format!("{api_url}/api/ipc/agents/list");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("{e}")))?;
+    let data: Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("{e}")))?;
+    let mut names = Vec::new();
+    if let Some(agents) = data.get("agents").and_then(|v| v.as_array()) {
+        for a in agents {
+            if let Some(id) = a.get("agent_id").and_then(|v| v.as_str()) {
+                names.push(id.to_string());
+            }
+        }
+    }
+    Ok(names)
+}
+
+async fn handle_list(api_url: &str) -> Result<(), CliError> {
+    let aliases = load_aliases();
+    println!("\x1b[1mConfigured aliases:\x1b[0m");
+    if aliases.is_empty() {
+        println!("  (none — run cvg setup to generate defaults)");
+    } else {
+        let mut sorted: Vec<_> = aliases.iter().collect();
+        sorted.sort_by_key(|(k, _)| (*k).clone());
+        for (alias, agent) in sorted {
+            println!("  \x1b[36m{alias:12}\x1b[0m → {agent}");
+        }
+    }
+    // Also show active agents
+    if let Ok(agents) = fetch_catalog_agents(api_url).await {
+        if !agents.is_empty() {
+            println!("\n\x1b[1mActive agents (direct name also works):\x1b[0m");
+            for name in &agents {
+                let aliased = aliases.values().any(|v| v == name);
+                let marker = if aliased { " (aliased)" } else { "" };
+                println!("  \x1b[2m{name}{marker}\x1b[0m");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn handle_set(alias: &str, agent: &str) -> Result<(), CliError> {
+    let path = aliases_path();
+    let content = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut table: toml::Value = content
+        .parse()
+        .unwrap_or_else(|_| toml::Value::Table(toml::map::Map::new()));
+    let aliases = table
+        .as_table_mut()
+        .unwrap()
+        .entry("aliases")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()))
+        .as_table_mut()
+        .ok_or_else(|| CliError::InvalidInput("corrupt aliases.toml".into()))?;
+    aliases.insert(alias.to_string(), toml::Value::String(agent.to_string()));
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(CliError::Io)?;
+    }
+    std::fs::write(&path, table.to_string()).map_err(CliError::Io)?;
+    println!("Alias set: {alias} → {agent}");
+    Ok(())
+}
+
+async fn run_ask(from: &str, to: &str, message: &str, timeout_secs: u64, api_url: &str) {
+    let client = reqwest::Client::new();
+    let body = json!({
+        "from": from,
+        "to": to,
+        "message": message,
+        "timeout_secs": timeout_secs
+    });
+    let url = format!("{api_url}/api/ipc/ask");
+    match client.post(&url).json(&body).send().await {
+        Ok(resp) => match resp.json::<Value>().await {
+            Ok(payload) => match parse_response(&payload) {
+                Ok(reply) => println!("{reply}"),
+                Err(err) => eprintln!("error: {err}"),
+            },
+            Err(e) => eprintln!("error: invalid response: {e}"),
+        },
+        Err(e) => eprintln!("error: request failed: {e}"),
+    }
+}
+
+fn parse_response(payload: &Value) -> Result<String, String> {
+    if payload.get("ok").and_then(Value::as_bool) == Some(true) {
+        let reply = payload
+            .get("reply")
+            .ok_or_else(|| "missing reply".to_string())?;
+        let from = reply
+            .get("from")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let content = reply
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        return Ok(format!("\x1b[32m\x1b[1m{from}\x1b[0m: {content}"));
+    }
+    let code = payload
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(Value::as_str)
+        .unwrap_or("ERROR");
+    let msg = payload
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("request failed");
+    Err(format!("{code}: {msg}"))
+}
+
+pub fn generate_default_aliases() -> String {
+    r#"[aliases]
+baccio = "baccio-tech-architect"
+rex = "rex-code-reviewer"
+ali = "ali-chief-of-staff"
+otto = "otto-performance-optimizer"
+luca = "luca-security-expert"
+sara = "sara-ux-ui-designer"
+paolo = "paolo-best-practices-enforcer"
+marco = "marco-devops-engineer"
+omri = "omri-data-scientist"
+"#
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_successful_reply() {
+        let payload = json!({
+            "ok": true,
+            "reply": { "from": "baccio", "content": "Analysis complete." }
+        });
+        let result = parse_response(&payload).unwrap();
+        assert!(result.contains("baccio"));
+        assert!(result.contains("Analysis complete."));
+    }
+
+    #[test]
+    fn parse_error_reply() {
+        let payload = json!({
+            "ok": false,
+            "error": { "code": "TIMEOUT", "message": "No reply within 120s" }
+        });
+        let err = parse_response(&payload).unwrap_err();
+        assert!(err.contains("TIMEOUT"));
+    }
+
+    #[test]
+    fn generate_defaults_has_all_aliases() {
+        let content = generate_default_aliases();
+        assert!(content.contains("baccio"));
+        assert!(content.contains("rex"));
+        assert!(content.contains("ali"));
+        assert!(content.contains("otto"));
+        assert!(content.contains("luca"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_audit.rs
+++ b/daemon/crates/convergio-cli/src/cli_audit.rs
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Audit CLI — replaces project-audit.sh.
+// Checks: file sizes (>250 lines), token budget, copyright headers, constitution files.
+
+use std::path::{Path, PathBuf};
+
+/// Constitution files that must exist at the project root.
+pub const CONSTITUTION_FILES: &[&str] = &[
+    "CONSTITUTION.md",
+    "AgenticManifesto.md",
+    "LEGAL_NOTICE.md",
+    "CLAUDE.md",
+];
+
+/// Token budget limits (in bytes) per instruction file type.
+/// Mirrors claude-config/rules/token-budget.md.
+pub struct Budget {
+    pub pattern: &'static str,
+    pub max_bytes: u64,
+    pub label: &'static str,
+}
+
+pub const BUDGETS: &[Budget] = &[
+    Budget {
+        pattern: "CLAUDE.md",
+        max_bytes: 16_384,
+        label: "CLAUDE.md/AGENTS.md",
+    },
+    Budget {
+        pattern: "AGENTS.md",
+        max_bytes: 16_384,
+        label: "CLAUDE.md/AGENTS.md",
+    },
+    Budget {
+        pattern: "rules/",
+        max_bytes: 8_192,
+        label: "rules/*.md",
+    },
+    Budget {
+        pattern: "skills/",
+        max_bytes: 6_144,
+        label: "skills/*/*.md",
+    },
+    Budget {
+        pattern: "agents/",
+        max_bytes: 6_144,
+        label: "agents/*/*.md",
+    },
+    Budget {
+        pattern: "copilot-agents/",
+        max_bytes: 6_144,
+        label: "copilot-agents/*.md",
+    },
+];
+
+#[derive(Debug)]
+pub struct Violation {
+    pub path: PathBuf,
+    pub kind: ViolationKind,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ViolationKind {
+    /// Source file exceeds 250-line limit.
+    TooManyLines { lines: usize },
+    /// Instruction file exceeds token budget.
+    TokenBudgetExceeded {
+        bytes: u64,
+        max_bytes: u64,
+        label: String,
+    },
+    /// Source file is missing the required copyright header.
+    MissingCopyright,
+    /// A required constitution file is absent from the project root.
+    ConstitutionMissing { filename: String },
+}
+
+/// Run all audit checks under `root`.  Returns list of violations (empty = clean).
+pub fn audit(root: &Path) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    check_constitution(root, &mut violations);
+    walk(root, root, &mut violations);
+    violations
+}
+
+/// Verify that all required constitution files exist at the project root.
+fn check_constitution(root: &Path, out: &mut Vec<Violation>) {
+    for name in CONSTITUTION_FILES {
+        if !root.join(name).exists() {
+            out.push(Violation {
+                path: root.join(name),
+                kind: ViolationKind::ConstitutionMissing {
+                    filename: name.to_string(),
+                },
+            });
+        }
+    }
+}
+
+/// Recursively walk the directory tree, skipping hidden dirs and build artifacts.
+fn walk(root: &Path, dir: &Path, out: &mut Vec<Violation>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Skip hidden dirs and common build/generated dirs.
+        if name_str.starts_with('.')
+            || matches!(
+                name_str.as_ref(),
+                "target" | "node_modules" | "dist" | "__pycache__"
+            )
+        {
+            continue;
+        }
+        if path.is_dir() {
+            walk(root, &path, out);
+        } else if path.is_file() {
+            check_file(root, &path, out);
+        }
+    }
+}
+
+/// Apply all file-level checks.
+fn check_file(root: &Path, path: &Path, out: &mut Vec<Violation>) {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    // Source files: line count + copyright.
+    if matches!(ext, "rs" | "ts" | "js" | "py" | "sh") {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            let lines = content.lines().count();
+            if lines > 250 {
+                out.push(Violation {
+                    path: path.to_owned(),
+                    kind: ViolationKind::TooManyLines { lines },
+                });
+            }
+            if !has_copyright(&content) {
+                out.push(Violation {
+                    path: path.to_owned(),
+                    kind: ViolationKind::MissingCopyright,
+                });
+            }
+        }
+        return;
+    }
+    // Instruction Markdown files: token budget check.
+    if ext == "md" {
+        if let Some(budget) = find_budget(root, path) {
+            if let Ok(meta) = std::fs::metadata(path) {
+                if meta.len() > budget.max_bytes {
+                    out.push(Violation {
+                        path: path.to_owned(),
+                        kind: ViolationKind::TokenBudgetExceeded {
+                            bytes: meta.len(),
+                            max_bytes: budget.max_bytes,
+                            label: budget.label.to_string(),
+                        },
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Return true if the file contains a copyright line within the first 5 lines.
+pub fn has_copyright(content: &str) -> bool {
+    content
+        .lines()
+        .take(5)
+        .any(|l| l.to_lowercase().contains("copyright"))
+}
+
+/// Match a markdown file path against the token-budget patterns.
+/// Returns the first matching budget, or None for unlisted md files.
+pub fn find_budget<'a>(root: &Path, path: &Path) -> Option<&'a Budget> {
+    let rel = match path.strip_prefix(root) {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+    let rel_str = rel.to_string_lossy();
+    let file_name = path.file_name()?.to_string_lossy().to_string();
+    for budget in BUDGETS {
+        if budget.pattern.ends_with('/') {
+            if rel_str.contains(budget.pattern) {
+                return Some(budget);
+            }
+        } else if file_name == budget.pattern {
+            return Some(budget);
+        }
+    }
+    None
+}
+
+/// Format a violation for human-readable output.
+pub fn format_violation(v: &Violation) -> String {
+    let p = v.path.display();
+    match &v.kind {
+        ViolationKind::TooManyLines { lines } => {
+            format!("[LINES]        {p}  ({lines} lines, max 250)")
+        }
+        ViolationKind::TokenBudgetExceeded {
+            bytes,
+            max_bytes,
+            label,
+        } => format!("[TOKEN-BUDGET] {p}  ({bytes}B > {max_bytes}B, type: {label})"),
+        ViolationKind::MissingCopyright => {
+            format!("[COPYRIGHT]    {p}  (missing copyright header)")
+        }
+        ViolationKind::ConstitutionMissing { filename } => {
+            format!("[CONSTITUTION] {filename}  (required file missing from project root)")
+        }
+    }
+}
+
+/// Entry point called from main.rs dispatch.
+pub fn handle(path: PathBuf) -> Result<(), crate::cli_error::CliError> {
+    let root = if path.as_os_str().is_empty() || path == std::path::Path::new(".") {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        path
+    };
+    println!("Auditing: {}", root.display());
+    let violations = audit(&root);
+    if violations.is_empty() {
+        println!("OK — no violations found.");
+        return Ok(());
+    }
+    println!("\n{} violation(s) found:\n", violations.len());
+    for v in &violations {
+        println!("  {}", format_violation(v));
+    }
+    Err(crate::cli_error::CliError::ViolationsFound(format!(
+        "{} violation(s) found",
+        violations.len()
+    )))
+}
+
+#[cfg(test)]
+#[path = "cli_audit_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_audit_project.rs
+++ b/daemon/crates/convergio-cli/src/cli_audit_project.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Project-level audit — fetches aggregated data from daemon API and writes report.
+
+use crate::cli_error::CliError;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::fs;
+
+/// Fetch project audit report from daemon API, optionally write to disk.
+pub async fn handle(
+    project_id: &str,
+    output: bool,
+    yes: bool,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/audit/project/{project_id}");
+    let resp = reqwest::get(&url)
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+
+    let status = resp.status();
+    let report: Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+
+    if !status.is_success() {
+        let msg = report["error"].as_str().unwrap_or("unknown error");
+        return Err(CliError::NotFound(msg.to_string()));
+    }
+
+    // Pretty-print to stdout
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).unwrap_or_else(|_| report.to_string())
+    );
+
+    if output {
+        write_report(project_id, &report, yes, api_url).await?;
+    }
+    Ok(())
+}
+
+/// Write audit report + metadata to project output directory, create deliverable record.
+async fn write_report(
+    project_id: &str,
+    report: &Value,
+    yes: bool,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let output_dir = crate::paths::project_output_dir(project_id);
+    let now = Utc::now();
+    let date_prefix = now.format("%Y-%m-%d").to_string();
+
+    // Find next version number by scanning existing audit folders
+    let version = next_audit_version(&output_dir, &date_prefix);
+    let folder_name = format!("{date_prefix}_audit_v{version}");
+    let dest = output_dir.join(&folder_name);
+
+    // Interactive confirmation unless --yes
+    if !yes {
+        eprintln!("Audit report will be written to:");
+        eprintln!("  {}", dest.display());
+        eprint!("Continue? [y/N] ");
+        let mut answer = String::new();
+        if std::io::stdin().read_line(&mut answer).is_err()
+            || !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
+        {
+            return Err(CliError::NotFound("Aborted.".into()));
+        }
+    }
+
+    // Permission preflight
+    fs::create_dir_all(&dest).map_err(|e| {
+        print_permission_help();
+        CliError::Io(e)
+    })?;
+
+    // Write report.json
+    let report_path = dest.join("report.json");
+    let report_str = serde_json::to_string_pretty(report).unwrap_or_else(|_| report.to_string());
+    fs::write(&report_path, &report_str).map_err(|e| {
+        print_permission_help();
+        CliError::Io(e)
+    })?;
+
+    // Write metadata.json
+    let metadata = json!({
+        "project_id": project_id,
+        "type": "audit",
+        "version": version,
+        "created_at": now.to_rfc3339(),
+        "output_path": dest.to_string_lossy(),
+    });
+    let meta_path = dest.join("metadata.json");
+    fs::write(&meta_path, serde_json::to_string_pretty(&metadata).unwrap())?;
+
+    eprintln!("Report written to: {}", dest.display());
+
+    // Create deliverable record in DB via daemon API
+    let body = json!({
+        "project_id": project_id,
+        "name": format!("audit_{date_prefix}"),
+        "output_type": "audit",
+    });
+    let client = reqwest::Client::new();
+    match client
+        .post(format!("{api_url}/api/deliverables"))
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            eprintln!("Deliverable record created.");
+        }
+        Ok(resp) => {
+            let msg = resp.text().await.unwrap_or_default();
+            eprintln!("warn: deliverable creation failed: {msg}");
+        }
+        Err(e) => {
+            eprintln!("warn: could not reach daemon for deliverable: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Scan output directory for existing audit folders to find next version number.
+fn next_audit_version(output_dir: &std::path::Path, date_prefix: &str) -> u32 {
+    let pattern = format!("{date_prefix}_audit_v");
+    let max = match fs::read_dir(output_dir) {
+        Ok(entries) => entries
+            .flatten()
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                name.strip_prefix(&pattern).and_then(|v| match v.parse::<u32>() {
+                    Ok(n) => Some(n),
+                    Err(_) => None,
+                })
+            })
+            .max()
+            .unwrap_or(0),
+        Err(_) => 0,
+    };
+    max + 1
+}
+
+/// Print OS-specific instructions for permission errors.
+fn print_permission_help() {
+    if cfg!(target_os = "macos") {
+        eprintln!(
+            "hint: on macOS, grant Full Disk Access to your terminal app via\n  \
+             System Settings > Privacy & Security > Full Disk Access"
+        );
+    } else if cfg!(target_os = "linux") {
+        eprintln!(
+            "hint: on Linux, check folder permissions with `ls -la` and fix with\n  \
+             chmod -R u+rX <folder>"
+        );
+    } else {
+        eprintln!("hint: ensure the current user has write permissions on the output folder");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_audit_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_audit_tests.rs
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_audit — split to keep cli_audit.rs under 250 lines.
+
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_tmp() -> TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn write_constitution(dir: &TempDir) {
+    for f in CONSTITUTION_FILES {
+        fs::write(dir.path().join(f), b"x").unwrap();
+    }
+}
+
+// --- Constitution checks ---
+
+#[test]
+fn constitution_all_present_no_violation() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    let violations = audit(dir.path());
+    let count = violations
+        .iter()
+        .filter(|v| matches!(v.kind, ViolationKind::ConstitutionMissing { .. }))
+        .count();
+    assert_eq!(count, 0, "all constitution files present");
+}
+
+#[test]
+fn constitution_missing_one_raises_violation() {
+    let dir = make_tmp();
+    for f in CONSTITUTION_FILES.iter().skip(1) {
+        fs::write(dir.path().join(f), b"x").unwrap();
+    }
+    let violations = audit(dir.path());
+    let missing: Vec<_> = violations.iter()
+        .filter(|v| matches!(&v.kind, ViolationKind::ConstitutionMissing { filename } if filename == "CONSTITUTION.md"))
+        .collect();
+    assert_eq!(missing.len(), 1, "CONSTITUTION.md missing raises violation");
+}
+
+// --- Line count checks ---
+
+#[test]
+fn file_under_250_lines_passes() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    let content = "// Copyright (c) 2026 Roberto D'Angelo.\nfn x() {}\n".repeat(100);
+    fs::write(dir.path().join("ok.rs"), content.as_bytes()).unwrap();
+    let line_viol: Vec<_> = audit(dir.path())
+        .into_iter()
+        .filter(|v| matches!(v.kind, ViolationKind::TooManyLines { .. }))
+        .collect();
+    assert!(line_viol.is_empty());
+}
+
+#[test]
+fn file_over_250_lines_fails() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    let mut content = "// Copyright (c) 2026 Roberto D'Angelo.\n".to_string();
+    for i in 0..260 {
+        content.push_str(&format!("let x{i} = {i};\n"));
+    }
+    fs::write(dir.path().join("big.rs"), content.as_bytes()).unwrap();
+    let line_viol: Vec<_> = audit(dir.path())
+        .into_iter()
+        .filter(|v| matches!(v.kind, ViolationKind::TooManyLines { .. }))
+        .collect();
+    assert_eq!(line_viol.len(), 1);
+    if let ViolationKind::TooManyLines { lines } = &line_viol[0].kind {
+        assert!(*lines > 250);
+    }
+}
+
+// --- Copyright checks ---
+
+#[test]
+fn file_with_copyright_passes() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    fs::write(
+        dir.path().join("ok.rs"),
+        b"// Copyright (c) 2026 Roberto D'Angelo.\nfn x() {}",
+    )
+    .unwrap();
+    let copy_viol: Vec<_> = audit(dir.path())
+        .into_iter()
+        .filter(|v| matches!(v.kind, ViolationKind::MissingCopyright))
+        .collect();
+    assert!(copy_viol.is_empty());
+}
+
+#[test]
+fn file_without_copyright_fails() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    fs::write(dir.path().join("bad.rs"), b"fn main() {}\n").unwrap();
+    let copy_viol: Vec<_> = audit(dir.path())
+        .into_iter()
+        .filter(|v| matches!(v.kind, ViolationKind::MissingCopyright))
+        .filter(|v| v.path.file_name().map(|n| n == "bad.rs").unwrap_or(false))
+        .collect();
+    assert_eq!(copy_viol.len(), 1);
+}
+
+// --- Token budget checks ---
+
+#[test]
+fn rules_file_within_budget_passes() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    let rules = dir.path().join("rules");
+    fs::create_dir(&rules).unwrap();
+    fs::write(rules.join("test.md"), b"# small rule").unwrap();
+    let budget_viol: Vec<_> = audit(dir.path())
+        .into_iter()
+        .filter(|v| matches!(v.kind, ViolationKind::TokenBudgetExceeded { .. }))
+        .collect();
+    assert!(budget_viol.is_empty());
+}
+
+#[test]
+fn rules_file_over_budget_fails() {
+    let dir = make_tmp();
+    write_constitution(&dir);
+    let rules = dir.path().join("rules");
+    fs::create_dir(&rules).unwrap();
+    // 8193 bytes > 8192 byte limit for rules/*.md
+    fs::write(rules.join("oversize.md"), vec![b'x'; 8_193]).unwrap();
+    let budget_viol: Vec<_> = audit(dir.path())
+        .into_iter()
+        .filter(|v| matches!(v.kind, ViolationKind::TokenBudgetExceeded { .. }))
+        .filter(|v| {
+            v.path
+                .file_name()
+                .map(|n| n == "oversize.md")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(budget_viol.len(), 1);
+}
+
+// --- format_violation ---
+
+#[test]
+fn format_violation_lines() {
+    let v = Violation {
+        path: PathBuf::from("src/big.rs"),
+        kind: ViolationKind::TooManyLines { lines: 300 },
+    };
+    let s = format_violation(&v);
+    assert!(s.contains("300") && s.contains("LINES"));
+}
+
+#[test]
+fn format_violation_copyright() {
+    let v = Violation {
+        path: PathBuf::from("src/bad.rs"),
+        kind: ViolationKind::MissingCopyright,
+    };
+    assert!(format_violation(&v).contains("COPYRIGHT"));
+}
+
+#[test]
+fn format_violation_constitution() {
+    let v = Violation {
+        path: PathBuf::from("CONSTITUTION.md"),
+        kind: ViolationKind::ConstitutionMissing {
+            filename: "CONSTITUTION.md".into(),
+        },
+    };
+    assert!(format_violation(&v).contains("CONSTITUTION"));
+}
+
+#[test]
+fn format_violation_token_budget() {
+    let v = Violation {
+        path: PathBuf::from("rules/big.md"),
+        kind: ViolationKind::TokenBudgetExceeded {
+            bytes: 9000,
+            max_bytes: 8192,
+            label: "rules/*.md".into(),
+        },
+    };
+    let s = format_violation(&v);
+    assert!(s.contains("TOKEN-BUDGET") && s.contains("9000"));
+}

--- a/daemon/crates/convergio-cli/src/cli_bus.rs
+++ b/daemon/crates/convergio-cli/src/cli_bus.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Bus (IPC) subcommands for the cvg CLI — delegates to daemon HTTP API.
+// JSON output by default; --human flag for readable text.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum BusCommands {
+    /// List connected agents on the IPC bus
+    Who {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Send a message to a specific agent
+    Send {
+        /// Sender agent name
+        from: String,
+        /// Recipient agent name
+        to: String,
+        /// Message content
+        message: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Read messages for an agent
+    Read {
+        /// Agent name to read messages for
+        name: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Broadcast a message to all agents
+    Broadcast {
+        /// Sender agent name
+        from: String,
+        /// Message content
+        message: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Render org hierarchy tree from org API data
+    Org {
+        /// Human-readable tree output (default true)
+        #[arg(long, default_value_t = true)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Watch direct messages for an agent over SSE
+    Watch {
+        /// Agent name to subscribe as
+        name: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Ask an agent and wait for a direct reply
+    Ask {
+        /// Sender agent name
+        from: String,
+        /// Recipient agent name
+        to: String,
+        /// Message content
+        message: String,
+        /// Timeout in seconds
+        #[arg(long, default_value_t = 120)]
+        timeout: u64,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: BusCommands) {
+    match cmd {
+        BusCommands::Who { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/ipc/agents"), human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        BusCommands::Send {
+            from,
+            to,
+            message,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "from": from,
+                "to": to,
+                "message": message,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(&format!("{api_url}/api/ipc/send"), &body, human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        BusCommands::Read {
+            name,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/ipc/messages?agent={name}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        BusCommands::Broadcast {
+            from,
+            message,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "from": from,
+                "message": message,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(&format!("{api_url}/api/ipc/broadcast"), &body, human)
+                .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        BusCommands::Org { human, api_url } => {
+            crate::cli_bus_org::run_org(&api_url, human).await;
+        }
+        BusCommands::Watch { name, api_url } => {
+            if let Err(e) = crate::cli_bus_watch::run_watch(&name, &api_url).await {
+                eprintln!("error: {e}");
+            }
+        }
+        BusCommands::Ask {
+            from,
+            to,
+            message,
+            timeout,
+            api_url,
+        } => {
+            crate::cli_bus_ask::run_ask(&from, &to, &message, timeout, &api_url).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bus_who_variant_exists() {
+        let cmd = BusCommands::Who {
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BusCommands::Who { .. }));
+    }
+
+    #[test]
+    fn bus_send_variant_exists() {
+        let cmd = BusCommands::Send {
+            from: "planner".to_string(),
+            to: "executor".to_string(),
+            message: "start task T1-01".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BusCommands::Send { .. }));
+    }
+
+    #[test]
+    fn bus_send_body_shape() {
+        let body = serde_json::json!({
+            "from": "planner",
+            "to": "executor",
+            "message": "start task T1-01",
+        });
+        assert_eq!(body["from"], "planner");
+        assert_eq!(body["to"], "executor");
+        assert_eq!(body["message"], "start task T1-01");
+    }
+
+    #[test]
+    fn bus_read_variant_exists() {
+        let cmd = BusCommands::Read {
+            name: "thor".to_string(),
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BusCommands::Read { .. }));
+    }
+
+    #[test]
+    fn bus_broadcast_variant_exists() {
+        let cmd = BusCommands::Broadcast {
+            from: "coordinator".to_string(),
+            message: "wave complete".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BusCommands::Broadcast { .. }));
+    }
+
+    #[test]
+    fn bus_broadcast_body_shape() {
+        let body = serde_json::json!({
+            "from": "coordinator",
+            "message": "wave complete",
+        });
+        assert_eq!(body["from"], "coordinator");
+        assert_eq!(body["message"], "wave complete");
+    }
+
+    #[test]
+    fn bus_read_url_includes_agent_param() {
+        let name = "thor";
+        let api_url = "http://localhost:8420";
+        let url = format!("{api_url}/api/ipc/messages?agent={name}");
+        assert!(url.contains("agent=thor"));
+    }
+
+    #[test]
+    fn bus_org_variant_exists() {
+        let cmd = BusCommands::Org {
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BusCommands::Org { .. }));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_bus_ask.rs
+++ b/daemon/crates/convergio-cli/src/cli_bus_ask.rs
@@ -1,0 +1,70 @@
+use serde_json::{json, Value};
+
+pub async fn run_ask(from: &str, to: &str, message: &str, timeout_secs: u64, api_url: &str) {
+    let client = reqwest::Client::new();
+    let body = json!({
+        "from": from,
+        "to": to,
+        "message": message,
+        "timeout_secs": timeout_secs
+    });
+    let url = format!("{api_url}/api/ipc/ask");
+    match client.post(&url).json(&body).send().await {
+        Ok(resp) => match resp.json::<Value>().await {
+            Ok(payload) => match parse_ask_response(&payload) {
+                Ok(reply) => println!("{reply}"),
+                Err(err) => eprintln!("error: {err}"),
+            },
+            Err(e) => eprintln!("error: invalid ask response: {e}"),
+        },
+        Err(e) => eprintln!("error: ask request failed: {e}"),
+    }
+}
+
+pub fn parse_ask_response(payload: &Value) -> Result<String, String> {
+    if payload.get("ok").and_then(Value::as_bool) == Some(true) {
+        let reply = payload
+            .get("reply")
+            .ok_or_else(|| "missing reply".to_string())?;
+        let from = reply
+            .get("from")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let content = reply
+            .get("content")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        return Ok(format!("{from}: {content}"));
+    }
+    let code = payload
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(Value::as_str)
+        .unwrap_or("ERROR");
+    let message = payload
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("request failed");
+    Err(format!("{code}: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ask_response;
+    use serde_json::json;
+
+    #[test]
+    fn ask_timeout_returns_structured_error() {
+        let payload = json!({
+            "ok": false,
+            "error": {
+                "code": "TIMEOUT",
+                "message": "No reply from priya within 120s"
+            }
+        });
+        let err = parse_ask_response(&payload).expect_err("timeout expected");
+        assert!(err.contains("TIMEOUT"));
+        assert!(err.contains("No reply from priya within 120s"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_bus_org.rs
+++ b/daemon/crates/convergio-cli/src/cli_bus_org.rs
@@ -1,0 +1,84 @@
+use serde_json::Value;
+
+pub async fn run_org(api_url: &str, human: bool) {
+    if !human {
+        if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/orgs"), false).await {
+            eprintln!("error: {e}");
+        }
+        return;
+    }
+    match reqwest::get(format!("{api_url}/api/orgs")).await {
+        Ok(resp) => match resp.json::<Value>().await {
+            Ok(v) => println!("{}", render_org_tree(&v)),
+            Err(e) => eprintln!("error: {e}"),
+        },
+        Err(e) => eprintln!("error: {e}"),
+    }
+}
+
+pub fn render_org_tree(v: &Value) -> String {
+    let orgs = v
+        .get("orgs")
+        .and_then(Value::as_array)
+        .cloned()
+        .or_else(|| v.as_array().cloned())
+        .unwrap_or_default();
+    if orgs.is_empty() {
+        return "No orgs found.".to_string();
+    }
+    let mut out = Vec::new();
+    for org in orgs {
+        let name = org.get("id").or_else(|| org.get("name")).and_then(Value::as_str).unwrap_or("unknown-org");
+        let status = org.get("status").and_then(Value::as_str).unwrap_or("UNKNOWN");
+        let budget = org.get("budget_pct").or_else(|| org.get("budget_percent")).and_then(Value::as_i64).unwrap_or(0);
+        out.push(format!("🏢 {name} [{status}] budget: {budget}%"));
+        if let Some(ceo) = org.get("ceo") {
+            out.push(format!(
+                "  CEO: {} ({}, {})",
+                ceo.get("name").and_then(Value::as_str).unwrap_or("n/a"),
+                ceo.get("model").and_then(Value::as_str).unwrap_or("unknown"),
+                ceo.get("status").and_then(Value::as_str).unwrap_or("unknown")
+            ));
+        }
+        let departments = org.get("departments").and_then(Value::as_array).cloned().unwrap_or_default();
+        for (i, d) in departments.iter().enumerate() {
+            let dname = d.get("name").and_then(Value::as_str).unwrap_or("General");
+            let dbranch = if i + 1 == departments.len() { "└──" } else { "├──" };
+            out.push(format!("  {dbranch} {dname}"));
+            let members = d.get("members").and_then(Value::as_array).cloned().unwrap_or_default();
+            for (j, m) in members.iter().enumerate() {
+                let mbranch = if i + 1 == departments.len() && j + 1 == members.len() { "    └──" } else { "    ├──" };
+                out.push(format!(
+                    "{mbranch} {} [{}] ({}, {})",
+                    m.get("name").and_then(Value::as_str).unwrap_or("unknown"),
+                    m.get("role").and_then(Value::as_str).unwrap_or("member"),
+                    m.get("model").and_then(Value::as_str).unwrap_or("model"),
+                    m.get("status").and_then(Value::as_str).unwrap_or("unknown")
+                ));
+            }
+        }
+    }
+    out.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_tree_from_mock_json() {
+        let data = serde_json::json!([{
+            "id":"fitness-project","status":"ACTIVE","budget_pct":72,
+            "ceo":{"name":"fitness-ceo","model":"sonnet","status":"active"},
+            "departments":[
+                {"name":"Engineering","members":[{"name":"dan","role":"lead","model":"claude","status":"active"},{"name":"rex","role":"reviewer","model":"copilot","status":"idle"}]},
+                {"name":"Design","members":[{"name":"sara","role":"UX","model":"claude","status":"active"}]}
+            ]
+        }]);
+        let out = render_org_tree(&data);
+        assert!(out.contains("🏢 fitness-project [ACTIVE] budget: 72%"));
+        assert!(out.contains("CEO: fitness-ceo"));
+        assert!(out.contains("Engineering"));
+        assert!(out.contains("dan [lead]"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_bus_watch.rs
+++ b/daemon/crates/convergio-cli/src/cli_bus_watch.rs
@@ -1,0 +1,73 @@
+use crate::cli_error::CliError;
+use futures_util::StreamExt;
+use serde_json::Value;
+
+const CYAN: &str = "\x1b[36m";
+const WHITE: &str = "\x1b[37m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+pub async fn run_watch(name: &str, api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/ipc/stream?agent={name}");
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(CliError::ApiCallFailed(format!(
+            "watch request failed: {}",
+            resp.status()
+        )));
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buffer = String::new();
+    while let Some(item) = stream.next().await {
+        let chunk =
+            item.map_err(|e| CliError::ApiCallFailed(format!("stream read error: {e}")))?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        while let Some(pos) = buffer.find('\n') {
+            let line = buffer[..pos].to_string();
+            buffer.drain(..=pos);
+            if let Some(out) = parse_sse_data_line(&line) {
+                println!("{out}");
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn parse_sse_data_line(line: &str) -> Option<String> {
+    let raw = line.trim();
+    let data = raw.strip_prefix("data: ")?;
+    let payload: Value = serde_json::from_str(data).ok()?;
+    let from = payload.get("from")?.as_str()?;
+    let to = payload.get("to")?.as_str()?;
+    let content = payload.get("content")?.as_str()?;
+    let ts = payload
+        .get("ts")
+        .and_then(Value::as_str)
+        .unwrap_or("00:00:00");
+    let hhmmss = chrono::DateTime::parse_from_rfc3339(ts)
+        .map(|dt| dt.format("%H:%M:%S").to_string())
+        .unwrap_or_else(|_| ts.to_string());
+    Some(format!(
+        "{DIM}[{hhmmss}]{RESET} {CYAN}{from}{RESET} → {CYAN}{to}{RESET}: {WHITE}{content}{RESET}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_sse_data_line;
+
+    #[test]
+    fn parse_sse_data_line_formats_display_row() {
+        let line = r#"data: {"from":"roberto","to":"priya","content":"Come stai?","ts":"2026-03-31T10:32:15Z"}"#;
+        let formatted = parse_sse_data_line(line).expect("parsed");
+        assert!(formatted.contains("[10:32:15]"));
+        assert!(formatted.contains("roberto"));
+        assert!(formatted.contains("priya"));
+        assert!(formatted.contains("Come stai?"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_capability.rs
+++ b/daemon/crates/convergio-cli/src/cli_capability.rs
@@ -1,0 +1,93 @@
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+const DEFAULT_API: &str = "http://127.0.0.1:8420";
+
+#[derive(Debug, Subcommand)]
+pub enum CapabilityCommands {
+    /// List registered capabilities (cvg capability list [--ring 2])
+    List {
+        #[arg(long)]
+        ring: Option<u8>,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        #[arg(long)]
+        human: bool,
+    },
+    /// Invoke a capability (cvg capability invoke <name> <input-json>)
+    Invoke {
+        name: String,
+        input: String,
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Register a capability from YAML (cvg capability register <path>)
+    Register {
+        path: String,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Manage per-agent permissions (cvg capability permissions <agent>)
+    Permissions {
+        agent: String,
+        #[arg(long)]
+        grant: Option<String>,
+        #[arg(long)]
+        revoke: Option<String>,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Show schema for a capability (cvg capability schema <name>)
+    Schema {
+        name: String,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        #[arg(long)]
+        human: bool,
+    },
+}
+
+pub async fn handle(cmd: CapabilityCommands) -> Result<(), CliError> {
+    match cmd {
+        CapabilityCommands::List { ring, api_url, human } => {
+            let qs = ring.map(|r| format!("?ring={r}")).unwrap_or_default();
+            crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/capabilities/list{qs}"),
+                human,
+            ).await
+        }
+        CapabilityCommands::Invoke { name, input, agent, api_url } => {
+            let parsed: serde_json::Value = serde_json::from_str(&input)
+                .map_err(|e| CliError::ApiCallFailed(format!("invalid JSON input: {e}")))?;
+            let body = serde_json::json!({
+                "name": name,
+                "input": parsed,
+                "agent_id": agent.unwrap_or_else(|| "cli".to_string()),
+            });
+            let url = format!("{api_url}/api/capabilities/invoke");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        CapabilityCommands::Register { path, api_url } => {
+            let body = serde_json::json!({"path": path});
+            let url = format!("{api_url}/api/capabilities/register");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        CapabilityCommands::Permissions { agent, grant, revoke, api_url } => {
+            let body = serde_json::json!({
+                "agent_id": agent,
+                "grant": grant,
+                "revoke": revoke,
+            });
+            let url = format!("{api_url}/api/capabilities/permissions");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        CapabilityCommands::Schema { name, api_url, human } => {
+            crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/capabilities/schema/{name}"),
+                human,
+            ).await
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_channel.rs
+++ b/daemon/crates/convergio-cli/src/cli_channel.rs
@@ -1,0 +1,230 @@
+// Channel CLI subcommands: list, status, test, send.
+// Delegates to daemon HTTP API at /api/channels.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum ChannelCommands {
+    /// List all registered channels and connection status
+    List {
+        /// Output as JSON (default: pretty table)
+        #[arg(long)]
+        json: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show verbose health status for all channels
+    Status {
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Send a test message through a channel and verify delivery
+    Test {
+        /// Channel name (e.g. ntfy, telegram)
+        name: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Send a message through a specific channel
+    Send {
+        /// Channel name (e.g. ntfy, telegram)
+        name: String,
+        /// Message text to send
+        message: String,
+        /// Severity level: info, warning, error, critical
+        #[arg(long, default_value = "info")]
+        severity: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: ChannelCommands) -> Result<(), CliError> {
+    match cmd {
+        ChannelCommands::List { json, api_url } => handle_list(json, &api_url).await,
+        ChannelCommands::Status { api_url } => handle_status(&api_url).await,
+        ChannelCommands::Test { name, api_url } => handle_test(&name, &api_url).await,
+        ChannelCommands::Send {
+            name,
+            message,
+            severity,
+            api_url,
+        } => handle_send(&name, &message, &severity, &api_url).await,
+    }
+}
+
+async fn handle_list(as_json: bool, api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/channels");
+    let val = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("failed to list channels".into()))?;
+
+    if as_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&val).unwrap_or_else(|_| val.to_string())
+        );
+        return Ok(());
+    }
+
+    let channels = val["channels"].as_array().cloned().unwrap_or_default();
+    if channels.is_empty() {
+        println!("No channels registered.");
+        return Ok(());
+    }
+    println!("{:<20} {:<12} {:<12}", "CHANNEL", "CONNECTED", "ERRORS");
+    println!("{}", "-".repeat(50));
+    for ch in &channels {
+        let name = ch["name"].as_str().unwrap_or("-");
+        let connected = ch["connected"].as_bool().unwrap_or(false);
+        let errors = ch["error_count"].as_u64().unwrap_or(0);
+        let status = if connected { "yes" } else { "no" };
+        println!("{:<20} {:<12} {:<12}", name, status, errors);
+    }
+    Ok(())
+}
+
+async fn handle_status(api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/channels");
+    let val = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("failed to get channel status".into()))?;
+
+    let channels = val["channels"].as_array().cloned().unwrap_or_default();
+    if channels.is_empty() {
+        println!("No channels registered.");
+        return Ok(());
+    }
+
+    for ch in &channels {
+        let name = ch["name"].as_str().unwrap_or("-");
+        let connected = ch["connected"].as_bool().unwrap_or(false);
+        let errors = ch["error_count"].as_u64().unwrap_or(0);
+        let last_msg = ch["last_message_at"].as_str().unwrap_or("never");
+        println!("--- {} ---", name);
+        println!("  Connected:    {}", if connected { "yes" } else { "no" });
+        println!("  Errors:       {errors}");
+        println!("  Last message: {last_msg}");
+        println!();
+    }
+    Ok(())
+}
+
+async fn handle_test(name: &str, api_url: &str) -> Result<(), CliError> {
+    let payload = serde_json::json!({
+        "message": "Convergio channel test message",
+        "severity": "info"
+    });
+    let url = format!("{api_url}/api/channels/{name}/send");
+    let val = crate::cli_http::post_and_return(&url, &payload)
+        .await
+        .map_err(|_| CliError::ApiCallFailed(format!("failed to test channel '{name}'")))?;
+
+    let delivered = val["delivered"].as_bool().unwrap_or(false);
+    if delivered {
+        println!("Channel '{name}' test: DELIVERED");
+    } else {
+        println!("Channel '{name}' test: NOT DELIVERED (check channel config)");
+    }
+    Ok(())
+}
+
+async fn handle_send(
+    name: &str,
+    message: &str,
+    severity: &str,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let payload = serde_json::json!({
+        "message": message,
+        "severity": severity,
+    });
+    let url = format!("{api_url}/api/channels/{name}/send");
+    crate::cli_http::post_and_print(&url, &payload, true)
+        .await
+        .map_err(|_| CliError::ApiCallFailed(format!("failed to send to channel '{name}'")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        cmd: ChannelCommands,
+    }
+
+    #[test]
+    fn parse_channel_list() {
+        let cli = TestCli::parse_from(["test", "list"]);
+        assert!(matches!(cli.cmd, ChannelCommands::List { json: false, .. }));
+    }
+
+    #[test]
+    fn parse_channel_list_json() {
+        let cli = TestCli::parse_from(["test", "list", "--json"]);
+        assert!(matches!(cli.cmd, ChannelCommands::List { json: true, .. }));
+    }
+
+    #[test]
+    fn parse_channel_status() {
+        let cli = TestCli::parse_from(["test", "status"]);
+        assert!(matches!(cli.cmd, ChannelCommands::Status { .. }));
+    }
+
+    #[test]
+    fn parse_channel_test() {
+        let cli = TestCli::parse_from(["test", "test", "ntfy"]);
+        if let ChannelCommands::Test { name, .. } = cli.cmd {
+            assert_eq!(name, "ntfy");
+        } else {
+            panic!("expected Test variant");
+        }
+    }
+
+    #[test]
+    fn parse_channel_send() {
+        let cli = TestCli::parse_from(["test", "send", "ntfy", "Hello world"]);
+        if let ChannelCommands::Send {
+            name,
+            message,
+            severity,
+            ..
+        } = cli.cmd
+        {
+            assert_eq!(name, "ntfy");
+            assert_eq!(message, "Hello world");
+            assert_eq!(severity, "info");
+        } else {
+            panic!("expected Send variant");
+        }
+    }
+
+    #[test]
+    fn parse_channel_send_with_severity() {
+        let cli = TestCli::parse_from([
+            "test",
+            "send",
+            "telegram",
+            "Alert!",
+            "--severity",
+            "critical",
+        ]);
+        if let ChannelCommands::Send {
+            name, severity, ..
+        } = cli.cmd
+        {
+            assert_eq!(name, "telegram");
+            assert_eq!(severity, "critical");
+        } else {
+            panic!("expected Send variant");
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_chat.rs
+++ b/daemon/crates/convergio-cli/src/cli_chat.rs
@@ -1,0 +1,106 @@
+use crate::cli_error::CliError;
+use std::io::{self, Write};
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const CYAN: &str = "\x1b[36m";
+const GREEN: &str = "\x1b[32m";
+const WHITE: &str = "\x1b[37m";
+const BLUE: &str = "\x1b[34m";
+
+const LOGO: &str = r#"
+    ◆ ConvergioChat
+"#;
+
+pub async fn handle(api_url: &str, message: Option<String>) -> Result<(), CliError> {
+    if let Some(msg) = message {
+        // Single-shot mode: send message and print response
+        let reply = send_message(api_url, &msg).await?;
+        println!("{GREEN}{BOLD}Ali:{RESET} {reply}");
+        return Ok(());
+    }
+
+    // Interactive REPL mode
+    print_banner();
+
+    loop {
+        print!("{CYAN}{BOLD}you ▸{RESET} ");
+        io::stdout().flush().unwrap();
+
+        let mut input = String::new();
+        if io::stdin().read_line(&mut input).is_err() || input.is_empty() {
+            break;
+        }
+
+        let trimmed = input.trim();
+        if trimmed.is_empty() { continue; }
+        if trimmed == "/quit" || trimmed == "/exit" || trimmed == "/q" {
+            println!("{DIM}Ciao!{RESET}");
+            break;
+        }
+        if trimmed == "/help" {
+            print_help();
+            continue;
+        }
+        if trimmed == "/status" {
+            if let Err(e) = crate::cli_status::handle(api_url).await {
+                eprintln!("error: {e}");
+            }
+            continue;
+        }
+
+        // Send to Ali
+        print!("{GREEN}{BOLD}Ali{RESET} {DIM}▸{RESET} ");
+        io::stdout().flush().unwrap();
+
+        match send_message(api_url, trimmed).await {
+            Ok(reply) => println!("{WHITE}{reply}{RESET}"),
+            Err(e) => println!("\x1b[31mError: {e}{RESET}"),
+        }
+        println!();
+    }
+    Ok(())
+}
+
+fn print_banner() {
+    println!("{CYAN}{BOLD}{LOGO}{RESET}");
+    println!("  {DIM}Chat with Ali orchestrator. Type /help for commands.{RESET}");
+    println!("  {DIM}────────────────────────────────────────────────────{RESET}");
+    println!();
+}
+
+fn print_help() {
+    println!();
+    println!("  {BOLD}Commands:{RESET}");
+    println!("    {BLUE}/status{RESET}   Platform status overview");
+    println!("    {BLUE}/help{RESET}     This message");
+    println!("    {BLUE}/quit{RESET}     Exit chat");
+    println!();
+}
+
+async fn send_message(api_url: &str, text: &str) -> Result<String, CliError> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "message": text,
+        "agent": "ali",
+    });
+    let resp = client
+        .post(format!("{api_url}/api/chat/message"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("send failed: {e}")))?;
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("parse failed: {e}")))?;
+
+    Ok(json
+        .get("reply")
+        .or_else(|| json.get("message"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("No response from Ali")
+        .to_string())
+}

--- a/daemon/crates/convergio-cli/src/cli_cheatsheet.rs
+++ b/daemon/crates/convergio-cli/src/cli_cheatsheet.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// `cvg cheatsheet` — print all available cvg commands grouped by domain.
+
+pub fn cheatsheet_text() -> &'static str {
+    r#"cvg cheatsheet — all available commands
+
+ORGANIZATIONS
+  cvg org list                         List orgs with status and budget
+  cvg org show <slug>                  Org details (members, services, decisions)
+  cvg org plans <slug>                 Plans belonging to an org
+  cvg org chart [slug]                 Orgchart (global if no slug)
+  cvg org create-org <name> --mission  Create org from mission
+  cvg org create-org-from <path>       Create org from repo scan
+
+PLANS
+  cvg plan list [--status S] [--limit N] [--human]  List plans (all, newest first)
+  cvg plan show <id> [--human]         Show plan details
+  cvg plan tree <id> [--human]         Execution tree (waves + tasks)
+  cvg plan create <proj> "name"        Create a new plan
+  cvg plan import <id> spec.yaml       Import spec YAML
+  cvg plan template                    Print example spec YAML
+  cvg plan start <id>                  Begin execution
+  cvg plan complete <id>               Mark complete (requires Thor + PR)
+  cvg plan validate <id>               Thor wave-level validation
+  cvg plan readiness <id>              Pre-execution checks
+  cvg plan cancel <id> "reason"        Cancel with reason
+
+TASKS & AGENTS
+  cvg task update <id> <status>        Update task status
+  cvg agent start "<name>"             Register agent session
+  cvg agent complete "<name>"          Mark agent done
+  cvg who agents                       Active agents across mesh
+
+MESH
+  cvg mesh status                      Peer topology
+  cvg mesh heartbeat                   Send heartbeat
+  cvg delegation start <plan> <peer>   Delegate plan to peer
+  cvg delegation status <plan>         Delegation progress
+
+KERNEL & VOICE
+  cvg kernel status                    Kernel status
+  cvg chat ["message"]                 Chat with Ali
+  cvg voice start                      Start voice pipeline
+
+RECOVERY
+  cvg checkpoint save <plan_id>        Snapshot plan state
+  cvg checkpoint restore <plan_id>     Restore from snapshot
+  cvg reap worktrees [--dry-run]       Clean stale worktrees
+
+OVERVIEW
+  cvg status                           Platform overview
+  cvg cheatsheet                       This help text
+"#
+}
+
+pub fn print_cheatsheet() {
+    print!("{}", cheatsheet_text());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cheatsheet_covers_major_domains() {
+        let text = cheatsheet_text();
+        let domains = [
+            "ORGANIZATIONS", "PLANS", "TASKS & AGENTS", "MESH",
+            "KERNEL & VOICE", "RECOVERY", "OVERVIEW",
+        ];
+        for domain in domains {
+            assert!(text.contains(domain), "must cover domain '{domain}'");
+        }
+    }
+
+    #[test]
+    fn cheatsheet_includes_new_commands() {
+        let text = cheatsheet_text();
+        assert!(text.contains("cvg org chart"), "must include org chart");
+        assert!(text.contains("cvg org plans"), "must include org plans");
+        assert!(text.contains("cvg cheatsheet"), "must include self-reference");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_checkpoint.rs
+++ b/daemon/crates/convergio-cli/src/cli_checkpoint.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Checkpoint subcommand — save/restore plan state via daemon HTTP API.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum CheckpointCommands {
+    /// Save current plan state to checkpoint file
+    Save {
+        /// Plan ID
+        plan_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Restore plan state from checkpoint file
+    Restore {
+        /// Plan ID
+        plan_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: CheckpointCommands) {
+    match cmd {
+        CheckpointCommands::Save {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({ "plan_id": plan_id });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/checkpoint/save"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        CheckpointCommands::Restore {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/checkpoint/restore?plan_id={plan_id}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkpoint_save_variant_exists() {
+        let cmd = CheckpointCommands::Save {
+            plan_id: 685,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, CheckpointCommands::Save { plan_id: 685, .. }));
+    }
+
+    #[test]
+    fn checkpoint_restore_variant_exists() {
+        let cmd = CheckpointCommands::Restore {
+            plan_id: 42,
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(
+            cmd,
+            CheckpointCommands::Restore { plan_id: 42, .. }
+        ));
+    }
+
+    #[test]
+    fn checkpoint_save_body_shape() {
+        let body = serde_json::json!({ "plan_id": 685_i64 });
+        assert_eq!(body["plan_id"], 685);
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_cleanup.rs
+++ b/daemon/crates/convergio-cli/src/cli_cleanup.rs
@@ -1,0 +1,159 @@
+// cvg cleanup — find and remove stale worktree branches and orphan worktrees.
+// Cleans up worktree-agent-*, worktree-plan-*, wt-plan-* branches without matching dirs.
+
+use crate::cli_error::CliError;
+use std::collections::HashSet;
+
+pub async fn handle() -> Result<(), CliError> {
+    let active_paths = list_active_worktree_paths();
+    let stale_branches = find_stale_branches(&active_paths);
+
+    if stale_branches.is_empty() {
+        println!("No stale worktree branches found.");
+    } else {
+        println!("Found {} stale branch(es):", stale_branches.len());
+        for b in &stale_branches {
+            println!("  - {b}");
+        }
+        delete_branches(&stale_branches);
+    }
+
+    // Always prune worktree metadata for removed directories
+    prune_worktrees();
+    Ok(())
+}
+
+/// List paths of active git worktrees (from `git worktree list --porcelain`).
+fn list_active_worktree_paths() -> HashSet<String> {
+    let out = match std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+    {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        _ => return HashSet::new(),
+    };
+    out.lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .map(String::from)
+        .collect()
+}
+
+/// Pure filtering logic extracted from find_stale_branches for unit-testability.
+/// Takes `branch_lines` as the raw output of `git branch --list`.
+fn classify_stale_branches(active_paths: &HashSet<String>, branch_lines: &str) -> Vec<String> {
+    let prefixes = [
+        "worktree-agent-",
+        "worktree-plan-",
+        "wt-plan-",
+        "workspace/ws-",
+    ];
+    let mut stale = Vec::new();
+    for line in branch_lines.lines() {
+        let branch = line.trim().trim_start_matches("* ");
+        if !prefixes.iter().any(|p| branch.starts_with(p) || branch.contains(p)) {
+            continue;
+        }
+        let has_active = active_paths.iter().any(|p| {
+            p.contains(&branch.replace('/', "-")) || p.contains(branch)
+        });
+        if !has_active {
+            stale.push(branch.to_string());
+        }
+    }
+    stale
+}
+
+/// Find branches matching worktree patterns that have no active worktree directory.
+fn find_stale_branches(active_paths: &HashSet<String>) -> Vec<String> {
+    let out = match std::process::Command::new("git")
+        .args(["branch", "--list"])
+        .output()
+    {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        _ => return Vec::new(),
+    };
+    classify_stale_branches(active_paths, &out)
+}
+
+fn delete_branches(branches: &[String]) {
+    for branch in branches {
+        let out = std::process::Command::new("git")
+            .args(["branch", "-D", branch])
+            .output();
+        match out {
+            Ok(o) if o.status.success() => {
+                println!("  deleted branch: {branch}");
+            }
+            Ok(o) => {
+                let err = String::from_utf8_lossy(&o.stderr);
+                eprintln!("  failed to delete {branch}: {err}");
+            }
+            Err(e) => {
+                eprintln!("  git branch -D {branch}: {e}");
+            }
+        }
+    }
+}
+
+fn prune_worktrees() {
+    match std::process::Command::new("git")
+        .args(["worktree", "prune"])
+        .output()
+    {
+        Ok(o) if o.status.success() => {
+            println!("Worktree metadata pruned.");
+        }
+        Ok(o) => {
+            let err = String::from_utf8_lossy(&o.stderr);
+            eprintln!("worktree prune failed: {err}");
+        }
+        Err(e) => {
+            eprintln!("worktree prune: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_branch_no_active_paths_marks_all_matching_as_stale() {
+        let active: HashSet<String> = HashSet::new();
+        let lines = "  worktree-plan-42\n  worktree-agent-x\n  main\n";
+        let stale = classify_stale_branches(&active, lines);
+        assert!(stale.contains(&"worktree-plan-42".to_string()), "plan-42 should be stale");
+        assert!(stale.contains(&"worktree-agent-x".to_string()), "agent-x should be stale");
+        // "main" does not match any worktree prefix — must not appear
+        assert!(!stale.contains(&"main".to_string()), "main is not a worktree branch");
+    }
+
+    #[test]
+    fn stale_branch_active_path_protects_matching_branch() {
+        let mut active: HashSet<String> = HashSet::new();
+        active.insert("/work/worktree-plan-42".to_string());
+        let lines = "  worktree-plan-42\n  worktree-plan-99\n";
+        let stale = classify_stale_branches(&active, lines);
+        // plan-42 has an active worktree directory — NOT stale
+        assert!(!stale.contains(&"worktree-plan-42".to_string()), "plan-42 has active worktree");
+        // plan-99 has no active directory — stale
+        assert!(stale.contains(&"worktree-plan-99".to_string()), "plan-99 should be stale");
+    }
+
+    #[test]
+    fn stale_branch_empty_input_returns_empty() {
+        let active: HashSet<String> = HashSet::new();
+        let stale = classify_stale_branches(&active, "");
+        assert!(stale.is_empty(), "no branches → no stale branches");
+    }
+
+    #[test]
+    fn stale_branch_current_branch_marker_stripped() {
+        // `git branch --list` prefixes the active branch with "* "
+        let active: HashSet<String> = HashSet::new();
+        let lines = "* worktree-plan-1\n  wt-plan-2\n";
+        let stale = classify_stale_branches(&active, lines);
+        assert!(stale.contains(&"worktree-plan-1".to_string()), "current branch marker stripped");
+        assert!(stale.contains(&"wt-plan-2".to_string()));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_commands.rs
+++ b/daemon/crates/convergio-cli/src/cli_commands.rs
@@ -1,0 +1,229 @@
+// CLI Commands enum — all top-level subcommands for cvg.
+// Pure HTTP client: server-side commands (Serve, Db, Hook, Daemon, Ipc, Tui)
+// are NOT included here — they live in the daemon binary.
+
+use crate::{
+    cli_agent, cli_bus, cli_capability, cli_channel, cli_checkpoint, cli_delegation,
+    cli_domain, cli_kb, cli_kernel, cli_lock, cli_memory, cli_ops, cli_org, cli_plan,
+    cli_project, cli_reap, cli_repo, cli_review, cli_run, cli_skill, cli_task,
+    cli_voice, cli_wave, cli_who, cli_workspace,
+};
+use clap::Subcommand;
+use std::path::PathBuf;
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    #[command(
+        next_help_heading = "User Commands",
+        about = "Initialize Convergio on this machine"
+    )]
+    Setup {
+        #[arg(long)]
+        defaults: bool,
+    },
+    #[command(about = "Show platform status, active plans, and recent activity")]
+    Status {
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    #[command(about = "Manage execution plans (create, list, validate, complete)")]
+    Plan {
+        #[command(subcommand)]
+        command: cli_plan::PlanCommands,
+    },
+    #[command(about = "Manage projects and repositories")]
+    Project {
+        #[command(subcommand)]
+        command: cli_project::ProjectCommands,
+    },
+    #[command(about = "Manage virtual organizations and teams")]
+    Org {
+        #[command(subcommand)]
+        command: cli_org::OrgCommands,
+    },
+    #[command(about = "Interactive AI chat with the platform")]
+    Chat {
+        message: Option<String>,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    #[command(about = "Show who is online (agents, sessions, peers)")]
+    Who {
+        #[command(subcommand)]
+        command: cli_who::WhoCommands,
+    },
+    #[command(
+        alias = "commands",
+        about = "Print quick-reference command cheatsheet"
+    )]
+    Cheatsheet,
+    #[command(
+        next_help_heading = "Operations",
+        about = "Manage agent lifecycle (start, stop, catalog)"
+    )]
+    Agent {
+        #[command(subcommand)]
+        command: cli_agent::AgentCommands,
+    },
+    #[command(about = "Manage individual tasks within plans")]
+    Task {
+        #[command(subcommand)]
+        command: cli_task::TaskCommands,
+    },
+    #[command(about = "Manage wave groups within plans")]
+    Wave {
+        #[command(subcommand)]
+        command: cli_wave::WaveCommands,
+    },
+    #[command(about = "Distributed mesh network operations")]
+    Mesh {
+        #[command(subcommand)]
+        command: cli_ops::MeshCommands,
+    },
+    #[command(about = "Delegate work to remote peers")]
+    Delegation {
+        #[command(subcommand)]
+        command: cli_delegation::DelegationCommands,
+    },
+    #[command(about = "Notification channels (Telegram, Slack)")]
+    Channel {
+        #[command(subcommand)]
+        command: cli_channel::ChannelCommands,
+    },
+    #[command(about = "Local AI kernel (Jarvis/Qwen) management")]
+    Kernel {
+        #[command(subcommand)]
+        command: cli_kernel::KernelCommands,
+    },
+    #[command(about = "Voice input/output and TTS")]
+    Voice {
+        #[command(subcommand)]
+        command: cli_voice::VoiceCommands,
+    },
+    #[command(about = "Manage isolated workspaces and worktrees")]
+    Workspace {
+        #[command(subcommand)]
+        command: cli_workspace::WorkspaceCommands,
+    },
+    #[command(about = "Execution run history and management")]
+    Run {
+        #[command(subcommand)]
+        command: cli_run::RunCommands,
+    },
+    #[command(about = "Save and restore plan checkpoints")]
+    Checkpoint {
+        #[command(subcommand)]
+        command: cli_checkpoint::CheckpointCommands,
+    },
+    #[command(about = "Plan review and approval workflow")]
+    Review {
+        #[command(subcommand)]
+        command: cli_review::ReviewCommands,
+    },
+    #[command(about = "Audit trail and compliance reports")]
+    Audit {
+        #[arg(long, default_value = ".")]
+        path: PathBuf,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        output: bool,
+        #[arg(long)]
+        yes: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    #[command(about = "Cost, token usage, and performance metrics")]
+    Metrics {
+        #[command(subcommand)]
+        command: cli_ops::MetricsCommands,
+    },
+    #[command(about = "Manage agent capabilities and roles")]
+    Capability {
+        #[command(subcommand)]
+        command: cli_capability::CapabilityCommands,
+    },
+    #[command(about = "Agent memory (remember, recall, share)")]
+    Memory {
+        #[command(subcommand)]
+        command: cli_memory::MemoryCommands,
+    },
+    #[command(about = "Knowledge base queries and management")]
+    Kb {
+        #[command(subcommand)]
+        command: cli_kb::KbCommands,
+    },
+    #[command(about = "Inter-agent message bus")]
+    Bus {
+        #[command(subcommand)]
+        command: cli_bus::BusCommands,
+    },
+    #[command(about = "Resource locking for concurrent agents")]
+    Lock {
+        #[command(subcommand)]
+        command: cli_lock::LockCommands,
+    },
+    #[command(about = "Session management")]
+    Session {
+        #[command(subcommand)]
+        command: cli_ops::SessionCommands,
+    },
+    #[command(about = "Skill registry and invocation")]
+    Skill {
+        #[command(subcommand)]
+        command: cli_skill::SkillCommands,
+    },
+    #[command(about = "Clean up orphan agents and stale resources")]
+    Reap {
+        #[command(subcommand)]
+        command: cli_reap::ReapCommands,
+    },
+    #[command(about = "Repository management")]
+    Repo {
+        #[command(subcommand)]
+        command: cli_repo::RepoCommands,
+    },
+    #[command(about = "Domain and routing management")]
+    Domain {
+        #[command(subcommand)]
+        command: cli_domain::DomainCommands,
+    },
+    #[command(about = "Alert rules and notifications")]
+    Alert {
+        #[command(subcommand)]
+        command: cli_ops::AlertCommands,
+    },
+    #[command(about = "Open API documentation in browser")]
+    Api,
+    #[command(about = "Clean up stale worktree branches")]
+    Cleanup,
+    #[command(name = "claude", about = "Register a Claude Code session")]
+    Claude {
+        name: String,
+        #[arg(long)]
+        parent: Option<String>,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    #[command(name = "copilot", about = "Register a Copilot CLI session")]
+    Copilot {
+        name: String,
+        #[arg(long)]
+        parent: Option<String>,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    #[command(name = "ask", about = "Ask an agent a question using alias resolution")]
+    Ask {
+        alias: String,
+        message: Option<String>,
+        #[arg(long)]
+        list: bool,
+        #[arg(long)]
+        set: Option<String>,
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}

--- a/daemon/crates/convergio-cli/src/cli_create_org.rs
+++ b/daemon/crates/convergio-cli/src/cli_create_org.rs
@@ -1,0 +1,54 @@
+// CLI handlers for creating orgs — delegates to daemon HTTP API.
+// Original used convergio_core::org directly; now pure HTTP client.
+
+use crate::cli_error::CliError;
+
+/// Create an org from a mission statement via daemon API.
+pub async fn handle_create_org(
+    name: &str,
+    mission: &str,
+    budget: f64,
+    yes: bool,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let body = serde_json::json!({
+        "name": name,
+        "mission": mission,
+        "budget": budget,
+        "auto_confirm": yes,
+    });
+    let url = format!("{api_url}/api/orgs/create-from-mission");
+    let val = crate::cli_http::post_and_return(&url, &body)
+        .await
+        .map_err(|code| CliError::ApiCallFailed(format!("daemon error (code {code})")))?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&val).unwrap_or_else(|_| val.to_string())
+    );
+    Ok(())
+}
+
+/// Create an org from a scanned repo via daemon API.
+pub async fn handle_create_org_from(
+    path: &str,
+    name: Option<&str>,
+    budget: f64,
+    yes: bool,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let body = serde_json::json!({
+        "path": path,
+        "name": name,
+        "budget": budget,
+        "auto_confirm": yes,
+    });
+    let url = format!("{api_url}/api/orgs/create-from-repo");
+    let val = crate::cli_http::post_and_return(&url, &body)
+        .await
+        .map_err(|code| CliError::ApiCallFailed(format!("daemon error (code {code})")))?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&val).unwrap_or_else(|_| val.to_string())
+    );
+    Ok(())
+}

--- a/daemon/crates/convergio-cli/src/cli_delegation.rs
+++ b/daemon/crates/convergio-cli/src/cli_delegation.rs
@@ -1,0 +1,216 @@
+// cvg delegation — manage plan delegation to mesh workers.
+// Why: Plan 706 — no orchestration for remote execution. Zero traceability.
+
+use crate::cli_error::CliError;
+use crate::cli_http;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum DelegationCommands {
+    /// Delegate a plan to a mesh peer for execution
+    Start {
+        /// Plan ID to delegate
+        plan_id: i64,
+        /// Target peer name (from peers.conf or mesh status)
+        #[arg(long)]
+        peer: String,
+        /// Fire-and-forget mode (skip progress polling)
+        #[arg(long)]
+        no_wait: bool,
+    },
+    /// Cancel an active delegation
+    Cancel {
+        /// Plan ID to cancel delegation for
+        plan_id: i64,
+    },
+    /// Show delegation status for a plan (peer, status, task, last update, output)
+    Status {
+        /// Plan ID to inspect (alias: --plan)
+        #[arg(long, short = 'p')]
+        plan: Option<i64>,
+        /// Positional plan_id (legacy; prefer --plan)
+        plan_id: Option<i64>,
+        /// Poll every 5s and refresh output
+        #[arg(long)]
+        live: bool,
+    },
+    /// List all active plans (potential delegations)
+    List,
+}
+
+fn api_err(code: i32) -> CliError {
+    CliError::ApiCallFailed(format!("daemon returned error (code {code})"))
+}
+
+/// Render a single delegation row (padded columns).
+pub fn format_progress_row(d: &serde_json::Value) -> String {
+    let peer = d["peer"].as_str().unwrap_or("-");
+    let status = d["status"].as_str().unwrap_or("-");
+    let task = d["current_task"].as_str().unwrap_or("-");
+    let updated = d["last_update"].as_str().unwrap_or("-");
+    let summary = d["output_summary"].as_str().unwrap_or("");
+    // Truncate long fields to fit 100-char terminal width
+    let task_short = if task.len() > 20 { &task[..20] } else { task };
+    let summary_short = if summary.len() > 40 {
+        &summary[..40]
+    } else {
+        summary
+    };
+    format!(
+        "{:<20} {:<10} {:<22} {:<24} {}",
+        peer, status, task_short, updated, summary_short
+    )
+}
+
+/// Render the column header line.
+pub fn format_progress_header() -> String {
+    format!(
+        "{:<20} {:<10} {:<22} {:<24} {}",
+        "PEER", "STATUS", "TASK", "LAST UPDATE", "OUTPUT"
+    )
+}
+
+/// Render a full progress table from the API response.
+pub fn format_progress_table(body: &serde_json::Value) -> String {
+    let list = match body["delegations"].as_array() {
+        Some(arr) if !arr.is_empty() => arr,
+        _ => return "No active delegations.".to_string(),
+    };
+    let sep = "-".repeat(100);
+    let mut lines = vec![format_progress_header(), sep];
+    for d in list {
+        lines.push(format_progress_row(d));
+    }
+    lines.join("\n")
+}
+
+async fn fetch_progress(api_url: &str, plan_id: i64) -> Result<serde_json::Value, CliError> {
+    let url = format!("{api_url}/api/delegation/by-plan/{plan_id}");
+    cli_http::get_and_return(&url).await.map_err(api_err)
+}
+
+/// Poll delegation progress every 2s, printing each stage transition.
+/// Exits on "done", "blocked", or after 120s timeout.
+async fn poll_progress(api_url: &str, plan_id: i64) -> Result<(), CliError> {
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(120);
+    let mut last_step = String::new();
+
+    loop {
+        if start.elapsed() > timeout {
+            println!("[timeout] delegation progress polling timed out after 120s");
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        let body = match fetch_progress(api_url, plan_id).await {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let dels = body["delegations"].as_array();
+        let entry = dels.and_then(|a| a.first());
+        let Some(d) = entry else { continue };
+        let step = d["current_task"].as_str().unwrap_or("-");
+        let status = d["status"].as_str().unwrap_or("running");
+        if step != last_step {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!("[{ts}] step: {step}");
+            last_step = step.to_string();
+        }
+        if matches!(status, "done" | "blocked") {
+            let summary = d["output_summary"].as_str().unwrap_or("");
+            println!("[{status}] {summary}");
+            break;
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle(cmd: DelegationCommands, api_url: &str) -> Result<(), CliError> {
+    match cmd {
+        DelegationCommands::Start { plan_id, peer, no_wait } => {
+            let url = format!("{api_url}/api/mesh/delegate");
+            let body = serde_json::json!({"plan_id": plan_id, "peer": peer});
+            cli_http::post_and_print(&url, &body, true).await?;
+            println!("Delegation started: plan {plan_id} → {peer}");
+            if !no_wait {
+                poll_progress(api_url, plan_id).await?;
+            }
+            Ok(())
+        }
+        DelegationCommands::Cancel { plan_id } => {
+            // List active delegations and cancel matching plan
+            let url = format!("{api_url}/api/delegation/by-plan/{plan_id}");
+            let body = cli_http::get_and_return(&url).await.map_err(api_err)?;
+            let del_id = body["delegations"]
+                .as_array()
+                .and_then(|arr| arr.first())
+                .and_then(|d| d["delegation_id"].as_str())
+                .unwrap_or("");
+            if del_id.is_empty() {
+                println!("No active delegation found for plan {plan_id}");
+                return Ok(());
+            }
+            let cancel_url = format!("{api_url}/api/mesh/delegate/{del_id}/cancel");
+            let cancel_body = serde_json::json!({"plan_id": plan_id});
+            cli_http::post_and_print(&cancel_url, &cancel_body, true).await?;
+            println!("Delegation cancelled: plan {plan_id}");
+            Ok(())
+        }
+        DelegationCommands::Status {
+            plan,
+            plan_id,
+            live,
+        } => {
+            let id = plan.or(plan_id).ok_or_else(|| {
+                CliError::ApiCallFailed("provide --plan <ID> or positional plan_id".to_string())
+            })?;
+
+            if live {
+                // Poll every 5s until interrupted
+                loop {
+                    // Clear screen with ANSI escape for live refresh
+                    print!("\x1B[2J\x1B[H");
+                    let body = fetch_progress(api_url, id).await?;
+                    println!("Plan {id} — delegation status (live, Ctrl+C to exit)");
+                    println!("{}", format_progress_table(&body));
+                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                }
+            } else {
+                let body = fetch_progress(api_url, id).await?;
+                println!("Plan {id} — delegation status");
+                println!("{}", format_progress_table(&body));
+            }
+            Ok(())
+        }
+        DelegationCommands::List => {
+            let url = format!("{api_url}/api/plan-db/list");
+            let body = cli_http::get_and_return(&url).await.map_err(api_err)?;
+            if let Some(plans) = body["plans"].as_array() {
+                let doing: Vec<_> = plans
+                    .iter()
+                    .filter(|p| p["status"].as_str() == Some("doing"))
+                    .collect();
+                if doing.is_empty() {
+                    println!("No active plans.");
+                } else {
+                    println!("{:<6} {:<45} {:<12} PROGRESS", "ID", "NAME", "HOST");
+                    println!("{}", "-".repeat(80));
+                    for p in &doing {
+                        let id = p["id"].as_i64().unwrap_or(0);
+                        let name = p["name"].as_str().unwrap_or("?");
+                        let host = p["execution_host"].as_str().unwrap_or("-");
+                        let done = p["tasks_done"].as_i64().unwrap_or(0);
+                        let total = p["tasks_total"].as_i64().unwrap_or(0);
+                        let display = if name.len() > 44 { &name[..44] } else { name };
+                        println!("{:<6} {:<45} {:<12} {}/{}", id, display, host, done, total);
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cli_delegation_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_delegation_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_delegation_tests.rs
@@ -1,0 +1,117 @@
+// Tests for cli_delegation: formatting, command parsing, start/cancel variants.
+// Why: Verify table rendering, field extraction, and new delegation subcommands.
+
+use super::*;
+use clap::Parser;
+use serde_json::json;
+
+/// Wrapper for clap parsing tests — mirrors main CLI structure.
+#[derive(Parser)]
+struct TestCli {
+    #[command(subcommand)]
+    cmd: DelegationCommands,
+}
+
+fn parse_delegation(args: &[&str]) -> DelegationCommands {
+    let mut full = vec!["cvg"];
+    full.extend_from_slice(args);
+    TestCli::parse_from(full).cmd
+}
+
+#[test]
+fn parse_start_command() {
+    let cmd = parse_delegation(&["start", "742", "--peer", "macProM1"]);
+    match cmd {
+        DelegationCommands::Start { plan_id, peer, no_wait } => {
+            assert_eq!(plan_id, 742);
+            assert_eq!(peer, "macProM1");
+            assert!(!no_wait, "no_wait should default to false");
+        }
+        _ => panic!("expected Start variant"),
+    }
+}
+
+#[test]
+fn parse_start_no_wait_flag() {
+    let cmd = parse_delegation(&["start", "99", "--peer", "worker", "--no-wait"]);
+    match cmd {
+        DelegationCommands::Start { plan_id, peer, no_wait } => {
+            assert_eq!(plan_id, 99);
+            assert_eq!(peer, "worker");
+            assert!(no_wait, "no_wait should be true when --no-wait is passed");
+        }
+        _ => panic!("expected Start variant"),
+    }
+}
+
+#[test]
+fn parse_cancel_command() {
+    let cmd = parse_delegation(&["cancel", "742"]);
+    match cmd {
+        DelegationCommands::Cancel { plan_id } => assert_eq!(plan_id, 742),
+        _ => panic!("expected Cancel variant"),
+    }
+}
+
+#[test]
+fn format_progress_row_all_fields() {
+    let data = json!({
+        "peer": "worker-milan",
+        "status": "running",
+        "current_task": "T2-03",
+        "last_update": "2026-03-26T15:00:00Z",
+        "output_summary": "Implementing feature X"
+    });
+    let row = format_progress_row(&data);
+    assert!(row.contains("worker-milan"), "peer name missing");
+    assert!(row.contains("running"), "status missing");
+    assert!(row.contains("T2-03"), "current_task missing");
+    assert!(
+        row.contains("Implementing feature X"),
+        "output_summary missing"
+    );
+}
+
+#[test]
+fn format_progress_row_missing_fields_uses_defaults() {
+    let data = json!({});
+    let row = format_progress_row(&data);
+    // Must not panic and must produce a non-empty line
+    assert!(!row.is_empty());
+}
+
+#[test]
+fn format_progress_header_has_columns() {
+    let hdr = format_progress_header();
+    assert!(hdr.contains("PEER"), "PEER column header missing");
+    assert!(hdr.contains("STATUS"), "STATUS column header missing");
+    assert!(hdr.contains("TASK"), "TASK column header missing");
+    assert!(hdr.contains("LAST UPDATE"), "LAST UPDATE header missing");
+}
+
+#[test]
+fn format_progress_table_empty_data_shows_none() {
+    let out = format_progress_table(&json!({"ok": true, "delegations": []}));
+    assert!(
+        out.contains("No active delegations") || out.contains("none"),
+        "expected empty state message, got: {out}"
+    );
+}
+
+#[test]
+fn format_progress_table_with_entries() {
+    let data = json!({
+        "ok": true,
+        "delegations": [{
+            "peer": "node-rome",
+            "status": "running",
+            "current_task": "T1-01",
+            "last_update": "2026-03-26T10:00:00Z",
+            "output_summary": "cargo check passed"
+        }]
+    });
+    let out = format_progress_table(&data);
+    assert!(out.contains("node-rome"));
+    assert!(out.contains("T1-01"));
+    assert!(out.contains("cargo check passed"));
+}

--- a/daemon/crates/convergio-cli/src/cli_domain.rs
+++ b/daemon/crates/convergio-cli/src/cli_domain.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Domain-skill mapping CLI subcommands: `cvg domain list` and `cvg domain map`.
+// Pure HTTP client — delegates all operations to daemon API.
+
+use crate::message_error::MessageResult;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum DomainCommands {
+    /// List all domain→skill mappings
+    List {
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+        /// Human-readable table output instead of JSON
+        #[arg(long)]
+        human: bool,
+    },
+    /// Add a domain→skill mapping
+    Map {
+        /// Domain name (e.g. healthcare)
+        domain: String,
+        /// Skill name — must match an existing claude-config/skills/<skill>/ directory
+        skill: String,
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+    },
+}
+
+pub async fn dispatch(cmd: DomainCommands) -> Result<(), crate::cli_error::CliError> {
+    match cmd {
+        DomainCommands::List { api_url, human } => handle_list(&api_url, human).await,
+        DomainCommands::Map {
+            domain,
+            skill,
+            description,
+            api_url,
+            human,
+        } => handle_map(&domain, &skill, description.as_deref(), &api_url, human).await?,
+    }
+    Ok(())
+}
+
+async fn handle_list(api_url: &str, human: bool) {
+    if let Err(e) =
+        crate::cli_http::fetch_and_print(&format!("{api_url}/api/domain/list"), human).await
+    {
+        eprintln!("error: {e}");
+    }
+}
+
+async fn handle_map(
+    domain: &str,
+    skill: &str,
+    description: Option<&str>,
+    api_url: &str,
+    human: bool,
+) -> Result<(), crate::cli_error::CliError> {
+    // Validate skill directory exists before calling daemon (fast-fail at CLI layer)
+    let skill_path = format!("claude-config/skills/{skill}");
+    validate_skill_dir(&skill_path)
+        .map_err(|e| crate::cli_error::CliError::InvalidInput(format!("error: {e}")))?;
+    let body = serde_json::json!({
+        "domain": domain,
+        "skill_name": skill,
+        "description": description,
+    });
+    if let Err(e) =
+        crate::cli_http::post_and_print(&format!("{api_url}/api/domain/map"), &body, human).await
+    {
+        eprintln!("error: {e}");
+    }
+    Ok(())
+}
+
+/// Validate that the skill directory exists at `path`.
+pub(crate) fn validate_skill_dir(path: &str) -> MessageResult<()> {
+    if std::path::Path::new(path).is_dir() {
+        Ok(())
+    } else {
+        Err(format!("skill directory does not exist: {path}").into())
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_error.rs
+++ b/daemon/crates/convergio-cli/src/cli_error.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Structured error type for CLI subcommands — replaces direct CLI termination calls.
+
+#[derive(Debug, thiserror::Error)]
+pub enum CliError {
+    #[error("{0}")]
+    InvalidInput(String),
+    #[error("{0}")]
+    ApiCallFailed(String),
+    #[error("{0}")]
+    NotFound(String),
+    #[error("{0}")]
+    ValidationRejected(String),
+    #[error("{0}")]
+    ViolationsFound(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl CliError {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            CliError::NotFound(_)
+            | CliError::ValidationRejected(_)
+            | CliError::ViolationsFound(_) => 1,
+            _ => 2,
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_http.rs
+++ b/daemon/crates/convergio-cli/src/cli_http.rs
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Shared HTTP helpers for CLI subcommands that delegate to the daemon HTTP API.
+
+use crate::cli_error::CliError;
+
+fn auth_header_value(token: Option<&str>) -> Option<String> {
+    token
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("Bearer {value}"))
+}
+
+fn with_auth(req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    match auth_header_value(std::env::var("CONVERGIO_AUTH_TOKEN").ok().as_deref()) {
+        Some(value) => req.header("Authorization", value),
+        None => req,
+    }
+}
+
+pub async fn fetch_and_print(url: &str, human: bool) -> Result<(), CliError> {
+    let client = reqwest::Client::new();
+    match with_auth(client.get(url)).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let val: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+            print_value(&val, human);
+            if !status.is_success() {
+                return Err(CliError::NotFound(val.to_string()));
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ApiCallFailed(format!(
+            "error connecting to daemon: {e}"
+        ))),
+    }
+}
+
+pub async fn post_and_print(
+    url: &str,
+    body: &serde_json::Value,
+    human: bool,
+) -> Result<(), CliError> {
+    let client = reqwest::Client::new();
+    match with_auth(client.post(url)).json(body).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let val: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+            print_value(&val, human);
+            if !status.is_success() {
+                return Err(CliError::NotFound(val.to_string()));
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ApiCallFailed(format!(
+            "error connecting to daemon: {e}"
+        ))),
+    }
+}
+
+/// POST to `url` and return the parsed JSON value without printing.
+/// Returns Err with an exit-code hint on failure (caller should exit).
+pub async fn post_and_return(
+    url: &str,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, i32> {
+    let client = reqwest::Client::new();
+    match with_auth(client.post(url)).json(body).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            match resp.json::<serde_json::Value>().await {
+                Ok(val) => {
+                    if status.is_success() {
+                        Ok(val)
+                    } else {
+                        eprintln!("error response from {url}: {val}");
+                        Err(1)
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error parsing response from {url}: {e}");
+                    Err(2)
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("error connecting to daemon ({url}): {e}");
+            Err(2)
+        }
+    }
+}
+
+/// GET `url` and return the parsed JSON value without printing.
+pub async fn get_and_return(url: &str) -> Result<serde_json::Value, i32> {
+    let client = reqwest::Client::new();
+    match with_auth(client.get(url)).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            match resp.json::<serde_json::Value>().await {
+                Ok(val) => {
+                    if status.is_success() {
+                        Ok(val)
+                    } else {
+                        eprintln!("error response from {url}: {val}");
+                        Err(1)
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error parsing response from {url}: {e}");
+                    Err(2)
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("error connecting to daemon ({url}): {e}");
+            Err(2)
+        }
+    }
+}
+
+pub fn print_value(val: &serde_json::Value, human: bool) {
+    if human {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+        );
+    } else {
+        println!("{val}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::auth_header_value;
+
+    #[test]
+    fn builds_bearer_header_when_token_present() {
+        assert_eq!(
+            auth_header_value(Some("secret")),
+            Some("Bearer secret".to_string())
+        );
+    }
+
+    #[test]
+    fn skips_bearer_header_when_token_missing() {
+        assert!(auth_header_value(None).is_none());
+        assert!(auth_header_value(Some("   ")).is_none());
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_kb.rs
+++ b/daemon/crates/convergio-cli/src/cli_kb.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// KB (knowledge base) subcommands for the cvg CLI — delegates to daemon HTTP API.
+// JSON output by default; --human flag for readable text.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum KbCommands {
+    /// Search the knowledge base
+    Search {
+        /// Search query string
+        query: String,
+        /// Maximum results to return
+        #[arg(long, default_value_t = 5)]
+        limit: u32,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Write an entry to the knowledge base
+    Write {
+        /// Entry title
+        title: String,
+        /// Entry content
+        content: String,
+        /// Domain/category
+        #[arg(long, default_value = "general")]
+        domain: String,
+        /// Confidence score (0.0–1.0)
+        #[arg(long, default_value_t = 0.8)]
+        confidence: f64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: KbCommands) -> Result<(), CliError> {
+    match cmd {
+        KbCommands::Search {
+            query,
+            limit,
+            human,
+            api_url,
+        } => {
+            fetch_and_print(
+                &format!("{api_url}/api/plan-db/kb-search?q={query}&limit={limit}"),
+                human,
+            )
+            .await?;
+        }
+        KbCommands::Write {
+            title,
+            content,
+            domain,
+            confidence,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "title": title,
+                "content": content,
+                "domain": domain,
+                "confidence": confidence,
+            });
+            post_and_print(&format!("{api_url}/api/plan-db/kb-write"), &body, human).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn fetch_and_print(url: &str, human: bool) -> Result<(), CliError> {
+    match reqwest::get(url).await {
+        Ok(resp) => {
+            let status = resp.status();
+            let val: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+            print_value(&val, human);
+            if !status.is_success() {
+                return Err(CliError::NotFound(val.to_string()));
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ApiCallFailed(format!(
+            "error connecting to daemon: {e}"
+        ))),
+    }
+}
+
+async fn post_and_print(url: &str, body: &serde_json::Value, human: bool) -> Result<(), CliError> {
+    let client = reqwest::Client::new();
+    match client.post(url).json(body).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            let val: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+            print_value(&val, human);
+            if !status.is_success() {
+                return Err(CliError::NotFound(val.to_string()));
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ApiCallFailed(format!(
+            "error connecting to daemon: {e}"
+        ))),
+    }
+}
+
+fn print_value(val: &serde_json::Value, human: bool) {
+    if human {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+        );
+    } else {
+        println!("{val}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kb_commands_search_variant_exists() {
+        let cmd = KbCommands::Search {
+            query: "rust async".to_string(),
+            limit: 10,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, KbCommands::Search { .. }));
+    }
+
+    #[test]
+    fn kb_commands_write_variant_exists() {
+        let cmd = KbCommands::Write {
+            title: "TDD pattern".to_string(),
+            content: "Write tests first".to_string(),
+            domain: "testing".to_string(),
+            confidence: 0.9,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, KbCommands::Write { .. }));
+    }
+
+    #[test]
+    fn kb_write_builds_correct_body() {
+        let body = serde_json::json!({
+            "title": "test",
+            "content": "body",
+            "domain": "general",
+            "confidence": 0.8_f64,
+        });
+        assert_eq!(body["domain"], "general");
+        assert!((body["confidence"].as_f64().unwrap() - 0.8).abs() < 0.001);
+    }
+
+    #[test]
+    fn kb_search_url_encodes_query() {
+        let query = "rust async";
+        let limit = 5u32;
+        let url = format!("http://localhost:8420/api/plan-db/kb-search?q={query}&limit={limit}");
+        assert!(url.contains("q=rust async"));
+        assert!(url.contains("limit=5"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_kernel.rs
+++ b/daemon/crates/convergio-cli/src/cli_kernel.rs
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// CLI commands for the kernel health monitor (cvg kernel start/stop/status/logs/test/here/say).
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+const DEFAULT_API: &str = "http://localhost:8420";
+
+#[derive(Debug, Subcommand)]
+pub enum KernelCommands {
+    /// Start the kernel engine (loads models, begins monitor loop)
+    Start {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        /// Override MLX model to load
+        #[arg(long)]
+        model: Option<String>,
+    },
+    /// Stop the kernel engine (unloads models, stops monitor loop)
+    Stop {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Show kernel status as table
+    Status {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Query kernel_events (cvg kernel logs [--level WARN] [--limit 50])
+    Logs {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        /// Minimum log level filter (DEBUG|INFO|WARN|ERROR)
+        #[arg(long)]
+        level: Option<String>,
+        /// Maximum number of events to return
+        #[arg(long, default_value_t = 50)]
+        limit: u32,
+    },
+    /// Run all monitor checks once and report results
+    Test {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Set this node as the active audio target (POST /api/kernel/active-node)
+    Here {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        /// Override node hostname (defaults to system hostname)
+        #[arg(long)]
+        node: Option<String>,
+    },
+    /// Debug TTS: speak text on the active node (stub — POST /api/kernel/speak)
+    Say {
+        /// Text to synthesise
+        text: String,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        /// BCP-47 locale for TTS
+        #[arg(long, default_value = "it-IT")]
+        locale: String,
+    },
+    /// Download all MLX models required by the kernel (runs scripts/kernel/setup-models.sh)
+    Setup {
+        /// Path to setup-models.sh; defaults to scripts/kernel/setup-models.sh relative to cwd
+        #[arg(long)]
+        script: Option<String>,
+    },
+}
+
+/// Dispatch kernel subcommands. Returns an exit code (0 = success).
+pub async fn dispatch(cmd: KernelCommands) -> std::process::ExitCode {
+    let result = dispatch_inner(cmd).await;
+    match result {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+async fn dispatch_inner(cmd: KernelCommands) -> Result<(), CliError> {
+    match cmd {
+        KernelCommands::Status { api_url } => {
+            let val = crate::cli_http::get_and_return(&format!("{api_url}/api/kernel/status"))
+                .await
+                .map_err(|code| CliError::ApiCallFailed(format!("exit {code}")))?;
+            print_status_table(&val);
+            Ok(())
+        }
+        KernelCommands::Start { api_url, model } => {
+            let mut body = serde_json::json!({});
+            if let Some(m) = model {
+                body["model"] = serde_json::Value::String(m);
+            }
+            crate::cli_http::post_and_print(&format!("{api_url}/api/kernel/start"), &body, false)
+                .await
+        }
+        KernelCommands::Stop { api_url } => {
+            let body = serde_json::json!({});
+            crate::cli_http::post_and_print(&format!("{api_url}/api/kernel/stop"), &body, false)
+                .await
+        }
+        KernelCommands::Logs {
+            api_url,
+            level,
+            limit,
+        } => {
+            let mut url = format!("{api_url}/api/kernel/logs?limit={limit}");
+            if let Some(l) = level {
+                url.push_str(&format!("&level={l}"));
+            }
+            let val = crate::cli_http::get_and_return(&url)
+                .await
+                .map_err(|code| CliError::ApiCallFailed(format!("exit {code}")))?;
+            print_logs_table(&val);
+            Ok(())
+        }
+        KernelCommands::Test { api_url } => {
+            let body = serde_json::json!({});
+            let val =
+                crate::cli_http::post_and_return(&format!("{api_url}/api/kernel/test"), &body)
+                    .await
+                    .map_err(|code| CliError::ApiCallFailed(format!("exit {code}")))?;
+            print_test_table(&val);
+            Ok(())
+        }
+        KernelCommands::Here { api_url, node } => {
+            let hostname = node.unwrap_or_else(|| {
+                hostname::get()
+                    .map(|h| h.into_string().unwrap_or_else(|_| "unknown".to_string()))
+                    .unwrap_or_else(|e| {
+                        eprintln!("warn: could not resolve hostname: {e}");
+                        "unknown".to_string()
+                    })
+            });
+            let body = serde_json::json!({ "node": hostname });
+            crate::cli_http::post_and_print(
+                &format!("{api_url}/api/kernel/active-node"),
+                &body,
+                false,
+            )
+            .await
+        }
+        KernelCommands::Say { text, api_url, locale } => {
+            let body = serde_json::json!({ "text": text, "locale": locale });
+            crate::cli_http::post_and_print(&format!("{api_url}/api/kernel/speak"), &body, false)
+                .await
+        }
+        KernelCommands::Setup { script } => {
+            let script_path = script.unwrap_or_else(|| {
+                "scripts/kernel/setup-models.sh".to_string()
+            });
+            let status = std::process::Command::new("bash")
+                .arg(&script_path)
+                .status()
+                .map_err(|e| CliError::ApiCallFailed(format!("failed to launch {script_path}: {e}")))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(CliError::ApiCallFailed(format!(
+                    "setup-models.sh exited with status {status}"
+                )))
+            }
+        }
+    }
+}
+
+/// Render GET /api/kernel/status as a two-column table.
+fn print_status_table(val: &serde_json::Value) {
+    let rows = [
+        ("models_loaded", val["models_loaded"].to_string()),
+        (
+            "ram_gb",
+            val["ram_gb"]
+                .as_f64()
+                .map(|f| format!("{f:.2}"))
+                .unwrap_or_else(|| val["ram_gb"].to_string()),
+        ),
+        ("uptime_secs", val["uptime_secs"].to_string()),
+        (
+            "active_node",
+            val["active_node"]
+                .as_str()
+                .unwrap_or("—")
+                .to_string(),
+        ),
+        (
+            "last_check",
+            val["last_check"].as_str().unwrap_or("—").to_string(),
+        ),
+    ];
+    println!("{:<16} {}", "field", "value");
+    println!("{}", "-".repeat(40));
+    for (k, v) in &rows {
+        println!("{k:<16} {v}");
+    }
+}
+
+/// Render GET /api/kernel/logs as a table.
+fn print_logs_table(val: &serde_json::Value) {
+    let empty = vec![];
+    let events = val.as_array().unwrap_or(&empty);
+    if events.is_empty() {
+        println!("(no events)");
+        return;
+    }
+    println!("{:<24} {:<8} {}", "timestamp", "level", "message");
+    println!("{}", "-".repeat(72));
+    for ev in events {
+        let ts = ev["timestamp"].as_str().unwrap_or("?");
+        let level = ev["level"].as_str().unwrap_or("?");
+        let msg = ev["message"].as_str().unwrap_or("?");
+        println!("{ts:<24} {level:<8} {msg}");
+    }
+}
+
+/// Render POST /api/kernel/test results as a table.
+fn print_test_table(val: &serde_json::Value) {
+    let empty = vec![];
+    let checks = val["checks"].as_array().unwrap_or(&empty);
+    if checks.is_empty() {
+        // Fall back to raw JSON if shape is unexpected.
+        println!(
+            "{}",
+            serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+        );
+        return;
+    }
+    println!("{:<28} {:<8} {}", "check", "status", "detail");
+    println!("{}", "-".repeat(72));
+    for ch in checks {
+        let name = ch["name"].as_str().unwrap_or("?");
+        let status = ch["status"].as_str().unwrap_or("?");
+        let detail = ch["detail"].as_str().unwrap_or("");
+        println!("{name:<28} {status:<8} {detail}");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_launch.rs
+++ b/daemon/crates/convergio-cli/src/cli_launch.rs
@@ -1,0 +1,186 @@
+// CLI wrappers: `cvg claude <name>` and `cvg copilot <name>`.
+// Registers the agent with the daemon, launches the AI tool, deregisters on exit.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum LaunchCommands {
+    /// Launch a claude session with auto-registration
+    Claude {
+        /// Agent name (used for IPC registration)
+        name: String,
+        /// Parent agent name (for parentage tree)
+        #[arg(long)]
+        parent: Option<String>,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Launch a copilot session with auto-registration
+    Copilot {
+        /// Agent name (used for IPC registration)
+        name: String,
+        /// Parent agent name (for parentage tree)
+        #[arg(long)]
+        parent: Option<String>,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+fn hostname() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+async fn register_agent(
+    api_url: &str,
+    name: &str,
+    agent_type: &str,
+    parent: Option<&str>,
+) -> Result<(), CliError> {
+    let host = hostname();
+    let pid = std::process::id();
+    let mut body = serde_json::json!({
+        "agent_id": name,
+        "host": host,
+        "agent_type": agent_type,
+        "pid": pid,
+    });
+    if let Some(p) = parent {
+        body["parent_agent"] = serde_json::json!(p);
+    }
+    let client = reqwest::Client::new();
+    let url = format!("{api_url}/api/ipc/agents/register");
+    match client.post(&url).json(&body).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            eprintln!("✓ registered {name}@{host} (type={agent_type})");
+            Ok(())
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            eprintln!("⚠ registration returned {status}: {text}");
+            Ok(()) // non-fatal: proceed with launch
+        }
+        Err(e) => {
+            eprintln!("⚠ daemon unreachable ({e}), launching without registration");
+            Ok(())
+        }
+    }
+}
+
+async fn deregister_agent(api_url: &str, name: &str) {
+    let host = hostname();
+    let body = serde_json::json!({
+        "agent_id": name,
+        "host": host,
+    });
+    let client = reqwest::Client::new();
+    let url = format!("{api_url}/api/ipc/agents/unregister");
+    match client.post(&url).json(&body).send().await {
+        Ok(_) => eprintln!("✓ deregistered {name}@{host}"),
+        Err(e) => eprintln!("⚠ deregister failed: {e}"),
+    }
+}
+
+async fn launch_tool(
+    api_url: &str,
+    name: &str,
+    agent_type: &str,
+    parent: Option<&str>,
+    command: &str,
+    args: &[&str],
+) -> Result<(), CliError> {
+    register_agent(api_url, name, agent_type, parent).await?;
+
+    let mut cmd = build_launch_command(api_url, name, command, args);
+    let status = cmd.status().await;
+
+    deregister_agent(api_url, name).await;
+
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => {
+            let code = s.code().unwrap_or(1);
+            Err(CliError::ApiCallFailed(format!(
+                "{command} exited with code {code}"
+            )))
+        }
+        Err(e) => Err(CliError::ApiCallFailed(format!(
+            "failed to launch {command}: {e}"
+        ))),
+    }
+}
+
+fn build_launch_command(
+    api_url: &str,
+    name: &str,
+    command: &str,
+    args: &[&str],
+) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(command);
+    cmd.args(args)
+        .env("CONVERGIO_AGENT_NAME", name)
+        .env("CONVERGIO_API_URL", api_url)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+    cmd
+}
+
+pub async fn handle(cmd: LaunchCommands) -> Result<(), CliError> {
+    match cmd {
+        LaunchCommands::Claude {
+            name,
+            parent,
+            api_url,
+        } => {
+            launch_tool(
+                &api_url,
+                &name,
+                "claude",
+                parent.as_deref(),
+                "claude",
+                &[],
+            )
+            .await
+        }
+        LaunchCommands::Copilot {
+            name,
+            parent,
+            api_url,
+        } => {
+            launch_tool(
+                &api_url,
+                &name,
+                "copilot",
+                parent.as_deref(),
+                "gh",
+                &["copilot"],
+            )
+            .await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_launch_command;
+
+    #[test]
+    fn launch_command_sets_agent_env_vars() {
+        let cmd = build_launch_command("http://localhost:8420", "priya", "echo", &["ok"]);
+        let envs: Vec<(String, String)> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| Some((k.to_string_lossy().to_string(), v?.to_string_lossy().to_string())))
+            .collect();
+        assert!(envs.iter().any(|(k, v)| k == "CONVERGIO_AGENT_NAME" && v == "priya"));
+        assert!(envs.iter().any(|(k, v)| k == "CONVERGIO_API_URL" && v == "http://localhost:8420"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_lock.rs
+++ b/daemon/crates/convergio-cli/src/cli_lock.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Lock subcommand — acquire/release/list file locks via daemon HTTP API.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum LockCommands {
+    /// Acquire a file lock for a task
+    Acquire {
+        /// File path to lock
+        file_path: String,
+        /// Task DB ID that owns this lock
+        task_id: i64,
+        /// Agent identifier
+        #[arg(long, default_value = "task-executor")]
+        agent: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Release a file lock
+    Release {
+        /// File path to unlock
+        file_path: String,
+        /// Task DB ID releasing this lock
+        task_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List all active file locks
+    List {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: LockCommands) {
+    match cmd {
+        LockCommands::Acquire {
+            file_path,
+            task_id,
+            agent,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "file_path": file_path, "task_id": task_id, "agent": agent,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/ipc/locks/acquire"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        LockCommands::Release {
+            file_path,
+            task_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({ "file_path": file_path, "task_id": task_id });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/ipc/locks/release"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        LockCommands::List { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/ipc/locks"), human).await {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_acquire_variant_exists() {
+        let cmd = LockCommands::Acquire {
+            file_path: "daemon/src/main.rs".to_string(),
+            task_id: 8796,
+            agent: "task-executor".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, LockCommands::Acquire { task_id: 8796, .. }));
+    }
+
+    #[test]
+    fn lock_release_variant_exists() {
+        let cmd = LockCommands::Release {
+            file_path: "daemon/src/main.rs".to_string(),
+            task_id: 8796,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, LockCommands::Release { task_id: 8796, .. }));
+    }
+
+    #[test]
+    fn lock_list_variant_exists() {
+        let cmd = LockCommands::List {
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, LockCommands::List { human: true, .. }));
+    }
+
+    #[test]
+    fn lock_acquire_body_shape() {
+        let body = serde_json::json!({
+            "file_path": "daemon/src/main.rs",
+            "task_id": 8796_i64,
+            "agent": "task-executor",
+        });
+        assert_eq!(body["task_id"], 8796);
+        assert_eq!(body["agent"], "task-executor");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_memory.rs
+++ b/daemon/crates/convergio-cli/src/cli_memory.rs
@@ -1,0 +1,138 @@
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+const DEFAULT_API: &str = "http://127.0.0.1:8420";
+
+#[derive(Debug, Subcommand)]
+pub enum MemoryCommands {
+    /// Store a new memory (cvg memory remember "content" --agent <id> --type Fact)
+    Remember {
+        content: String,
+        #[arg(long)]
+        agent: String,
+        #[arg(long, default_value = "Fact")]
+        r#type: String,
+        #[arg(long, value_delimiter = ',')]
+        tags: Option<Vec<String>>,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Recall memories (cvg memory recall --query "search" --limit 10)
+    Recall {
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long)]
+        semantic: Option<String>,
+        #[arg(long)]
+        r#type: Option<String>,
+        #[arg(long)]
+        agent: Option<String>,
+        #[arg(long, default_value = "10")]
+        limit: usize,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        #[arg(long)]
+        human: bool,
+    },
+    /// Forget a memory by ID (cvg memory forget <id>)
+    Forget {
+        id: String,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Share a memory with other agents (cvg memory share <id> --to agent1,agent2)
+    Share {
+        id: String,
+        #[arg(long, value_delimiter = ',')]
+        to: Vec<String>,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Attest a memory (cvg memory attest <id> --agent <id> --confidence 0.95)
+    Attest {
+        id: String,
+        #[arg(long)]
+        agent: String,
+        #[arg(long, default_value = "1.0")]
+        confidence: f64,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Export all memories as Markdown files (cvg memory export --dir <path>)
+    Export {
+        #[arg(long)]
+        dir: String,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Rebuild indexes: Markdown → SQLite → VectorStore (cvg memory reindex)
+    Reindex {
+        /// Directory with Markdown memory files
+        #[arg(long)]
+        dir: Option<String>,
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: MemoryCommands) -> Result<(), CliError> {
+    match cmd {
+        MemoryCommands::Remember { content, agent, r#type, tags, api_url } => {
+            let body = serde_json::json!({
+                "agent_id": agent,
+                "memory_type": r#type,
+                "content": content,
+                "tags": tags.unwrap_or_default(),
+                "access_level": "Private"
+            });
+            let url = format!("{api_url}/api/memory/remember");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        MemoryCommands::Recall { query, semantic, r#type, agent, limit, api_url, human } => {
+            let mut params = vec![format!("limit={limit}")];
+            if let Some(q) = query { params.push(format!("query={q}")); }
+            if let Some(s) = semantic { params.push(format!("semantic={s}")); }
+            if let Some(t) = r#type { params.push(format!("type={t}")); }
+            if let Some(a) = agent { params.push(format!("agent={a}")); }
+            let qs = params.join("&");
+            crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/memory/recall?{qs}"),
+                human,
+            ).await
+        }
+        MemoryCommands::Forget { id, api_url } => {
+            let url = format!("{api_url}/api/memory/forget/{id}");
+            let client = reqwest::Client::new();
+            let resp = client.delete(&url).send().await
+                .map_err(|e| CliError::ApiCallFailed(format!("error: {e}")))?;
+            let val: serde_json::Value = resp.json().await
+                .map_err(|e| CliError::ApiCallFailed(format!("error: {e}")))?;
+            println!("{val}");
+            Ok(())
+        }
+        MemoryCommands::Share { id, to, api_url } => {
+            let body = serde_json::json!({"memory_id": id, "target_agent_ids": to});
+            let url = format!("{api_url}/api/memory/share");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        MemoryCommands::Attest { id, agent, confidence, api_url } => {
+            let body = serde_json::json!({
+                "memory_id": id,
+                "attesting_agent_id": agent,
+                "confidence": confidence
+            });
+            let url = format!("{api_url}/api/memory/attest");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        MemoryCommands::Export { dir, api_url } => {
+            let body = serde_json::json!({"dir": dir});
+            let url = format!("{api_url}/api/memory/export");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        MemoryCommands::Reindex { dir, api_url } => {
+            let body = serde_json::json!({"dir": dir});
+            let url = format!("{api_url}/api/memory/reindex");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_mesh_join.rs
+++ b/daemon/crates/convergio-cli/src/cli_mesh_join.rs
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// `cvg mesh join <coordinator_url>` — register this node with a mesh coordinator.
+
+use crate::cli_error::CliError;
+use crate::cli_setup_steps as steps;
+
+/// Join the mesh by registering with the coordinator daemon.
+/// Sends self-detected info, receives peers.conf + env, writes locally.
+pub(crate) async fn handle_mesh_join(coordinator_url: &str) -> Result<(), CliError> {
+    println!("Joining mesh via coordinator: {coordinator_url}");
+
+    let node_name = steps::detect_hostname();
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let os = detect_os();
+    let (tailscale_ip, dns_name) = detect_tailscale_self();
+    if tailscale_ip.is_empty() {
+        return Err(CliError::InvalidInput(
+            "Tailscale not detected. Mesh requires Tailscale.".into(),
+        ));
+    }
+
+    println!("  Node:     {node_name}");
+    println!("  User:     {user}");
+    println!("  OS:       {os}");
+    println!("  IP:       {tailscale_ip}");
+    println!("  DNS:      {dns_name}");
+
+    let body = serde_json::json!({
+        "name": node_name,
+        "ssh_alias": format!("{node_name}-ts"),
+        "user": user,
+        "os": os,
+        "tailscale_ip": tailscale_ip,
+        "dns_name": dns_name,
+        "capabilities": detect_capabilities(),
+        "role": "worker",
+    });
+
+    print!("  Registering with coordinator... ");
+    let url = format!("{coordinator_url}/api/mesh/register");
+    let client = reqwest::Client::new();
+    let mut request = client.post(&url).json(&body);
+    if let Ok(token) = std::env::var("CONVERGIO_AUTH_TOKEN") {
+        if !token.is_empty() {
+            request = request.bearer_auth(token);
+        }
+    }
+    let resp = request.send().await.map_err(|e| {
+        CliError::ApiCallFailed(format!("cannot reach coordinator: {e}"))
+    })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(CliError::ApiCallFailed(format!(
+            "coordinator returned {status}: {text}"
+        )));
+    }
+
+    let result: serde_json::Value = resp.json().await.map_err(|e| {
+        CliError::ApiCallFailed(format!("invalid response: {e}"))
+    })?;
+    println!("OK");
+
+    if let Some(peers_config) = result["peers_config"].as_str() {
+        let path = peers_conf_path()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(CliError::Io)?;
+        }
+        std::fs::write(&path, peers_config).map_err(CliError::Io)?;
+        println!("  peers.conf written to {}", path.display());
+    }
+
+    if let Some(env_content) = result["env_content"].as_str() {
+        if !env_content.is_empty() {
+            merge_env_file(env_content)?;
+            println!("  env file updated");
+        }
+    }
+
+    println!();
+    if let Some(msg) = result["message"].as_str() {
+        println!("  {msg}");
+    }
+    println!();
+    println!("Next steps:");
+    println!("  cvg setup     — configure local node (if not done)");
+    println!("  cvg serve     — start the daemon");
+    println!("  cvg status    — verify mesh connectivity");
+    Ok(())
+}
+
+fn detect_os() -> String {
+    if cfg!(target_os = "macos") { "macos".to_string() }
+    else if cfg!(target_os = "linux") { "linux".to_string() }
+    else { std::env::consts::OS.to_string() }
+}
+
+fn detect_tailscale_self() -> (String, String) {
+    let output = std::process::Command::new("tailscale")
+        .args(["status", "--json"])
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return (String::new(), String::new()),
+    };
+    let json: serde_json::Value = match serde_json::from_slice(&output.stdout) {
+        Ok(v) => v,
+        Err(_) => return (String::new(), String::new()),
+    };
+    let ip = json.pointer("/Self/TailscaleIPs/0")
+        .and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let dns = json.pointer("/Self/DNSName")
+        .and_then(|v| v.as_str()).unwrap_or("").trim_end_matches('.').to_string();
+    (ip, dns)
+}
+
+fn detect_capabilities() -> Vec<String> {
+    let mut caps = Vec::new();
+    if which("claude") { caps.push("claude".to_string()); }
+    if which("gh") { caps.push("copilot".to_string()); }
+    if which("ollama") { caps.push("ollama".to_string()); }
+    if caps.is_empty() { caps.push("worker".to_string()); }
+    caps
+}
+
+fn which(cmd: &str) -> bool {
+    std::process::Command::new("which").arg(cmd)
+        .output().ok().map(|o| o.status.success()).unwrap_or(false)
+}
+
+fn home_dir() -> Result<std::path::PathBuf, CliError> {
+    dirs::home_dir().ok_or_else(|| CliError::InvalidInput("HOME directory not found".into()))
+}
+
+fn peers_conf_path() -> Result<std::path::PathBuf, CliError> {
+    Ok(home_dir()?.join(".claude/config/peers.conf"))
+}
+
+fn merge_env_file(new_content: &str) -> Result<(), CliError> {
+    let path = home_dir()?.join(".convergio/env");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(CliError::Io)?;
+    }
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut lines: Vec<String> = existing.lines().map(String::from).collect();
+    for line in new_content.lines() {
+        if let Some((k, _)) = line.split_once('=') {
+            let k = k.trim();
+            if k.is_empty() { continue; }
+            // F-30: exact key match — split existing lines on '=' and compare full key name
+            if !lines.iter().any(|l| {
+                l.trim_start()
+                    .split_once('=')
+                    .map(|(ek, _)| ek.trim() == k)
+                    .unwrap_or(false)
+            }) {
+                lines.push(line.to_string());
+            }
+        }
+    }
+    std::fs::write(&path, lines.join("\n") + "\n").map_err(CliError::Io)
+}

--- a/daemon/crates/convergio-cli/src/cli_ops.rs
+++ b/daemon/crates/convergio-cli/src/cli_ops.rs
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Mesh and Session subcommands for the cvg CLI — delegates to daemon HTTP API via reqwest.
+// JSON output by default; --human flag for readable text.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum MeshCommands {
+    /// Send a heartbeat to the mesh (POST /api/heartbeat)
+    Heartbeat {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show current mesh status (GET /api/mesh)
+    Status {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show cluster-level heartbeat status (GET /api/heartbeat/status)
+    ClusterStatus {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Join a mesh by registering with a coordinator node
+    Join {
+        /// Coordinator daemon URL (e.g. http://100.89.245.79:8420)
+        coordinator_url: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SessionCommands {
+    /// Clean up old/stale sessions
+    Reap {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Trigger session recovery
+    Recovery {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Check session / dashboard health (GET /api/dashboard)
+    Check {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MetricsCommands {
+    /// Show metrics summary (GET /api/metrics/summary)
+    Summary {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Trigger metrics collection (POST /api/metrics/collect)
+    Collect {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AlertCommands {
+    /// List active notifications (GET /api/notifications)
+    List {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle_mesh(cmd: MeshCommands) {
+    match cmd {
+        MeshCommands::Heartbeat { human, api_url } => {
+            // POST with empty body — signals this node is alive
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/heartbeat"),
+                &serde_json::json!({}),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        MeshCommands::Status { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/mesh"), human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        MeshCommands::ClusterStatus { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/heartbeat/status"), human)
+                .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        MeshCommands::Join { coordinator_url } => {
+            if let Err(e) = crate::cli_mesh_join::handle_mesh_join(&coordinator_url).await {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+pub async fn handle_session(cmd: SessionCommands) {
+    match cmd {
+        SessionCommands::Reap { human, api_url } => {
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/sessions/reap"),
+                &serde_json::json!({}),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        SessionCommands::Recovery { human, api_url } => {
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/sessions/recovery"),
+                &serde_json::json!({}),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        SessionCommands::Check { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/dashboard"), human).await {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+pub async fn handle_metrics(cmd: MetricsCommands) {
+    match cmd {
+        MetricsCommands::Summary { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/metrics/summary"), human)
+                .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        MetricsCommands::Collect { human, api_url } => {
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/metrics/collect"),
+                &serde_json::json!({}),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+pub async fn handle_alert(cmd: AlertCommands) {
+    match cmd {
+        AlertCommands::List { human, api_url } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(&format!("{api_url}/api/notifications"), human).await {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cli_ops_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_ops_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_ops_tests.rs
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_ops module (mesh and session commands).
+
+use super::*;
+
+#[test]
+fn mesh_heartbeat_variant_exists() {
+    let cmd = MeshCommands::Heartbeat {
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, MeshCommands::Heartbeat { human: false, .. }));
+}
+
+#[test]
+fn mesh_status_variant_exists() {
+    let cmd = MeshCommands::Status {
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, MeshCommands::Status { human: true, .. }));
+}
+
+#[test]
+fn mesh_cluster_status_variant_exists() {
+    let cmd = MeshCommands::ClusterStatus {
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, MeshCommands::ClusterStatus { .. }));
+}
+
+#[test]
+fn session_reap_variant_exists() {
+    let cmd = SessionCommands::Reap {
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, SessionCommands::Reap { human: false, .. }));
+}
+
+#[test]
+fn session_recovery_variant_exists() {
+    let cmd = SessionCommands::Recovery {
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, SessionCommands::Recovery { human: true, .. }));
+}
+
+#[test]
+fn mesh_heartbeat_url() {
+    let url = format!("{}/api/heartbeat", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/heartbeat");
+}
+
+#[test]
+fn mesh_status_url() {
+    let url = format!("{}/api/mesh", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/mesh");
+}
+
+#[test]
+fn mesh_cluster_status_url() {
+    let url = format!("{}/api/heartbeat/status", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/heartbeat/status");
+}
+
+#[test]
+fn session_reap_url() {
+    let url = format!("{}/api/sessions/reap", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/sessions/reap");
+}
+
+#[test]
+fn session_recovery_url() {
+    let url = format!("{}/api/sessions/recovery", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/sessions/recovery");
+}
+
+#[test]
+fn print_value_json_compact() {
+    let val = serde_json::json!({"nodes": 3, "healthy": true});
+    let compact = val.to_string();
+    assert!(!compact.is_empty());
+    assert!(!compact.contains('\n'));
+}
+
+#[test]
+fn print_value_json_pretty() {
+    let val = serde_json::json!({"nodes": 3});
+    let pretty = serde_json::to_string_pretty(&val).unwrap();
+    assert!(pretty.contains('\n'));
+}
+
+// --- Session Check ---
+
+#[test]
+fn session_check_variant_exists() {
+    let cmd = SessionCommands::Check {
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, SessionCommands::Check { human: false, .. }));
+}
+
+#[test]
+fn session_check_url() {
+    let url = format!("{}/api/dashboard", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/dashboard");
+}
+
+// --- Metrics ---
+
+#[test]
+fn metrics_summary_variant_exists() {
+    let cmd = MetricsCommands::Summary {
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, MetricsCommands::Summary { human: false, .. }));
+}
+
+#[test]
+fn metrics_summary_url() {
+    let url = format!("{}/api/metrics/summary", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/metrics/summary");
+}
+
+#[test]
+fn metrics_collect_variant_exists() {
+    let cmd = MetricsCommands::Collect {
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, MetricsCommands::Collect { human: true, .. }));
+}
+
+#[test]
+fn metrics_collect_url() {
+    let url = format!("{}/api/metrics/collect", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/metrics/collect");
+}
+
+// --- Alerts ---
+
+#[test]
+fn alert_list_variant_exists() {
+    let cmd = AlertCommands::List {
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, AlertCommands::List { human: false, .. }));
+}
+
+#[test]
+fn alert_list_url() {
+    let url = format!("{}/api/notifications", "http://localhost:8420");
+    assert_eq!(url, "http://localhost:8420/api/notifications");
+}

--- a/daemon/crates/convergio-cli/src/cli_org.rs
+++ b/daemon/crates/convergio-cli/src/cli_org.rs
@@ -1,0 +1,228 @@
+use crate::cli_error::CliError;
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+#[derive(Debug, Subcommand)]
+pub enum OrgCommands {
+    /// Create a new org and bootstrap its CEO agent session
+    Create {
+        /// Org identifier
+        name: String,
+        /// Org mission
+        #[arg(long)]
+        mission: String,
+        /// Org objectives
+        #[arg(long)]
+        objectives: String,
+        /// Daily org budget
+        #[arg(long)]
+        budget: f64,
+        /// CEO agent name
+        #[arg(long, default_value = "ceo")]
+        ceo_agent: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List orgs with status, CEO, members and budget usage
+    List {
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show one org with details
+    Show {
+        id: String,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List plans belonging to an org
+    Plans {
+        slug: String,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show global orgchart (all orgs) or single org chart
+    Chart {
+        /// Org slug (omit for global ecosystem view)
+        slug: Option<String>,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a virtual organization from a mission/goal
+    CreateOrg {
+        name: String,
+        #[arg(long)]
+        mission: String,
+        #[arg(long, default_value = "50")]
+        budget: f64,
+        #[arg(long)]
+        yes: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a virtual organization from an existing repo
+    CreateOrgFrom {
+        path: String,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long, default_value = "50")]
+        budget: f64,
+        #[arg(long)]
+        yes: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: OrgCommands) -> Result<(), CliError> {
+    match cmd {
+        OrgCommands::Create {
+            name,
+            mission,
+            objectives,
+            budget,
+            ceo_agent,
+            api_url,
+        } => create_org_and_spawn_ceo(&name, &mission, &objectives, budget, &ceo_agent, &api_url).await,
+        OrgCommands::List { api_url } => crate::cli_org_show::list_orgs(&api_url).await,
+        OrgCommands::Show { id, api_url } => crate::cli_org_show::show_org(&id, &api_url).await,
+        OrgCommands::Plans { slug, api_url } => crate::cli_org_show::org_plans(&slug, &api_url).await,
+        OrgCommands::Chart { slug, api_url } => crate::cli_org_show::org_chart(slug.as_deref(), &api_url).await,
+        OrgCommands::CreateOrg { name, mission, budget, yes, api_url } => {
+            crate::cli_create_org::handle_create_org(&name, &mission, budget, yes, &api_url).await
+        }
+        OrgCommands::CreateOrgFrom { path, name, budget, yes, api_url } => {
+            crate::cli_create_org::handle_create_org_from(&path, name.as_deref(), budget, yes, &api_url).await
+        }
+    }
+}
+
+async fn create_org_and_spawn_ceo(
+    name: &str,
+    mission: &str,
+    objectives: &str,
+    budget: f64,
+    ceo_agent: &str,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let client = reqwest::Client::new();
+    let create_body = json!({
+        "id": name,
+        "mission": mission,
+        "objectives": objectives,
+        "ceo_agent": ceo_agent,
+        "budget": budget,
+    });
+    let create_resp = client
+        .post(format!("{api_url}/api/orgs"))
+        .json(&create_body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("failed to create org: {e}")))?;
+    let create_status = create_resp.status();
+    let create_json: Value = create_resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("failed to decode org response: {e}")))?;
+    if !create_status.is_success() {
+        return Err(CliError::ApiCallFailed(format!(
+            "org create failed with status {create_status}: {create_json}"
+        )));
+    }
+    let start_body = json!({"agent_id": ceo_agent, "name": ceo_agent, "task_id": Value::Null});
+    let start_resp = client
+        .post(format!("{api_url}/api/plan-db/agent/start"))
+        .json(&start_body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("failed to start ceo agent: {e}")))?;
+    let start_status = start_resp.status();
+    let start_json: Value = start_resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("failed to decode ceo start response: {e}")))?;
+    if !start_status.is_success() {
+        return Err(CliError::ApiCallFailed(format!(
+            "ceo start failed with status {start_status}: {start_json}"
+        )));
+    }
+    let out = json!({
+        "ok": true,
+        "org": create_json,
+        "ceo_spawn": start_json,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        cmd: OrgCommands,
+    }
+
+    #[test]
+    fn parse_org_create_command() {
+        let cli = TestCli::parse_from([
+            "cvg",
+            "create",
+            "acme-labs",
+            "--mission",
+            "Build autonomous orgs",
+            "--objectives",
+            "Ship quickly",
+            "--budget",
+            "1200",
+        ]);
+        match cli.cmd {
+            OrgCommands::Create {
+                name,
+                mission,
+                objectives,
+                budget,
+                ceo_agent,
+                ..
+            } => {
+                assert_eq!(name, "acme-labs");
+                assert_eq!(mission, "Build autonomous orgs");
+                assert_eq!(objectives, "Ship quickly");
+                assert_eq!(budget, 1200.0);
+                assert_eq!(ceo_agent, "ceo");
+            }
+            _ => panic!("expected create command"),
+        }
+    }
+
+    #[test]
+    fn parse_org_list_command() {
+        let cli = TestCli::parse_from(["cvg", "list"]);
+        match cli.cmd {
+            OrgCommands::List { api_url } => {
+                assert_eq!(api_url, "http://localhost:8420");
+            }
+            _ => panic!("expected list command"),
+        }
+    }
+
+    #[test]
+    fn format_org_list_contains_expected_columns() {
+        let rendered = crate::cli_org_show::format_org_row(&serde_json::json!({
+            "id": "fitness-project",
+            "status": "active",
+            "ceo_agent": "fitness-ceo",
+            "member_count": 7,
+            "budget_usage_pct": 60.0
+        }));
+        assert!(rendered.contains("fitness-project"));
+        assert!(rendered.contains("fitness-ceo"));
+        assert!(rendered.contains("60.0%"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_org_show.rs
+++ b/daemon/crates/convergio-cli/src/cli_org_show.rs
@@ -1,0 +1,144 @@
+use crate::cli_error::CliError;
+use crate::cli_http::get_and_return;
+use serde_json::{json, Value};
+
+const CYAN: &str = "\x1b[36m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RESET: &str = "\x1b[0m";
+
+pub async fn list_orgs(api_url: &str) -> Result<(), CliError> {
+    let payload = get_and_return(&format!("{api_url}/api/orgs"))
+        .await
+        .map_err(|_| CliError::ApiCallFailed("list orgs failed".into()))?;
+    println!("{CYAN}ORG ID | STATUS | CEO | MEMBERS | BUDGET{RESET}");
+    for org in payload["orgs"].as_array().into_iter().flatten() {
+        let id = org["id"].as_str().unwrap_or_default();
+        let details = fetch_org_detail(api_url, id).await?;
+        println!("{}", format_org_row(&details));
+    }
+    Ok(())
+}
+
+pub async fn show_org(id: &str, api_url: &str) -> Result<(), CliError> {
+    let detail = fetch_org_detail(api_url, id).await?;
+    let decisions = get_and_return(&format!("{api_url}/api/orgs/{id}/decisions"))
+        .await.unwrap_or_else(|_| json!({"decisions": []}));
+    let telemetry = get_and_return(&format!("{api_url}/api/orgs/{id}/telemetry?period=day"))
+        .await.unwrap_or_else(|_| json!({"aggregate": {}}));
+    let digest = get_and_return(&format!("{api_url}/api/orgs/{id}/digest"))
+        .await.unwrap_or_else(|_| json!({"digest": null}));
+    let out = json!({
+        "org": detail["org"],
+        "members": detail["members"],
+        "services": detail["services"],
+        "recent_decisions": decisions["decisions"],
+        "telemetry": telemetry["aggregate"],
+        "latest_digest": digest["digest"]
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+    );
+    Ok(())
+}
+
+pub async fn org_plans(slug: &str, api_url: &str) -> Result<(), CliError> {
+    let payload = get_and_return(&format!("{api_url}/api/orgs/{slug}/plans"))
+        .await
+        .map_err(|_| CliError::ApiCallFailed("get org plans failed".into()))?;
+    let plans = payload["plans"].as_array();
+    if plans.map(|p| p.is_empty()).unwrap_or(true) {
+        println!("No plans linked to org '{slug}'");
+        return Ok(());
+    }
+    println!("{CYAN}ID | NAME | STATUS | PROGRESS{RESET}");
+    for p in plans.into_iter().flatten() {
+        let id = p["id"].as_i64().unwrap_or(0);
+        let name = p["name"].as_str().unwrap_or("-");
+        let status = p["status"].as_str().unwrap_or("-");
+        let done = p["tasks_done"].as_i64().unwrap_or(0);
+        let total = p["tasks_total"].as_i64().unwrap_or(0);
+        let color = if status == "completed" { GREEN } else { YELLOW };
+        println!("#{id} | {name} | {color}{status}{RESET} | {done}/{total}");
+    }
+    Ok(())
+}
+
+pub async fn org_chart(slug: Option<&str>, api_url: &str) -> Result<(), CliError> {
+    let url = match slug {
+        Some(s) => format!("{api_url}/api/orgs/{s}/orgchart"),
+        None => format!("{api_url}/api/orgs/chart"),
+    };
+    let payload = get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("get orgchart failed".into()))?;
+    // Global chart returns "chart" (ASCII); per-slug returns structured JSON
+    if let Some(chart) = payload["chart"].as_str() {
+        println!("{chart}");
+    } else {
+        render_single_orgchart(&payload);
+    }
+    Ok(())
+}
+
+/// Render a single org's chart from the per-slug JSON response.
+fn render_single_orgchart(data: &Value) {
+    let org = &data["org"];
+    let name = org["id"].as_str().unwrap_or("unknown");
+    let status = org["status"].as_str().unwrap_or("-");
+    let ceo = org["ceo_agent"].as_str().unwrap_or("-");
+    println!("{CYAN}{name}{RESET} ({status})");
+    println!("  CEO: {GREEN}{ceo}{RESET}");
+    for dept in data["departments"].as_array().into_iter().flatten() {
+        let dname = dept["name"].as_str().unwrap_or("General");
+        println!("  \u{251c}\u{2500}\u{2500} {CYAN}{dname}{RESET}");
+        for agent in dept["agents"].as_array().into_iter().flatten() {
+            let aname = agent["agent"].as_str().unwrap_or("-");
+            let role = agent["role"].as_str().unwrap_or("-");
+            println!("  \u{2502}   \u{2514}\u{2500}\u{2500} {aname} ({YELLOW}{role}{RESET})");
+        }
+    }
+    if let Some(plans) = data["plans"].as_array() {
+        if !plans.is_empty() {
+            println!("  Plans:");
+            for p in plans {
+                let pname = p["title"].as_str().or(p["name"].as_str()).unwrap_or("-");
+                let pstatus = p["status"].as_str().unwrap_or("-");
+                println!("    - {pname} [{YELLOW}{pstatus}{RESET}]");
+            }
+        }
+    }
+}
+
+pub fn format_org_row(org_detail: &Value) -> String {
+    let id = org_detail["org"]["id"].as_str()
+        .or_else(|| org_detail["id"].as_str()).unwrap_or("-");
+    let status = org_detail["org"]["status"].as_str()
+        .or_else(|| org_detail["status"].as_str()).unwrap_or("-");
+    let ceo = org_detail["org"]["ceo_agent"].as_str()
+        .or_else(|| org_detail["ceo_agent"].as_str()).unwrap_or("-");
+    let members = org_detail["member_count"].as_u64().unwrap_or(0);
+    let budget = org_detail["budget_usage_pct"].as_f64().unwrap_or(0.0);
+    let color = if status == "active" { GREEN } else { YELLOW };
+    format!("{id} | {color}{status}{RESET} | {ceo} | {members} | {budget:.1}%")
+}
+
+async fn fetch_org_detail(api_url: &str, id: &str) -> Result<Value, CliError> {
+    let detail = get_and_return(&format!("{api_url}/api/orgs/{id}"))
+        .await
+        .map_err(|_| CliError::ApiCallFailed("get org detail failed".into()))?;
+    let member_count = detail["members"].as_array().map(|m| m.len()).unwrap_or(0);
+    let budget = detail["org"]["budget"].as_f64().unwrap_or(0.0).max(1.0);
+    let agg = get_and_return(&format!("{api_url}/api/orgs/{id}/telemetry?period=day"))
+        .await
+        .unwrap_or_else(|_| json!({"aggregate": {"cost": 0.0}}));
+    let cost = agg["aggregate"]["cost"].as_f64().unwrap_or(0.0);
+    Ok(json!({
+        "org": detail["org"],
+        "members": detail["members"],
+        "services": detail["services"],
+        "member_count": member_count,
+        "budget_usage_pct": (cost / budget) * 100.0
+    }))
+}

--- a/daemon/crates/convergio-cli/src/cli_plan.rs
+++ b/daemon/crates/convergio-cli/src/cli_plan.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Plan subcommands for cvg CLI — daemon HTTP API. Handlers in cli_plan_handlers.rs.
+// JSON output by default; --human flag for readable text.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum PlanCommands {
+    /// List plans (all by default, newest first)
+    List {
+        /// Filter by status: done, doing, todo, cancelled, active
+        #[arg(long)]
+        status: Option<String>,
+        /// Max plans to show (default 20, 0 = unlimited)
+        #[arg(long)]
+        limit: Option<i64>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show execution tree for a plan
+    #[command(alias = "execution-tree")]
+    Tree {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show plan JSON
+    Show {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Check plan staleness (drift check)
+    Drift {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Validate a wave in a plan (Thor)
+    Validate {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a new plan
+    Create {
+        /// Project identifier
+        project_id: String,
+        /// Plan name
+        name: String,
+        /// Source spec file path
+        #[arg(long)]
+        source_file: Option<String>,
+        /// Parent plan ID (makes this a sub-plan, promotes parent to master)
+        #[arg(long)]
+        parent: Option<i64>,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Import a spec YAML into a plan
+    Import {
+        /// Plan ID to import into
+        plan_id: i64,
+        /// Path to spec YAML file
+        spec_file: String,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Start plan execution
+    Start {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Mark plan as complete
+    Complete {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Cancel a plan with reason
+    Cancel {
+        /// Plan ID
+        plan_id: i64,
+        /// Cancellation reason
+        reason: String,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Approve a plan for execution
+    Approve {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Check plan readiness (review, tasks, models)
+    Readiness {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Print example spec YAML template with all supported fields
+    Template,
+    /// Close a plan — triggers completion + mesh broadcast
+    Close {
+        /// Plan ID
+        plan_id: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: PlanCommands) -> Result<(), crate::cli_error::CliError> {
+    crate::cli_plan_handlers::dispatch(cmd).await
+}
+
+#[cfg(test)]
+#[path = "cli_plan_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_plan_handlers.rs
+++ b/daemon/crates/convergio-cli/src/cli_plan_handlers.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Handler dispatch for plan subcommands — split from cli_plan.rs for 250-line limit.
+
+use crate::cli_error::CliError;
+use crate::cli_plan::PlanCommands;
+
+pub async fn dispatch(cmd: PlanCommands) -> Result<(), CliError> {
+    match cmd {
+        // --- GET-based subcommands ---
+        PlanCommands::List { status, limit, human, api_url } => {
+            let mut params = Vec::new();
+            if let Some(s) = &status {
+                params.push(format!("status={s}"));
+            }
+            if let Some(l) = limit {
+                params.push(format!("limit={l}"));
+            }
+            let qs = if params.is_empty() {
+                String::new()
+            } else {
+                format!("?{}", params.join("&"))
+            };
+            let url = format!("{api_url}/api/plan-db/list{qs}");
+            if let Err(e) = crate::cli_http::fetch_and_print(&url, human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Tree {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            if human {
+                let url = format!("{api_url}/api/plan-db/execution-tree/{plan_id}");
+                if let Ok(val) = crate::cli_http::get_and_return(&url).await {
+                    crate::cli_plan_tree_fmt::print_execution_tree(&val);
+                }
+            } else {
+                if let Err(e) = crate::cli_http::fetch_and_print(
+                    &format!("{api_url}/api/plan-db/execution-tree/{plan_id}"),
+                    false,
+                )
+                .await
+                {
+                    eprintln!("error: {e}");
+                }
+            }
+        }
+        PlanCommands::Show {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            if human {
+                let url = format!("{api_url}/api/plan-db/json/{plan_id}");
+                if let Ok(val) = crate::cli_http::get_and_return(&url).await {
+                    crate::cli_plan_show::print_plan_human(&val);
+                }
+            } else if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/json/{plan_id}"),
+                false,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Drift {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/drift-check/{plan_id}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Validate {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plans/{plan_id}/validate"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        // --- POST-based subcommands ---
+        PlanCommands::Create {
+            project_id,
+            name,
+            source_file,
+            parent,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "project_id": project_id,
+                "name": name,
+                "source_file": source_file,
+                "parent_plan_id": parent,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(&format!("{api_url}/api/plan-db/create"), &body, human)
+                .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Import {
+            plan_id,
+            spec_file,
+            human,
+            api_url,
+        } => {
+            let content = std::fs::read_to_string(&spec_file).map_err(|e| {
+                let hint = if e.kind() == std::io::ErrorKind::NotFound {
+                    format!(". Does '{spec_file}' exist? Use absolute path or check cwd.")
+                } else {
+                    String::new()
+                };
+                CliError::InvalidInput(format!(
+                    "cannot read spec file '{spec_file}': {e}{hint}"
+                ))
+            })?;
+            let body = serde_json::json!({
+                "plan_id": plan_id,
+                "spec": content,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(&format!("{api_url}/api/plan-db/import"), &body, human)
+                .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Start {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/start/{plan_id}"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Complete {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/complete/{plan_id}"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Cancel {
+            plan_id,
+            reason,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({ "reason": reason });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/cancel/{plan_id}"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Approve {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/approve/{plan_id}"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Readiness {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/readiness/{plan_id}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        PlanCommands::Template => {
+            crate::cli_plan_template::print_template();
+        }
+        PlanCommands::Close {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/complete/{plan_id}"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/daemon/crates/convergio-cli/src/cli_plan_show.rs
+++ b/daemon/crates/convergio-cli/src/cli_plan_show.rs
@@ -1,0 +1,234 @@
+// Human-readable formatter for `cvg plan show --human`.
+// Displays plan overview with wave/task breakdown using status icons.
+
+use serde_json::Value;
+
+/// Status icon for task display.
+fn status_icon(status: &str) -> &'static str {
+    match status {
+        "done" => "\u{2713}",           // check mark
+        "in_progress" => "\u{25cf}",    // filled circle
+        "submitted" => "~",
+        "pending" => "\u{2610}",        // empty checkbox
+        "blocked" => "!",
+        "failed" | "error" => "\u{2717}", // cross mark
+        "skipped" | "cancelled" => "x",
+        _ => " ",
+    }
+}
+
+/// Truncate a string to `max` chars, appending ellipsis if needed.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}
+
+/// Print a plan in human-readable format from the /api/plan-db/json response.
+pub fn print_plan_human(val: &Value) {
+    let plan_name = val["name"].as_str().unwrap_or("?");
+    let plan_id = val["id"].as_i64().unwrap_or(0);
+    let plan_status = val["status"].as_str().unwrap_or("?");
+    let created = val["created_at"].as_str().unwrap_or("");
+
+    // Count tasks from waves array
+    let waves = val["waves"].as_array();
+    let (total, done, wave_count) = count_tasks(waves);
+
+    println!("Plan #{plan_id}: {plan_name}");
+    println!(
+        "Status: {plan_status} | Created: {created}"
+    );
+    println!("Progress: {done}/{total} tasks ({wave_count} waves)");
+    println!("{}", "-".repeat(60));
+
+    if let Some(waves) = waves {
+        for (i, wave) in waves.iter().enumerate() {
+            print_wave(i + 1, wave);
+        }
+    }
+}
+
+fn count_tasks(waves: Option<&Vec<Value>>) -> (i64, i64, usize) {
+    let Some(waves) = waves else {
+        return (0, 0, 0);
+    };
+    let mut total = 0i64;
+    let mut done = 0i64;
+    for wave in waves {
+        if let Some(tasks) = wave["tasks"].as_array() {
+            total += tasks.len() as i64;
+            done += tasks
+                .iter()
+                .filter(|t| t["status"].as_str() == Some("done"))
+                .count() as i64;
+        }
+    }
+    (total, done, waves.len())
+}
+
+fn wave_status(wave: &Value) -> &str {
+    // Derive from wave-level field or infer from tasks
+    if let Some(s) = wave["status"].as_str() {
+        return s;
+    }
+    let Some(tasks) = wave["tasks"].as_array() else {
+        return "pending";
+    };
+    let all_done = tasks
+        .iter()
+        .all(|t| t["status"].as_str() == Some("done"));
+    let any_active = tasks.iter().any(|t| {
+        matches!(
+            t["status"].as_str(),
+            Some("in_progress") | Some("submitted")
+        )
+    });
+    if all_done {
+        "done"
+    } else if any_active {
+        "doing"
+    } else {
+        "pending"
+    }
+}
+
+fn print_wave(index: usize, wave: &Value) {
+    let wave_name = wave["name"]
+        .as_str()
+        .or_else(|| wave["wave_id"].as_str())
+        .unwrap_or("unnamed");
+    let ws = wave_status(wave);
+    println!("\nWave {index}: {wave_name} [{ws}]");
+
+    let Some(tasks) = wave["tasks"].as_array() else {
+        return;
+    };
+    for task in tasks {
+        let tid = task["task_id"]
+            .as_str()
+            .unwrap_or_else(|| task["id"].as_str().unwrap_or("?"));
+        let title = task["title"].as_str().unwrap_or("untitled");
+        let status = task["status"].as_str().unwrap_or("pending");
+        let model = task["model"].as_str().unwrap_or("");
+        let effort = task["effort"].as_i64();
+        let icon = status_icon(status);
+        let title_trunc = truncate(title, 35);
+
+        let mut suffix = String::new();
+        if !model.is_empty() {
+            suffix.push_str(&format!("  {model}"));
+        }
+        if let Some(e) = effort {
+            suffix.push_str(&format!("  effort:{e}"));
+        }
+        println!("  {icon} {tid:<8} {title_trunc:<37}{suffix}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn status_icons_are_correct() {
+        assert_eq!(status_icon("done"), "\u{2713}");
+        assert_eq!(status_icon("in_progress"), "\u{25cf}");
+        assert_eq!(status_icon("pending"), "\u{2610}");
+        assert_eq!(status_icon("failed"), "\u{2717}");
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 35), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_adds_ellipsis() {
+        let long = "a]".repeat(20);
+        let result = truncate(&long, 10);
+        assert!(result.len() <= 10);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn print_plan_human_no_panic() {
+        let plan = json!({
+            "id": 10038,
+            "name": "Jarvis Fallback Fix + Mesh Auto-Update",
+            "status": "doing",
+            "created_at": "01 Apr 2026, 09:47 CET",
+            "waves": [
+                {
+                    "name": "Jarvis Fallback",
+                    "status": "done",
+                    "tasks": [
+                        {
+                            "task_id": "W1-T1",
+                            "title": "Fix keyword fallback",
+                            "status": "done",
+                            "model": "sonnet",
+                            "effort": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "Mesh Auto-Update",
+                    "tasks": [
+                        {
+                            "task_id": "W2-T1",
+                            "title": "Version in heartbeat",
+                            "status": "done",
+                            "model": "opus",
+                            "effort": 2
+                        },
+                        {
+                            "task_id": "W2-T2",
+                            "title": "Auto-update loop",
+                            "status": "in_progress",
+                            "model": "opus",
+                            "effort": 3
+                        },
+                        {
+                            "task_id": "W2-T3",
+                            "title": "Restart loop + rollback",
+                            "status": "pending",
+                            "model": "sonnet",
+                            "effort": 1
+                        }
+                    ]
+                }
+            ]
+        });
+        // Must not panic
+        print_plan_human(&plan);
+    }
+
+    #[test]
+    fn empty_plan_no_panic() {
+        let plan = json!({"id": 1, "name": "empty", "status": "pending"});
+        print_plan_human(&plan);
+    }
+
+    #[test]
+    fn wave_status_inferred_from_tasks() {
+        let wave = json!({
+            "tasks": [
+                {"status": "done"},
+                {"status": "done"}
+            ]
+        });
+        assert_eq!(wave_status(&wave), "done");
+
+        let wave2 = json!({
+            "tasks": [
+                {"status": "done"},
+                {"status": "in_progress"}
+            ]
+        });
+        assert_eq!(wave_status(&wave2), "doing");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_plan_template.rs
+++ b/daemon/crates/convergio-cli/src/cli_plan_template.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// `cvg plan template` — generate an example spec YAML with all supported fields.
+
+/// Return the canonical example spec YAML.
+/// Kept as a standalone function so tests can assert on structure.
+pub fn example_spec_yaml() -> &'static str {
+    r#"# Convergio Plan Spec — YAML Template
+# Import: cvg plan import <plan_id> this-file.yaml
+
+waves:
+  - id: "W1"
+    name: "Foundation"          # also accepts: title
+    depends_on: null            # wave dependency (e.g. "W1")
+    estimated_hours: 8          # default: 8
+    tasks:
+      - id: "T1-01"
+        title: "Implement feature X"   # also accepts: do, summary
+        type: feature                  # feature|bugfix|test|planning|analysis|review|docs
+        priority: P1                   # P0|P1|P2 (default: P1)
+        description: "Detailed description of what to build"
+        model: gpt-5.3-codex          # auto-inferred from type if absent
+        assignee: null                 # optional: copilot|claude
+        output_type: pr                # pr|document|analysis|design|legal_opinion
+        validator_agent: thor          # auto-inferred from output_type if absent
+        effort_level: 2                # 1-3, auto-inferred from file count if absent
+        files:                         # files this task modifies
+          - src/module/feature.rs
+          - src/module/feature_tests.rs
+        verify:                        # verify commands (auto-generated from files if empty)
+          - "test -f src/module/feature.rs"
+          - "cargo test --lib feature"
+        test_criteria: "cargo test --lib feature passes"
+
+  - id: "W2"
+    name: "Integration"
+    depends_on: "W1"
+    estimated_hours: 4
+    tasks:
+      - id: "T2-01"
+        do: "Write integration tests"  # 'do' is an alias for 'title'
+        type: test
+        files:
+          - tests/integration.rs
+"#
+}
+
+/// Print the template to stdout.
+pub fn print_template() {
+    print!("{}", example_spec_yaml());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_contains_required_structure() {
+        let yaml = example_spec_yaml();
+        assert!(yaml.contains("waves:"), "must have waves key");
+        assert!(yaml.contains("tasks:"), "must have tasks key");
+        assert!(yaml.contains("id:"), "must have id field");
+        assert!(yaml.contains("title:"), "must have title field");
+        assert!(yaml.contains("files:"), "must have files field");
+        assert!(yaml.contains("verify:"), "must have verify field");
+    }
+
+    #[test]
+    fn template_documents_aliases() {
+        let yaml = example_spec_yaml();
+        assert!(yaml.contains("do:"), "must document 'do' alias");
+        assert!(yaml.contains("also accepts: title"), "must note title alias for name");
+        assert!(yaml.contains("also accepts: do, summary"), "must note do/summary aliases");
+    }
+
+    #[test]
+    fn template_is_valid_yaml() {
+        let yaml = example_spec_yaml();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml)
+            .expect("template must be valid YAML");
+        let waves = parsed.get("waves").expect("must have waves key");
+        assert!(waves.is_sequence(), "waves must be an array");
+    }
+
+    #[test]
+    fn template_documents_all_task_fields() {
+        let yaml = example_spec_yaml();
+        let expected_fields = [
+            "id:", "title:", "type:", "priority:", "description:",
+            "model:", "assignee:", "output_type:", "validator_agent:",
+            "effort_level:", "files:", "verify:", "test_criteria:",
+        ];
+        for field in expected_fields {
+            assert!(yaml.contains(field), "template must document field '{field}'");
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_plan_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_plan_tests.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_plan.rs — extracted for 250-line limit.
+
+use super::*;
+
+#[test]
+fn plan_commands_list_variant_exists() {
+    let cmd = PlanCommands::List {
+        status: None,
+        limit: None,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::List { .. }));
+}
+
+#[test]
+fn plan_commands_list_with_status_filter() {
+    let cmd = PlanCommands::List {
+        status: Some("done".to_string()),
+        limit: Some(10),
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::List { .. }));
+}
+
+#[test]
+fn plan_commands_tree_variant_exists() {
+    let cmd = PlanCommands::Tree {
+        plan_id: 42,
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::Tree { plan_id: 42, .. }));
+}
+
+#[test]
+fn plan_commands_show_variant_exists() {
+    let cmd = PlanCommands::Show {
+        plan_id: 1,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::Show { .. }));
+}
+
+#[test]
+fn plan_commands_create_variant_exists() {
+    let cmd = PlanCommands::Create {
+        project_id: "convergio".to_string(),
+        name: "Migration Plan".to_string(),
+        source_file: Some("/tmp/spec.yaml".to_string()),
+        parent: None,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::Create { .. }));
+}
+
+#[test]
+fn plan_commands_create_with_parent_variant_exists() {
+    let cmd = PlanCommands::Create {
+        project_id: "convergio".to_string(),
+        name: "Sub Plan".to_string(),
+        source_file: None,
+        parent: Some(42),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::Create { parent: Some(42), .. }));
+}
+
+#[test]
+fn plan_commands_import_variant_exists() {
+    let cmd = PlanCommands::Import {
+        plan_id: 100,
+        spec_file: "/tmp/spec.yaml".to_string(),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::Import { plan_id: 100, .. }));
+}
+
+#[test]
+fn plan_commands_readiness_variant_exists() {
+    let cmd = PlanCommands::Readiness {
+        plan_id: 688,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, PlanCommands::Readiness { plan_id: 688, .. }));
+}

--- a/daemon/crates/convergio-cli/src/cli_plan_tree_fmt.rs
+++ b/daemon/crates/convergio-cli/src/cli_plan_tree_fmt.rs
@@ -1,0 +1,102 @@
+// Human-readable formatter for `cvg plan tree --human`.
+// Shows plan name, status, and waves with task breakdown.
+
+use serde_json::Value;
+
+pub fn print_execution_tree(val: &Value) {
+    let plan = &val["plan"];
+    let plan_name = plan["name"].as_str().unwrap_or("?");
+    let plan_status = plan["status"].as_str().unwrap_or("?");
+    let done = plan["tasks_done"].as_i64().unwrap_or(0);
+    let total = plan["tasks_total"].as_i64().unwrap_or(0);
+
+    println!("Plan: {plan_name} [{plan_status}] ({done}/{total} tasks)");
+    println!("{}", "-".repeat(70));
+
+    if let Some(tree) = val["tree"].as_array() {
+        for entry in tree {
+            let wave = &entry["wave"];
+            let wave_id = wave["wave_id"].as_str().unwrap_or("?");
+            let wave_name = wave["name"].as_str().unwrap_or("unnamed");
+            let wave_status = wave["status"].as_str().unwrap_or("?");
+            let w_done = wave["tasks_done"].as_i64().unwrap_or(0);
+            let w_total = wave["tasks_total"].as_i64().unwrap_or(0);
+
+            println!(
+                "\n  {wave_id}: {wave_name} [{wave_status}] ({w_done}/{w_total})"
+            );
+
+            if let Some(tasks) = entry["tasks"].as_array() {
+                for task in tasks {
+                    let tid = task["task_id"].as_str().unwrap_or("?");
+                    let title = task["title"].as_str().unwrap_or("untitled");
+                    let status = task["status"].as_str().unwrap_or("?");
+                    let icon = match status {
+                        "done" => "+",
+                        "in_progress" => ">",
+                        "submitted" => "~",
+                        "blocked" => "!",
+                        "skipped" | "cancelled" => "x",
+                        _ => " ",
+                    };
+                    println!("    [{icon}] {tid}: {title} ({status})");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn print_execution_tree_formats_without_panic() {
+        let tree = json!({
+            "ok": true,
+            "plan": {
+                "name": "Plan X v2 Hardening",
+                "status": "doing",
+                "tasks_done": 5,
+                "tasks_total": 12,
+            },
+            "tree": [
+                {
+                    "wave": {
+                        "wave_id": "W1",
+                        "name": "Runner Session Fixes",
+                        "status": "done",
+                        "tasks_done": 3,
+                        "tasks_total": 3,
+                    },
+                    "tasks": [
+                        {"task_id": "T1-01", "title": "Fix runner session", "status": "done"},
+                        {"task_id": "T1-02", "title": "Add retry logic", "status": "done"},
+                    ]
+                },
+                {
+                    "wave": {
+                        "wave_id": "W2",
+                        "name": "Simple Bug Fixes",
+                        "status": "in_progress",
+                        "tasks_done": 0,
+                        "tasks_total": 4,
+                    },
+                    "tasks": [
+                        {"task_id": "T2-01a", "title": "Fix simple bugs", "status": "in_progress"},
+                        {"task_id": "T2-01b", "title": "Fix complex bugs", "status": "pending"},
+                    ]
+                }
+            ]
+        });
+        // Smoke test: must not panic
+        print_execution_tree(&tree);
+    }
+
+    #[test]
+    fn empty_tree_does_not_panic() {
+        let tree = json!({"plan": {}, "tree": []});
+        print_execution_tree(&tree);
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_project.rs
+++ b/daemon/crates/convergio-cli/src/cli_project.rs
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Project subcommands for the cvg CLI — local filesystem ops + daemon HTTP API.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+use std::path::PathBuf;
+
+#[derive(Debug, Subcommand)]
+pub enum ProjectCommands {
+    /// Create a new project with input folder and output directory
+    Create {
+        /// Project name
+        #[arg(long)]
+        name: String,
+        /// Input folder path (must exist and be readable)
+        #[arg(long)]
+        input: PathBuf,
+        /// Skip interactive confirmation
+        #[arg(long)]
+        yes: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List all projects as JSON
+    List {
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show a single project with deliverable count
+    Show {
+        /// Project ID
+        id: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show hierarchical plan tree for a project
+    Plans {
+        /// Project ID
+        id: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: ProjectCommands) -> Result<(), CliError> {
+    match cmd {
+        ProjectCommands::Create {
+            name,
+            input,
+            yes,
+            api_url,
+        } => handle_create(&name, &input, yes, &api_url).await,
+        ProjectCommands::List { api_url } => handle_list(&api_url).await,
+        ProjectCommands::Show { id, api_url } => handle_show(&id, &api_url).await,
+        ProjectCommands::Plans { id, api_url } => handle_plans(&id, &api_url).await,
+    }
+}
+
+async fn handle_list(api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/dashboard/projects");
+    let val = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("failed to fetch projects".into()))?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&val).unwrap_or_else(|_| val.to_string())
+    );
+    Ok(())
+}
+
+async fn handle_create(
+    name: &str,
+    input: &PathBuf,
+    yes: bool,
+    api_url: &str,
+) -> Result<(), CliError> {
+    // Validate input folder exists and is readable (F-18)
+    if !input.exists() {
+        return Err(CliError::InvalidInput(format!(
+            "input folder does not exist: {}",
+            input.display()
+        )));
+    }
+    if !input.is_dir() {
+        return Err(CliError::InvalidInput(format!(
+            "input path is not a directory: {}",
+            input.display()
+        )));
+    }
+    // Permission check — attempt to read the directory (F-19)
+    std::fs::read_dir(input).map_err(|e| {
+        print_permission_help();
+        CliError::InvalidInput(format!("cannot read input folder: {e}"))
+    })?;
+
+    // Resolve output directory via platform_paths (F-21)
+    let output_dir = crate::paths::project_output_dir(name);
+
+    // Interactive confirmation unless --yes (F-20)
+    if !yes {
+        eprintln!("Project: {name}");
+        eprintln!("  Input:  {}", input.display());
+        eprintln!("  Output: {}", output_dir.display());
+        eprint!("Create? [y/N] ");
+        let mut answer = String::new();
+        if std::io::stdin().read_line(&mut answer).is_err() || !confirmed(&answer) {
+            return Err(CliError::NotFound("Aborted.".into()));
+        }
+    }
+
+    // Create output directory on local filesystem
+    std::fs::create_dir_all(&output_dir).map_err(|e| {
+        print_permission_help();
+        CliError::Io(e)
+    })?;
+
+    // Canonicalize paths for storage
+    let input_abs = std::fs::canonicalize(input).unwrap_or_else(|_| input.clone());
+    let output_abs = std::fs::canonicalize(&output_dir).unwrap_or_else(|_| output_dir.clone());
+
+    // Register project in daemon DB via HTTP API
+    let body = serde_json::json!({
+        "name": name,
+        "path": input_abs.to_string_lossy(),
+        "input_path": input_abs.to_string_lossy(),
+        "output_path": output_abs.to_string_lossy(),
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{api_url}/api/dashboard/projects"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+
+    let status = resp.status();
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&val).unwrap_or_else(|_| val.to_string())
+    );
+    if !status.is_success() {
+        return Err(CliError::NotFound("API returned non-success status".into()));
+    }
+    Ok(())
+}
+
+async fn handle_show(id: &str, api_url: &str) -> Result<(), CliError> {
+    let project_url = format!("{api_url}/api/dashboard/projects");
+    let resp = reqwest::get(&project_url)
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+
+    let project = val
+        .as_array()
+        .and_then(|arr| arr.iter().find(|p| p["id"].as_str() == Some(id)));
+    match project {
+        Some(p) => {
+            let mut out = p.clone();
+            let count = fetch_deliverable_count(id, api_url).await;
+            out["deliverable_count"] = serde_json::json!(count);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&out).unwrap_or_else(|_| out.to_string())
+            );
+            Ok(())
+        }
+        None => Err(CliError::NotFound(format!("project not found: {id}"))),
+    }
+}
+
+async fn handle_plans(id: &str, api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/project/{id}/tree");
+    let val = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("failed to fetch project tree".into()))?;
+    crate::cli_project_tree::print_project_tree(&val, id);
+    Ok(())
+}
+
+async fn fetch_deliverable_count(project_id: &str, api_url: &str) -> i64 {
+    let url = format!("{api_url}/api/deliverables?project_id={project_id}&count_only=true");
+    match reqwest::get(&url).await {
+        Ok(resp) => match resp.json::<serde_json::Value>().await {
+            Ok(v) => v.get("count")
+                .and_then(|c| c.as_i64())
+                .or_else(|| v.as_array().map(|a| a.len() as i64))
+                .unwrap_or(0),
+            Err(_) => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
+fn confirmed(answer: &str) -> bool {
+    matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+/// Print OS-specific instructions for permission errors (F-19)
+fn print_permission_help() {
+    if cfg!(target_os = "macos") {
+        eprintln!(
+            "hint: on macOS, grant Full Disk Access to your terminal app via\n  \
+             System Settings → Privacy & Security → Full Disk Access"
+        );
+    } else if cfg!(target_os = "linux") {
+        eprintln!(
+            "hint: on Linux, check folder permissions with `ls -la` and fix with\n  \
+             chmod -R u+rX <folder>"
+        );
+    } else {
+        eprintln!("hint: ensure the current user has read permissions on the input folder");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_project_tree.rs
+++ b/daemon/crates/convergio-cli/src/cli_project_tree.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tree-view printer for `cvg project plans` — split from cli_project.rs for 250-line limit.
+
+use serde_json::Value;
+
+pub fn print_project_tree(val: &Value, fallback_id: &str) {
+    println!(
+        "Project: {} ({})",
+        val["project_name"].as_str().unwrap_or(fallback_id),
+        val["project_id"].as_str().unwrap_or(fallback_id),
+    );
+    println!(
+        "Tasks: {}/{}\n",
+        val["done_tasks"].as_i64().unwrap_or(0),
+        val["total_tasks"].as_i64().unwrap_or(0),
+    );
+    if let Some(plans) = val["plans"].as_array() {
+        for plan in plans {
+            print_plan_node(plan, 0);
+        }
+    }
+}
+
+fn print_plan_node(node: &Value, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let marker = if node["is_master"].as_bool().unwrap_or(false) { "+" } else { "-" };
+    let mode = node["execution_mode"].as_str().unwrap_or("");
+    let deps = node["depends_on"].as_str().unwrap_or("");
+    println!(
+        "{indent}{marker} [{}] {} ({}/{}){}{}",
+        node["status"].as_str().unwrap_or("?"),
+        node["name"].as_str().unwrap_or("unnamed"),
+        node["tasks_done"].as_i64().unwrap_or(0),
+        node["tasks_total"].as_i64().unwrap_or(0),
+        if mode.is_empty() { String::new() } else { format!(" mode={mode}") },
+        if deps.is_empty() { String::new() } else { format!(" depends_on={deps}") },
+    );
+    if let Some(children) = node["children"].as_array() {
+        for child in children {
+            print_plan_node(child, depth + 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn print_project_tree_formats_output() {
+        let tree = json!({
+            "project_id": "p1",
+            "project_name": "TestProject",
+            "total_tasks": 10,
+            "done_tasks": 6,
+            "plans": [
+                {
+                    "id": 1, "name": "Master", "status": "doing",
+                    "tasks_done": 5, "tasks_total": 8, "is_master": true,
+                    "execution_mode": "mixed", "depends_on": null,
+                    "children": [
+                        {
+                            "id": 2, "name": "Child A", "status": "done",
+                            "tasks_done": 5, "tasks_total": 5, "is_master": false,
+                            "execution_mode": null, "depends_on": null, "children": []
+                        },
+                        {
+                            "id": 3, "name": "Child B", "status": "todo",
+                            "tasks_done": 0, "tasks_total": 3, "is_master": false,
+                            "execution_mode": null, "depends_on": "2", "children": []
+                        }
+                    ]
+                },
+                {
+                    "id": 4, "name": "Orphan", "status": "doing",
+                    "tasks_done": 1, "tasks_total": 2, "is_master": false,
+                    "execution_mode": null, "depends_on": null, "children": []
+                }
+            ]
+        });
+        // Smoke test: just verify it doesn't panic
+        print_project_tree(&tree, "p1");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_reap.rs
+++ b/daemon/crates/convergio-cli/src/cli_reap.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// `cvg reap [--dry-run]` — delegates reaping to daemon HTTP API.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum ReapCommands {
+    /// Run all reapers (worktree, branch, lock-file). Add --dry-run to preview only.
+    Run {
+        /// Preview changes without removing anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Repository root (default: current directory).
+        #[arg(long, default_value = ".")]
+        repo_root: String,
+        /// Lock-file directory (default: /tmp).
+        #[arg(long, default_value = "/tmp")]
+        lock_dir: String,
+        /// Human-readable output (default: JSON).
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: ReapCommands) {
+    match cmd {
+        ReapCommands::Run {
+            dry_run,
+            repo_root,
+            lock_dir,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "dry_run": dry_run,
+                "repo_root": repo_root,
+                "lock_dir": lock_dir,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/reap/run"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reap_run_command_dry_run_field() {
+        let cmd = ReapCommands::Run {
+            dry_run: true,
+            repo_root: ".".into(),
+            lock_dir: "/tmp".into(),
+            human: false,
+            api_url: "http://localhost:8420".into(),
+        };
+        assert!(matches!(cmd, ReapCommands::Run { dry_run: true, .. }));
+    }
+
+    #[test]
+    fn reap_run_command_default_dirs() {
+        let cmd = ReapCommands::Run {
+            dry_run: false,
+            repo_root: ".".into(),
+            lock_dir: "/tmp".into(),
+            human: true,
+            api_url: "http://localhost:8420".into(),
+        };
+        assert!(matches!(cmd, ReapCommands::Run { human: true, .. }));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_repo.rs
+++ b/daemon/crates/convergio-cli/src/cli_repo.rs
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Repository CLI subcommands: add, list, show, link, sync.
+// Delegates to daemon HTTP API at /api/repositories.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum RepoCommands {
+    /// Register a repository in the platform
+    Add {
+        /// Short unique name for the repository (e.g. convergio-platform)
+        name: String,
+        /// Absolute filesystem path to the repository root
+        #[arg(long)]
+        path: String,
+        /// Optional GitHub URL (e.g. https://github.com/org/repo)
+        #[arg(long)]
+        github_url: Option<String>,
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+        /// Transport type: local | ssh | tailscale (default: local)
+        #[arg(long, default_value = "local")]
+        transport: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List all registered repositories
+    List {
+        /// Output as JSON (default: pretty table)
+        #[arg(long)]
+        json: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show details for a single repository
+    Show {
+        /// Repository name
+        name: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Link a repository to a project
+    Link {
+        /// Repository name
+        repo_name: String,
+        /// Project ID
+        project_id: String,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Verify all registered repos exist on disk and check health
+    Sync {
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: RepoCommands) -> Result<(), CliError> {
+    match cmd {
+        RepoCommands::Add {
+            name,
+            path,
+            github_url,
+            description,
+            transport,
+            api_url,
+        } => handle_add(&name, &path, github_url, description, &transport, &api_url).await,
+        RepoCommands::List { json, api_url } => handle_list(json, &api_url).await,
+        RepoCommands::Show { name, api_url } => handle_show(&name, &api_url).await,
+        RepoCommands::Link {
+            repo_name,
+            project_id,
+            api_url,
+        } => handle_link(&repo_name, &project_id, &api_url).await,
+        RepoCommands::Sync { api_url } => handle_sync(&api_url).await,
+    }
+}
+
+async fn handle_add(
+    name: &str,
+    path: &str,
+    github_url: Option<String>,
+    description: Option<String>,
+    transport: &str,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let payload = serde_json::json!({
+        "name": name,
+        "path": path,
+        "github_url": github_url,
+        "description": description,
+        "transport": transport
+    });
+    let url = format!("{api_url}/api/repositories");
+    crate::cli_http::post_and_print(&url, &payload, true)
+        .await
+        .map_err(|_| CliError::ApiCallFailed(format!("failed to add repository '{name}'")))
+}
+
+async fn handle_list(as_json: bool, api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/repositories");
+    let val = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("failed to list repositories".into()))?;
+
+    if as_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&val).unwrap_or_else(|_| val.to_string())
+        );
+        return Ok(());
+    }
+
+    // Human-readable table
+    let repos = val.as_array().cloned().unwrap_or_default();
+    if repos.is_empty() {
+        println!("No repositories registered.");
+        return Ok(());
+    }
+    println!(
+        "{:<30} {:<12} {:<12} {}",
+        "NAME", "TRANSPORT", "HEALTH", "PATH"
+    );
+    println!("{}", "-".repeat(80));
+    for r in &repos {
+        let name = r["name"].as_str().unwrap_or("-");
+        let transport = r["transport"].as_str().unwrap_or("local");
+        let health = r["health_status"].as_str().unwrap_or("unknown");
+        let path = r["path"].as_str().unwrap_or("-");
+        println!("{:<30} {:<12} {:<12} {}", name, transport, health, path);
+    }
+    Ok(())
+}
+
+async fn handle_show(name: &str, api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/repositories/{name}");
+    crate::cli_http::fetch_and_print(&url, true)
+        .await
+        .map_err(|_| CliError::ApiCallFailed(format!("failed to show repository '{name}'")))
+}
+
+async fn handle_link(repo_name: &str, project_id: &str, api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/repositories/{repo_name}/link");
+    let payload = serde_json::json!({ "project_id": project_id });
+    crate::cli_http::post_and_print(&url, &payload, true)
+        .await
+        .map_err(|_| CliError::ApiCallFailed(format!("failed to link repository '{repo_name}'")))
+}
+
+async fn handle_sync(api_url: &str) -> Result<(), CliError> {
+    let url = format!("{api_url}/api/repositories");
+    let val = crate::cli_http::get_and_return(&url)
+        .await
+        .map_err(|_| CliError::ApiCallFailed("failed to fetch repositories for sync".into()))?;
+
+    let repos = val.as_array().cloned().unwrap_or_default();
+    if repos.is_empty() {
+        println!("No repositories to sync.");
+        return Ok(());
+    }
+
+    let mut ok = 0usize;
+    let mut missing = 0usize;
+    for r in &repos {
+        let name = r["name"].as_str().unwrap_or("?");
+        let path = r["path"].as_str().unwrap_or("");
+        let exists = std::path::Path::new(path).exists();
+        if exists {
+            println!("[OK]      {name} -> {path}");
+            ok += 1;
+        } else {
+            eprintln!("[MISSING] {name} -> {path} (path does not exist)");
+            missing += 1;
+        }
+    }
+    println!("\nSync complete: {ok} ok, {missing} missing.");
+    if missing > 0 {
+        return Err(CliError::InvalidInput(format!(
+            "{missing} repositor{} not found on disk",
+            if missing == 1 { "y" } else { "ies" }
+        )));
+    }
+    Ok(())
+}

--- a/daemon/crates/convergio-cli/src/cli_review.rs
+++ b/daemon/crates/convergio-cli/src/cli_review.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Review subcommand — register/check/reset plan reviews via daemon HTTP API.
+
+use clap::Subcommand;
+
+/// Valid verdict values for `cvg review register`.
+const VALID_VERDICTS: &[&str] = &["proceed", "revise", "reject"];
+
+/// Returns true if the verdict is one of the accepted values.
+pub fn is_valid_verdict(verdict: &str) -> bool {
+    VALID_VERDICTS.contains(&verdict)
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ReviewCommands {
+    /// Register a plan review record.
+    ///
+    /// Usage (with plan ID):
+    ///   cvg review register --plan-id <ID> <reviewer_agent> <verdict> [--suggestions ...]
+    ///
+    /// Usage (pre-plan, by spec file — use before cvg plan create):
+    ///   cvg review register --spec-file <path> <reviewer_agent> <verdict> [--suggestions ...]
+    ///
+    /// Verdict must be one of: proceed | revise | reject
+    Register {
+        /// Plan DB ID (optional if --spec-file is supplied)
+        #[arg(long)]
+        plan_id: Option<i64>,
+        /// Path to the spec file (optional if --plan-id is supplied).
+        /// When supplied and plan_id is absent, the review is stored without a
+        /// plan link and automatically linked when `cvg plan create` imports
+        /// the matching spec file.
+        #[arg(long)]
+        spec_file: Option<String>,
+        /// Reviewer agent name (e.g. plan-reviewer, plan-business-advisor)
+        reviewer_agent: String,
+        /// Verdict: must be one of proceed | revise | reject
+        verdict: String,
+        /// Optional suggestions text
+        #[arg(long)]
+        suggestions: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Check review counts for a plan
+    Check {
+        /// Plan ID
+        plan_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Reset (delete) all reviews for a plan (omit plan_id to reset pre-plan state)
+    Reset {
+        /// Plan ID (optional — omit to reset without a plan, e.g. before cvg plan create)
+        plan_id: Option<i64>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: ReviewCommands) {
+    match cmd {
+        ReviewCommands::Register {
+            plan_id,
+            spec_file,
+            reviewer_agent,
+            verdict,
+            suggestions,
+            human,
+            api_url,
+        } => {
+            // Validate verdict before sending — catch user errors locally with clear message.
+            if !is_valid_verdict(&verdict) {
+                eprintln!(
+                    "error: invalid verdict '{verdict}'\n\
+                     Valid values: proceed | revise | reject\n\
+                     Usage: cvg review register [--plan-id <ID> | --spec-file <path>] \
+                     <reviewer_agent> <verdict>"
+                );
+                std::process::exit(1);
+            }
+
+            // At least one of plan_id or spec_file must be supplied.
+            if plan_id.is_none() && spec_file.is_none() {
+                eprintln!(
+                    "error: supply either --plan-id <ID> or --spec-file <path>\n\
+                     Usage: cvg review register [--plan-id <ID> | --spec-file <path>] \
+                     <reviewer_agent> <verdict>"
+                );
+                std::process::exit(1);
+            }
+
+            let body = serde_json::json!({
+                "plan_id": plan_id,
+                "spec_file": spec_file,
+                "reviewer_agent": reviewer_agent,
+                "verdict": verdict,
+                "suggestions": suggestions,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/review/register"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        ReviewCommands::Check {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/review/check?plan_id={plan_id}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        ReviewCommands::Reset {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({ "plan_id": plan_id.unwrap_or(0) });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/review/reset"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cli_review_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_review_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_review_tests.rs
@@ -1,0 +1,122 @@
+// Tests for cli_review extracted to keep cli_review.rs ≤250 lines.
+// Why: CONSTITUTION Article V (250-line limit).
+use super::*;
+
+// BUG 1 — verdict validation tests
+#[test]
+fn verdict_proceed_is_valid() {
+    assert!(is_valid_verdict("proceed"));
+}
+
+#[test]
+fn verdict_revise_is_valid() {
+    assert!(is_valid_verdict("revise"));
+}
+
+#[test]
+fn verdict_reject_is_valid() {
+    assert!(is_valid_verdict("reject"));
+}
+
+#[test]
+fn verdict_approved_is_invalid() {
+    assert!(!is_valid_verdict("approved"));
+}
+
+#[test]
+fn verdict_empty_is_invalid() {
+    assert!(!is_valid_verdict(""));
+}
+
+#[test]
+fn verdict_typo_is_invalid() {
+    assert!(!is_valid_verdict("preceed"));
+}
+
+// BUG 3 — spec_file review registration tests
+#[test]
+fn review_register_with_spec_file_no_plan_id() {
+    let cmd = ReviewCommands::Register {
+        plan_id: None,
+        spec_file: Some("/tmp/plan.yaml".to_string()),
+        reviewer_agent: "plan-reviewer".to_string(),
+        verdict: "proceed".to_string(),
+        suggestions: None,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, ReviewCommands::Register { plan_id: None, .. }));
+}
+
+#[test]
+fn review_register_with_plan_id_no_spec_file() {
+    let cmd = ReviewCommands::Register {
+        plan_id: Some(685),
+        spec_file: None,
+        reviewer_agent: "plan-reviewer".to_string(),
+        verdict: "proceed".to_string(),
+        suggestions: None,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, ReviewCommands::Register { plan_id: Some(685), .. }));
+}
+
+#[test]
+fn review_register_variant_exists() {
+    let cmd = ReviewCommands::Register {
+        plan_id: Some(685),
+        spec_file: None,
+        reviewer_agent: "plan-reviewer".to_string(),
+        verdict: "proceed".to_string(),
+        suggestions: None,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, ReviewCommands::Register { plan_id: Some(685), .. }));
+}
+
+#[test]
+fn review_check_variant_exists() {
+    let cmd = ReviewCommands::Check {
+        plan_id: 100,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, ReviewCommands::Check { plan_id: 100, .. }));
+}
+
+#[test]
+fn review_reset_variant_exists() {
+    let cmd = ReviewCommands::Reset {
+        plan_id: Some(1),
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(
+        cmd,
+        ReviewCommands::Reset {
+            plan_id: Some(1),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn review_reset_without_plan_id() {
+    let cmd = ReviewCommands::Reset {
+        plan_id: None,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, ReviewCommands::Reset { plan_id: None, .. }));
+}
+
+#[test]
+fn review_register_body_shape() {
+    let body = serde_json::json!({
+        "plan_id": 685_i64, "reviewer_agent": "plan-reviewer",
+        "verdict": "proceed", "suggestions": serde_json::Value::Null,
+    });
+    assert_eq!(body["verdict"], "proceed");
+}

--- a/daemon/crates/convergio-cli/src/cli_run.rs
+++ b/daemon/crates/convergio-cli/src/cli_run.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Run subcommands for the cvg CLI — delegates to daemon HTTP API via reqwest.
+// JSON output by default; --human flag for readable text.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum RunCommands {
+    /// Create a new execution run
+    Create {
+        /// Plan ID to run
+        plan_id: i64,
+        /// Optional run label
+        #[arg(long)]
+        label: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List execution runs
+    List {
+        /// Filter by plan ID
+        #[arg(long)]
+        plan_id: Option<i64>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Pause a running execution
+    Pause {
+        /// Run ID to pause
+        run_id: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Resume a paused execution
+    Resume {
+        /// Run ID to resume
+        run_id: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: RunCommands) -> Result<(), CliError> {
+    match cmd {
+        RunCommands::Create {
+            plan_id,
+            label,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "plan_id": plan_id,
+                "label": label,
+            });
+            post_and_print(&format!("{api_url}/api/runs"), &body, human).await
+        }
+        RunCommands::List {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let url = match plan_id {
+                Some(id) => format!("{api_url}/api/runs?plan_id={id}"),
+                None => format!("{api_url}/api/runs"),
+            };
+            fetch_and_print(&url, human).await
+        }
+        RunCommands::Pause {
+            run_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            post_and_print(&format!("{api_url}/api/runs/{run_id}/pause"), &body, human).await
+        }
+        RunCommands::Resume {
+            run_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            post_and_print(&format!("{api_url}/api/runs/{run_id}/resume"), &body, human).await
+        }
+    }
+}
+
+async fn fetch_and_print(url: &str, human: bool) -> Result<(), CliError> {
+    let resp = reqwest::get(url)
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let status = resp.status();
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    print_value(&val, human);
+    if !status.is_success() {
+        return Err(CliError::NotFound("API returned non-success status".into()));
+    }
+    Ok(())
+}
+
+async fn post_and_print(url: &str, body: &serde_json::Value, human: bool) -> Result<(), CliError> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let status = resp.status();
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    print_value(&val, human);
+    if !status.is_success() {
+        return Err(CliError::NotFound("API returned non-success status".into()));
+    }
+    Ok(())
+}
+
+fn print_value(val: &serde_json::Value, human: bool) {
+    if human {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+        );
+    } else {
+        println!("{val}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_commands_create_variant_exists() {
+        let cmd = RunCommands::Create {
+            plan_id: 685,
+            label: Some("wave-1".to_string()),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, RunCommands::Create { plan_id: 685, .. }));
+    }
+
+    #[test]
+    fn run_commands_list_variant_exists() {
+        let cmd = RunCommands::List {
+            plan_id: None,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, RunCommands::List { plan_id: None, .. }));
+    }
+
+    #[test]
+    fn run_commands_pause_variant_exists() {
+        let cmd = RunCommands::Pause {
+            run_id: "run-42".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, RunCommands::Pause { .. }));
+    }
+
+    #[test]
+    fn run_commands_resume_variant_exists() {
+        let cmd = RunCommands::Resume {
+            run_id: "run-42".to_string(),
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, RunCommands::Resume { .. }));
+    }
+
+    #[test]
+    fn run_list_url_with_plan_filter() {
+        let plan_id = Some(685i64);
+        let api_url = "http://localhost:8420";
+        let url = match plan_id {
+            Some(id) => format!("{api_url}/api/runs?plan_id={id}"),
+            None => format!("{api_url}/api/runs"),
+        };
+        assert!(url.contains("plan_id=685"));
+    }
+
+    #[test]
+    fn run_pause_url_format() {
+        let run_id = "run-99";
+        let url = format!("http://localhost:8420/api/runs/{run_id}/pause");
+        assert_eq!(url, "http://localhost:8420/api/runs/run-99/pause");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_setup.rs
+++ b/daemon/crates/convergio-cli/src/cli_setup.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// `cvg setup` — interactive first-run wizard for Convergio Platform.
+
+use crate::cli_error::CliError;
+use crate::cli_setup_steps as steps;
+use dialoguer::{Confirm, Input, Select};
+
+const ROLES: [&str; 3] = ["standalone", "coordinator", "worker"];
+const ROLE_DESC: [&str; 3] = [
+    "standalone  — single node, no mesh networking",
+    "coordinator — orchestrates workers, hosts plans DB",
+    "worker      — receives delegated tasks from coordinator",
+];
+
+/// Run the interactive setup wizard. `--defaults` skips all prompts.
+pub(crate) async fn handle_setup(defaults: bool) -> Result<(), CliError> {
+    if defaults {
+        return write_defaults().await;
+    }
+
+    println!();
+    println!("Welcome to Convergio Setup!");
+    println!("===========================");
+    println!();
+
+    // Step 1: Node name
+    let detected = steps::detect_hostname();
+    let node_name: String = Input::new()
+        .with_prompt("Step 1/5 — Node name")
+        .default(detected)
+        .interact_text()
+        .map_err(|e| CliError::InvalidInput(e.to_string()))?;
+
+    // Step 2: Role
+    println!();
+    println!("Step 2/5 — Node role");
+    for desc in &ROLE_DESC {
+        println!("  {desc}");
+    }
+    let role_idx = Select::new()
+        .with_prompt("Select role")
+        .items(&ROLES)
+        .default(0)
+        .interact()
+        .map_err(|e| CliError::InvalidInput(e.to_string()))?;
+    let role = ROLES[role_idx];
+
+    // Step 3: Network
+    println!();
+    println!("Step 3/5 — Network");
+    let use_tailscale = detect_network();
+
+    // Step 4: AI Model / API key
+    println!();
+    println!("Step 4/5 — AI Model");
+    configure_api_key().await?;
+
+    // Step 5: Write config + summary
+    println!();
+    println!("Step 5/5 — Writing configuration...");
+    let config_path = crate::paths::config_path();
+    let content = steps::render_config(&node_name, role, use_tailscale);
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| CliError::Io(e))?;
+    }
+    std::fs::write(&config_path, &content)
+        .map_err(|e| CliError::Io(e))?;
+
+    // Generate default aliases if not present
+    let aliases_path = config_path
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join("aliases.toml");
+    if !aliases_path.exists() {
+        let defaults = crate::cli_ask::generate_default_aliases();
+        std::fs::write(&aliases_path, &defaults).map_err(CliError::Io)?;
+        println!("Agent aliases written to {}", aliases_path.display());
+    }
+
+    println!();
+    println!("Configuration saved to {}", config_path.display());
+    println!();
+    print_summary(&node_name, role, use_tailscale);
+
+    // Offer mesh join for worker/coordinator roles with Tailscale
+    if role != "standalone" && use_tailscale {
+        println!();
+        offer_mesh_join().await?;
+    }
+
+    println!();
+    println!("Next steps:");
+    println!("  cvg serve    — start the daemon");
+    println!("  cvg status   — check platform health");
+    println!();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Network detection (Step 3)
+// ---------------------------------------------------------------------------
+
+fn detect_network() -> bool {
+    if let Some(ts) = steps::detect_tailscale() {
+        println!(
+            "  Tailscale detected (IP: {})",
+            if ts.ip.is_empty() { "unknown" } else { &ts.ip }
+        );
+        if !ts.peers.is_empty() {
+            println!("  Peers found:");
+            for peer in &ts.peers {
+                println!("    - {peer}");
+            }
+        }
+        let use_ts = Confirm::new()
+            .with_prompt("  Use Tailscale for mesh networking?")
+            .default(true)
+            .interact()
+            .unwrap_or(true);
+        return use_ts;
+    }
+
+    let ifaces = steps::detect_lan_interfaces();
+    if !ifaces.is_empty() {
+        println!(
+            "  LAN mode (interfaces: {})",
+            ifaces.join(", ")
+        );
+    } else {
+        println!("  LAN mode (no Tailscale detected)");
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// API key configuration (Step 4)
+// ---------------------------------------------------------------------------
+
+async fn configure_api_key() -> Result<(), CliError> {
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        if !key.is_empty() {
+            println!(
+                "  Claude API key found in environment. \
+                 Default model: claude-sonnet-4-6"
+            );
+            return Ok(());
+        }
+    }
+
+    let key: String = Input::new()
+        .with_prompt(
+            "  Enter Anthropic API key (or press Enter to skip)",
+        )
+        .allow_empty(true)
+        .interact_text()
+        .map_err(|e| CliError::InvalidInput(e.to_string()))?;
+
+    if key.is_empty() {
+        println!(
+            "  Skipped. Set ANTHROPIC_API_KEY later or run \
+             `cvg setup` again."
+        );
+        return Ok(());
+    }
+
+    print!("  Validating key... ");
+    if steps::validate_api_key(&key).await {
+        println!("OK");
+        steps::write_env_file(&key).map_err(CliError::Io)?;
+        println!("  Key saved to ~/.convergio/env");
+    } else {
+        println!("FAILED");
+        println!(
+            "  Key could not be validated. Saving anyway — \
+             check it later."
+        );
+        steps::write_env_file(&key).map_err(CliError::Io)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Defaults mode (--defaults)
+// ---------------------------------------------------------------------------
+
+async fn write_defaults() -> Result<(), CliError> {
+    let node_name = steps::detect_hostname();
+    let ts = steps::detect_tailscale().is_some();
+    let content = steps::render_config(&node_name, "standalone", ts);
+    let config_path = crate::paths::config_path();
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).map_err(CliError::Io)?;
+    }
+    std::fs::write(&config_path, &content).map_err(CliError::Io)?;
+    println!(
+        "Default config written to {}",
+        config_path.display()
+    );
+    print_summary(&node_name, "standalone", ts);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+fn print_summary(name: &str, role: &str, tailscale: bool) {
+    let net = if tailscale { "tailscale" } else { "lan" };
+    println!("Summary:");
+    println!("  Node:      {name}");
+    println!("  Role:      {role}");
+    println!("  Network:   {net}");
+    println!("  Model:     claude-sonnet-4-6");
+}
+
+async fn offer_mesh_join() -> Result<(), CliError> {
+    let join = Confirm::new()
+        .with_prompt("Join an existing mesh now?")
+        .default(true)
+        .interact()
+        .unwrap_or(false);
+    if !join {
+        println!("  Skipped. Run `cvg mesh join <coordinator_url>` later.");
+        return Ok(());
+    }
+    let url: String = Input::new()
+        .with_prompt("Coordinator URL (e.g. http://100.89.245.79:8420)")
+        .interact_text()
+        .map_err(|e| CliError::InvalidInput(e.to_string()))?;
+    crate::cli_mesh_join::handle_mesh_join(&url).await
+}

--- a/daemon/crates/convergio-cli/src/cli_setup_steps.rs
+++ b/daemon/crates/convergio-cli/src/cli_setup_steps.rs
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Setup wizard helper functions — network detection, API validation, env file.
+
+use std::io;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Node detection
+// ---------------------------------------------------------------------------
+
+/// Auto-detect short hostname for node name.
+pub(crate) fn detect_hostname() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tailscale detection
+// ---------------------------------------------------------------------------
+
+pub(crate) struct TailscaleInfo {
+    pub ip: String,
+    pub peers: Vec<String>,
+}
+
+/// Check if Tailscale is installed and running. Returns IP + peer list.
+pub(crate) fn detect_tailscale() -> Option<TailscaleInfo> {
+    let output = std::process::Command::new("tailscale")
+        .args(["status", "--json"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).ok()?;
+    let self_ip = json
+        .get("Self")
+        .and_then(|s| s.get("TailscaleIPs"))
+        .and_then(|ips| ips.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let mut peers = Vec::new();
+    if let Some(peer_map) = json.get("Peer").and_then(|p| p.as_object()) {
+        for (_key, peer) in peer_map {
+            if let Some(name) = peer.get("HostName").and_then(|h| h.as_str())
+            {
+                let ip = peer
+                    .get("TailscaleIPs")
+                    .and_then(|ips| ips.as_array())
+                    .and_then(|arr| arr.first())
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                peers.push(format!("{name} ({ip})"));
+            }
+        }
+    }
+    Some(TailscaleInfo {
+        ip: self_ip,
+        peers,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// LAN interface detection
+// ---------------------------------------------------------------------------
+
+/// List non-loopback network interface names (macOS/Linux).
+pub(crate) fn detect_lan_interfaces() -> Vec<String> {
+    let output = std::process::Command::new("ifconfig")
+        .output()
+        .or_else(|_| std::process::Command::new("ip").args(["link"]).output());
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut ifaces = Vec::new();
+    for line in text.lines() {
+        // macOS: "en0: flags=..." / Linux: "2: eth0: <..."
+        if let Some(name) = extract_iface_name(line) {
+            if name != "lo" && name != "lo0" {
+                ifaces.push(name);
+            }
+        }
+    }
+    ifaces.dedup();
+    ifaces
+}
+
+fn extract_iface_name(line: &str) -> Option<String> {
+    // macOS format: "en0: flags=8863<UP,..."
+    if !line.starts_with(' ') && !line.starts_with('\t') {
+        if let Some(name) = line.split(':').next() {
+            let name = name.trim();
+            // Linux ip link: "2: eth0" — strip leading number
+            let name = if let Some((_num, rest)) = name.split_once(": ") {
+                rest
+            } else {
+                name
+            };
+            if !name.is_empty()
+                && name
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+            {
+                return Some(name.to_string());
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// API key validation
+// ---------------------------------------------------------------------------
+
+/// Test Anthropic API key with a minimal models endpoint call.
+pub(crate) async fn validate_api_key(key: &str) -> bool {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get("https://api.anthropic.com/v1/models")
+        .header("x-api-key", key)
+        .header("anthropic-version", "2023-06-01")
+        .send()
+        .await;
+    matches!(resp, Ok(r) if r.status().is_success())
+}
+
+// ---------------------------------------------------------------------------
+// Env file management
+// ---------------------------------------------------------------------------
+
+fn env_file_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".convergio/env")
+}
+
+/// Append or update ANTHROPIC_API_KEY in ~/.convergio/env.
+pub(crate) fn write_env_file(api_key: &str) -> io::Result<()> {
+    let path = env_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut lines: Vec<String> = existing
+        .lines()
+        .filter(|l| !l.starts_with("ANTHROPIC_API_KEY="))
+        .map(|l| l.to_string())
+        .collect();
+    lines.push(format!("ANTHROPIC_API_KEY={api_key}"));
+    std::fs::write(&path, lines.join("\n") + "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Config serialization — write a populated config.toml
+// ---------------------------------------------------------------------------
+
+/// Generate config.toml content from wizard answers.
+pub(crate) fn render_config(
+    node_name: &str,
+    role: &str,
+    use_tailscale: bool,
+) -> String {
+    let transport = if use_tailscale { "tailscale" } else { "lan" };
+    let discovery = if use_tailscale { "tailscale" } else { "mdns" };
+    format!(
+        r#"# Convergio Platform Configuration
+# Generated by `cvg setup`
+
+[node]
+name = "{node_name}"
+role = "{role}"
+
+[daemon]
+port = 8420
+auto_update = true
+
+[mesh]
+transport = "{transport}"
+discovery = "{discovery}"
+
+[mesh.tailscale]
+enabled = {use_tailscale}
+
+[inference]
+default_model = "claude-sonnet-4-6"
+api_key_env = "ANTHROPIC_API_KEY"
+
+[kernel]
+model = "none"
+max_tokens = 2048
+
+[telegram]
+enabled = false
+"#
+    )
+}

--- a/daemon/crates/convergio-cli/src/cli_skill.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Skill lint+transpile subcommands — replaces skill-lint.sh and skill-transpile-*.sh.
+use crate::cli_error::CliError;
+use clap::Subcommand;
+use std::path::PathBuf;
+
+// Re-export validation helpers so transpile module and tests keep working
+pub(crate) use crate::cli_skill_validate::{capitalise, strip_h1, yaml_get};
+
+// Re-export lint_one so cli_skill_tests.rs (super::*) keeps working
+pub(crate) use crate::cli_skill_validators::lint_one;
+
+pub(crate) const MIN_CONSTITUTION_VERSION: &str = "2.0.0";
+pub(crate) const TOKEN_BUDGET_BYTES: u64 = 6144;
+
+#[derive(Debug, Subcommand)]
+pub enum SkillCommands {
+    /// Validate a skill directory (skill.yaml + SKILL.md)
+    Lint {
+        /// Path to the skill directory (must contain skill.yaml and SKILL.md)
+        skill_dir: PathBuf,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Lint all subdirectories inside this directory
+        #[arg(long)]
+        all: bool,
+    },
+    /// Transpile skill to provider format
+    Transpile {
+        /// Path to the skill directory
+        skill_dir: PathBuf,
+        /// Output directory (default: current directory)
+        #[arg(long, default_value = ".")]
+        output_dir: PathBuf,
+        /// Target provider: claude-code, copilot-cli, generic-llm
+        #[arg(long, default_value = "claude-code")]
+        provider: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+    },
+    /// Enable a skill and auto-activate its required agents/plugins
+    Enable {
+        /// Path to the skill directory
+        skill_dir: PathBuf,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+    },
+    /// Disable a skill and remove unshared plugins/agents
+    Disable {
+        /// Path to the skill directory
+        skill_dir: PathBuf,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+    },
+}
+
+pub async fn handle(cmd: SkillCommands) -> Result<(), CliError> {
+    match cmd {
+        SkillCommands::Lint {
+            skill_dir,
+            human,
+            all,
+        } => {
+            handle_lint(&skill_dir, human, all)?;
+        }
+        SkillCommands::Transpile {
+            skill_dir,
+            output_dir,
+            provider,
+            human,
+        } => {
+            crate::cli_skill_transpile::handle_transpile(
+                &skill_dir,
+                &output_dir,
+                &provider,
+                human,
+            )?;
+        }
+        SkillCommands::Enable {
+            skill_dir,
+            api_url,
+            human,
+        } => {
+            crate::cli_skill_enable::handle(&skill_dir, &api_url, human).await?;
+        }
+        SkillCommands::Disable {
+            skill_dir,
+            api_url,
+            human,
+        } => {
+            crate::cli_skill_disable::handle(&skill_dir, &api_url, human).await?;
+        }
+    }
+    Ok(())
+}
+
+// -- Lint --------------------------------------------------------------------
+
+fn handle_lint(skill_dir: &PathBuf, human: bool, all: bool) -> Result<(), CliError> {
+    if all {
+        let entries = std::fs::read_dir(skill_dir).map_err(|err| {
+            CliError::InvalidInput(format!(
+                "error reading directory {}: {err}",
+                skill_dir.display()
+            ))
+        })?;
+        let mut results = Vec::new();
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                results.push(lint_one(&entry.path()));
+            }
+        }
+        if results.is_empty() {
+            return Err(CliError::NotFound(format!(
+                "no skill directories found in {}",
+                skill_dir.display()
+            )));
+        }
+        let pass = results.iter().filter(|r| r.ok).count();
+        let fail = results.iter().filter(|r| !r.ok).count();
+        if human {
+            for r in &results {
+                for msg in &r.messages {
+                    println!("{msg}");
+                }
+            }
+            println!("\nSummary: {pass} passed, {fail} failed");
+        } else {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "results": results.iter().map(|r| r.to_json()).collect::<Vec<_>>(),
+                    "summary": {"pass": pass, "fail": fail}
+                })
+            );
+        }
+        if fail > 0 {
+            return Err(CliError::NotFound(format!("{fail} skill(s) failed lint")));
+        }
+    } else {
+        let result = lint_one(skill_dir);
+        let pass: usize = if result.ok { 1 } else { 0 };
+        let fail = 1 - pass;
+        if human {
+            for msg in &result.messages {
+                println!("{msg}");
+            }
+            println!("\nSummary: {pass} passed, {fail} failed");
+        } else {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "results": [result.to_json()],
+                    "summary": {"pass": pass, "fail": fail}
+                })
+            );
+        }
+        if !result.ok {
+            return Err(CliError::NotFound("skill failed lint".into()));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) struct LintResult {
+    pub(crate) skill: String,
+    pub(crate) ok: bool,
+    pub(crate) messages: Vec<String>,
+}
+impl LintResult {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({"skill": self.skill, "ok": self.ok, "messages": self.messages})
+    }
+}
+
+#[cfg(test)]
+#[path = "cli_skill_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_skill_disable.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_disable.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Skill disable subcommand — removes unshared plugins/agents when a skill is disabled.
+
+use crate::cli_error::CliError;
+use crate::cli_skill_validate::{agent_name_valid, yaml_get_list};
+use crate::message_error::MessageResult;
+use std::path::{Path, PathBuf};
+
+/// Result of deactivating plugins for a disabled skill.
+#[derive(Debug)]
+pub struct DeactivatePluginsResult {
+    /// Plugins removed from allowedPlugins (not required by any other skill).
+    pub disabled_plugins: Vec<String>,
+    /// Agents disabled via daemon API.
+    pub disabled_agents: Vec<String>,
+    /// Plugins kept because another active skill also requires them.
+    pub kept_shared: Vec<String>,
+}
+
+/// Collect all plugins required by skills OTHER than `disabled_skill_name`.
+/// Scans every skill.yaml in `skills_dir` subdirectories, skipping the one being disabled.
+fn collect_other_skills_plugins(skills_dir: &Path, disabled_skill_name: &str) -> Vec<String> {
+    let mut other_plugins: Vec<String> = Vec::new();
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(e) => e,
+        Err(_) => return other_plugins,
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let dir_name = entry.file_name();
+        let dir_str = dir_name.to_string_lossy();
+        if dir_str == disabled_skill_name {
+            continue; // skip the skill being disabled
+        }
+        let yaml_path = entry.path().join("skill.yaml");
+        if let Ok(content) = std::fs::read_to_string(&yaml_path) {
+            if let Some(plugins) = yaml_get_list(&content, "requires-plugins") {
+                other_plugins.extend(plugins);
+            }
+        }
+    }
+    other_plugins
+}
+
+/// Remove plugins that are no longer needed from .claude/settings.json allowedPlugins.
+/// Returns which were removed and which were kept (shared with other skills).
+pub fn deactivate_plugins(
+    yaml_content: &str,
+    skills_dir: &Path,
+    disabled_skill_name: &str,
+    claude_dir: &Path,
+) -> MessageResult<DeactivatePluginsResult> {
+    let plugins = yaml_get_list(yaml_content, "requires-plugins").unwrap_or_default();
+    if plugins.is_empty() {
+        return Ok(DeactivatePluginsResult {
+            disabled_plugins: vec![],
+            disabled_agents: vec![],
+            kept_shared: vec![],
+        });
+    }
+
+    let other_plugins = collect_other_skills_plugins(skills_dir, disabled_skill_name);
+
+    let mut to_remove: Vec<String> = Vec::new();
+    let mut kept_shared: Vec<String> = Vec::new();
+    for plugin in &plugins {
+        if other_plugins.contains(plugin) {
+            kept_shared.push(plugin.clone());
+        } else {
+            to_remove.push(plugin.clone());
+        }
+    }
+
+    if !to_remove.is_empty() {
+        let settings_path = claude_dir.join("settings.json");
+        if settings_path.is_file() {
+            let raw = std::fs::read_to_string(&settings_path)
+                .map_err(|e| format!("read {}: {e}", settings_path.display()))?;
+            let mut settings: serde_json::Value = serde_json::from_str(&raw)
+                .map_err(|e| format!("parse {}: {e}", settings_path.display()))?;
+
+            if let Some(arr) = settings
+                .get_mut("allowedPlugins")
+                .and_then(|v| v.as_array_mut())
+            {
+                arr.retain(|v| {
+                    v.as_str()
+                        .map(|s| !to_remove.contains(&s.to_string()))
+                        .unwrap_or(true)
+                });
+            }
+
+            let pretty = serde_json::to_string_pretty(&settings)
+                .map_err(|e| format!("serialize settings: {e}"))?;
+            std::fs::write(&settings_path, pretty)
+                .map_err(|e| format!("write {}: {e}", settings_path.display()))?;
+        }
+    }
+
+    Ok(DeactivatePluginsResult {
+        disabled_plugins: to_remove,
+        disabled_agents: vec![], // populated by async handle()
+        kept_shared,
+    })
+}
+
+/// Disable a skill: removes unshared plugins and disables unshared agents via daemon API.
+pub async fn handle(skill_dir: &Path, api_url: &str, human: bool) -> Result<(), CliError> {
+    let yaml_path = skill_dir.join("skill.yaml");
+    if !yaml_path.is_file() {
+        return Err(CliError::InvalidInput(format!(
+            "skill.yaml not found in {}",
+            skill_dir.display()
+        )));
+    }
+    let yaml_content = std::fs::read_to_string(&yaml_path)
+        .map_err(|e| CliError::InvalidInput(format!("read error: {e}")))?;
+
+    let skill_name = skill_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    // Determine skills_dir as parent of skill_dir
+    let skills_dir = skill_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let claude_dir = home.join(".claude");
+
+    let mut plugin_result =
+        match deactivate_plugins(&yaml_content, &skills_dir, &skill_name, &claude_dir) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("warning: plugin deactivation failed: {e}");
+                DeactivatePluginsResult {
+                    disabled_plugins: vec![],
+                    disabled_agents: vec![],
+                    kept_shared: vec![],
+                }
+            }
+        };
+
+    // Disable agents not shared with other active skills
+    let agents = yaml_get_list(&yaml_content, "requires-agents").unwrap_or_default();
+    let other_agent_plugins: Vec<String> = {
+        let entries = match std::fs::read_dir(&skills_dir) {
+            Ok(e) => Some(e),
+            Err(e) => {
+                eprintln!("warn: could not read skills directory: {e}");
+                None
+            }
+        };
+        let mut v = Vec::new();
+        if let Some(entries) = entries {
+            for entry in entries.flatten() {
+                if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                if entry.file_name().to_string_lossy() == skill_name {
+                    continue;
+                }
+                let yp = entry.path().join("skill.yaml");
+                if let Ok(c) = std::fs::read_to_string(&yp) {
+                    if let Some(a) = yaml_get_list(&c, "requires-agents") {
+                        v.extend(a);
+                    }
+                }
+            }
+        }
+        v
+    };
+
+    for agent_name in &agents {
+        if !agent_name_valid(agent_name) {
+            eprintln!("warning: skipping invalid agent name '{agent_name}'");
+            continue;
+        }
+        if other_agent_plugins.contains(agent_name) {
+            plugin_result.kept_shared.push(agent_name.clone());
+            continue;
+        }
+        let body = serde_json::json!({"name": agent_name});
+        let url = format!("{api_url}/api/agents/disable");
+        match reqwest::Client::new().post(&url).json(&body).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                plugin_result.disabled_agents.push(agent_name.clone());
+                if human {
+                    println!("disabled agent: {agent_name}");
+                }
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                eprintln!("warning: failed to disable agent '{agent_name}': {status} {text}");
+            }
+            Err(e) => {
+                eprintln!("warning: failed to disable agent '{agent_name}': {e}");
+            }
+        }
+    }
+
+    if human {
+        for p in &plugin_result.disabled_plugins {
+            println!("removed plugin: {p}");
+        }
+        for p in &plugin_result.kept_shared {
+            println!("kept shared: {p}");
+        }
+        println!(
+            "\nSummary: {} plugins removed, {} agents disabled, {} kept (shared)",
+            plugin_result.disabled_plugins.len(),
+            plugin_result.disabled_agents.len(),
+            plugin_result.kept_shared.len(),
+        );
+    } else {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "disabled_plugins": plugin_result.disabled_plugins,
+                "disabled_agents": plugin_result.disabled_agents,
+                "kept_shared": plugin_result.kept_shared,
+            })
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "cli_skill_disable_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_skill_disable_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_disable_tests.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_skill_disable — shared-dependency check for plugins and agents.
+
+use super::deactivate_plugins;
+use std::fs;
+use tempfile::TempDir;
+
+// --- Helpers -----------------------------------------------------------------
+
+fn write_skill_yaml(dir: &std::path::Path, name: &str, plugins: &[&str]) {
+    let plugin_list = if plugins.is_empty() {
+        String::new()
+    } else {
+        format!("requires-plugins: [{}]\n", plugins.join(", "))
+    };
+    let yaml = format!(
+        "name: {name}\nversion: 1.0.0\ndescription: A skill\ndomain: testing\n\
+         constitution-version: 2.0.0\nlicense: MPL-2.0\ncopyright: Roberto D'Angelo, 2026\n{plugin_list}"
+    );
+    fs::create_dir_all(dir).unwrap();
+    fs::write(dir.join("skill.yaml"), yaml).unwrap();
+}
+
+fn write_settings_json(claude_dir: &std::path::Path, plugins: &[&str]) {
+    fs::create_dir_all(claude_dir).unwrap();
+    let arr: Vec<serde_json::Value> = plugins
+        .iter()
+        .map(|p| serde_json::Value::String((*p).to_string()))
+        .collect();
+    let val = serde_json::json!({ "allowedPlugins": arr });
+    fs::write(
+        claude_dir.join("settings.json"),
+        serde_json::to_string_pretty(&val).unwrap(),
+    )
+    .unwrap();
+}
+
+fn read_allowed_plugins(claude_dir: &std::path::Path) -> Vec<String> {
+    let text = fs::read_to_string(claude_dir.join("settings.json")).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    val["allowedPlugins"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect()
+}
+
+// --- Tests -------------------------------------------------------------------
+
+/// A skill's unique plugin is removed from allowedPlugins after disable.
+#[test]
+fn test_disable_removes_unshared() {
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+
+    // skill-a requires mcp-unique (only skill in directory)
+    let skill_a_dir = skills_dir.join("skill-a");
+    write_skill_yaml(&skill_a_dir, "skill-a", &["mcp-unique"]);
+
+    let claude_dir = tmp.path().join(".claude");
+    write_settings_json(&claude_dir, &["mcp-unique"]);
+
+    let yaml = fs::read_to_string(skill_a_dir.join("skill.yaml")).unwrap();
+    let result = deactivate_plugins(&yaml, &skills_dir, "skill-a", &claude_dir).unwrap();
+
+    assert!(
+        result.disabled_plugins.contains(&"mcp-unique".to_string()),
+        "mcp-unique should be disabled: {:?}",
+        result
+    );
+    assert!(
+        result.kept_shared.is_empty(),
+        "nothing shared: {:?}",
+        result
+    );
+
+    let remaining = read_allowed_plugins(&claude_dir);
+    assert!(
+        !remaining.contains(&"mcp-unique".to_string()),
+        "mcp-unique must be removed from settings.json: {remaining:?}"
+    );
+}
+
+/// A plugin shared with another active skill is kept in allowedPlugins.
+#[test]
+fn test_disable_keeps_shared() {
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+
+    // skill-a requires mcp-shared (being disabled)
+    let skill_a_dir = skills_dir.join("skill-a");
+    write_skill_yaml(&skill_a_dir, "skill-a", &["mcp-shared"]);
+
+    // skill-b also requires mcp-shared — so the plugin is shared
+    let skill_b_dir = skills_dir.join("skill-b");
+    write_skill_yaml(&skill_b_dir, "skill-b", &["mcp-shared"]);
+
+    let claude_dir = tmp.path().join(".claude");
+    write_settings_json(&claude_dir, &["mcp-shared"]);
+
+    let yaml = fs::read_to_string(skill_a_dir.join("skill.yaml")).unwrap();
+    let result = deactivate_plugins(&yaml, &skills_dir, "skill-a", &claude_dir).unwrap();
+
+    assert!(
+        result.kept_shared.contains(&"mcp-shared".to_string()),
+        "mcp-shared should be kept (shared): {:?}",
+        result
+    );
+    assert!(
+        result.disabled_plugins.is_empty(),
+        "nothing disabled: {:?}",
+        result
+    );
+
+    let remaining = read_allowed_plugins(&claude_dir);
+    assert!(
+        remaining.contains(&"mcp-shared".to_string()),
+        "mcp-shared must remain in settings.json: {remaining:?}"
+    );
+}

--- a/daemon/crates/convergio-cli/src/cli_skill_enable.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_enable.rs
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Skill enable subcommand — reads skill.yaml, activates required agents and plugins.
+
+use crate::cli_error::CliError;
+use crate::cli_skill_validate::{agent_name_valid, yaml_get_list};
+use crate::message_error::MessageResult;
+use std::path::{Path, PathBuf};
+
+/// Result of activating plugins into settings.json.
+pub struct PluginActivationResult {
+    pub added: Vec<String>,
+    pub skipped: Vec<String>,
+}
+
+/// Read .claude/settings.json, add plugins from requires-plugins that are not already present,
+/// write back. Creates the file (and parent dir) if absent. Returns counts of added/skipped.
+/// If requires-plugins is empty or absent, returns Ok with empty vecs and does NOT touch disk.
+pub fn activate_plugins(
+    yaml_content: &str,
+    claude_dir: &Path,
+) -> MessageResult<PluginActivationResult> {
+    let plugins = yaml_get_list(yaml_content, "requires-plugins").unwrap_or_default();
+    if plugins.is_empty() {
+        return Ok(PluginActivationResult {
+            added: vec![],
+            skipped: vec![],
+        });
+    }
+
+    let settings_path = claude_dir.join("settings.json");
+    let mut settings: serde_json::Value = if settings_path.is_file() {
+        let raw = std::fs::read_to_string(&settings_path)
+            .map_err(|e| format!("read {}: {e}", settings_path.display()))?;
+        serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", settings_path.display()))?
+    } else {
+        serde_json::json!({})
+    };
+
+    let allowed = settings
+        .get_mut("allowedPlugins")
+        .and_then(|v| v.as_array_mut());
+
+    let mut added = Vec::new();
+    let mut skipped = Vec::new();
+
+    if let Some(arr) = allowed {
+        let existing: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect();
+        for plugin in &plugins {
+            if existing.contains(plugin) {
+                skipped.push(plugin.clone());
+            } else {
+                arr.push(serde_json::Value::String(plugin.clone()));
+                added.push(plugin.clone());
+            }
+        }
+    } else {
+        // Key absent or not an array — replace/create it
+        let arr: Vec<serde_json::Value> = plugins
+            .iter()
+            .map(|p| serde_json::Value::String(p.clone()))
+            .collect();
+        settings["allowedPlugins"] = serde_json::Value::Array(arr);
+        added = plugins.clone();
+    }
+
+    if !added.is_empty() {
+        // Ensure parent dir exists (handles first-run with no .claude dir)
+        if let Some(parent) = settings_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create dir {}: {e}", parent.display()))?;
+        }
+        let pretty = serde_json::to_string_pretty(&settings)
+            .map_err(|e| format!("serialize settings: {e}"))?;
+        std::fs::write(&settings_path, pretty)
+            .map_err(|e| format!("write {}: {e}", settings_path.display()))?;
+    }
+
+    Ok(PluginActivationResult { added, skipped })
+}
+
+/// Enable a skill: parse requires-agents + requires-plugins, activate agents and plugins.
+pub async fn handle(skill_dir: &Path, api_url: &str, human: bool) -> Result<(), CliError> {
+    let yaml_path = skill_dir.join("skill.yaml");
+    if !yaml_path.is_file() {
+        return Err(CliError::InvalidInput(format!(
+            "skill.yaml not found in {}",
+            skill_dir.display()
+        )));
+    }
+    let yaml_content = std::fs::read_to_string(&yaml_path)
+        .map_err(|e| CliError::InvalidInput(format!("read error: {e}")))?;
+
+    let agents = yaml_get_list(&yaml_content, "requires-agents").unwrap_or_default();
+
+    let mut agents_enabled: usize = 0;
+    for agent_name in &agents {
+        if !agent_name_valid(agent_name) {
+            eprintln!("warning: skipping invalid agent name '{agent_name}'");
+            continue;
+        }
+        let body = serde_json::json!({"name": agent_name, "target_dir": ".github/agents"});
+        let url = format!("{api_url}/api/agents/enable");
+        match reqwest::Client::new().post(&url).json(&body).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                agents_enabled += 1;
+                if human {
+                    println!("enabled agent: {agent_name}");
+                }
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                eprintln!("warning: failed to enable agent '{agent_name}': {status} {text}");
+            }
+            Err(e) => {
+                eprintln!("warning: failed to enable agent '{agent_name}': {e}");
+            }
+        }
+    }
+
+    // Activate plugins in ~/.claude/settings.json
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let claude_dir = home.join(".claude");
+    let plugin_result = match activate_plugins(&yaml_content, &claude_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("warning: plugin activation failed: {e}");
+            PluginActivationResult {
+                added: vec![],
+                skipped: vec![],
+            }
+        }
+    };
+
+    if human {
+        for p in &plugin_result.added {
+            println!("activated plugin: {p}");
+        }
+        for p in &plugin_result.skipped {
+            println!("plugin already active (skipped): {p}");
+        }
+        println!(
+            "\nSummary: {agents_enabled} agents enabled, {} plugins activated, {} plugins already active",
+            plugin_result.added.len(),
+            plugin_result.skipped.len()
+        );
+    } else {
+        let plugins = yaml_get_list(&yaml_content, "requires-plugins").unwrap_or_default();
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "agents_enabled": agents_enabled,
+                "agents_total": agents.len(),
+                "plugins_activated": plugin_result.added,
+                "plugins_skipped": plugin_result.skipped,
+                "plugins_total": plugins.len(),
+            })
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "cli_skill_enable_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_skill_enable_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_enable_tests.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Integration tests for cli_skill_enable plugin activation.
+
+use super::activate_plugins;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_skill_yaml(dir: &std::path::Path, plugins: &[&str]) -> std::path::PathBuf {
+    let plugin_list = if plugins.is_empty() {
+        String::new()
+    } else {
+        format!("requires-plugins: [{}]\n", plugins.join(", "))
+    };
+    let yaml = format!(
+        "name: test-skill\nversion: 1.0.0\ndescription: A skill\ndomain: testing\n\
+         constitution-version: 2.0.0\nlicense: MPL-2.0\ncopyright: Roberto D'Angelo, 2026\n{plugin_list}"
+    );
+    let path = dir.join("skill.yaml");
+    fs::write(&path, yaml).unwrap();
+    path
+}
+
+fn make_settings_json(claude_dir: &std::path::Path, content: &str) {
+    fs::create_dir_all(claude_dir).unwrap();
+    fs::write(claude_dir.join("settings.json"), content).unwrap();
+}
+
+fn read_allowed_plugins(claude_dir: &std::path::Path) -> Vec<String> {
+    let path = claude_dir.join("settings.json");
+    let text = fs::read_to_string(&path).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    val["allowedPlugins"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect()
+}
+
+#[test]
+fn test_enable_activates_plugins_creates_settings_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    let skill_dir = tmp.path().join("my-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_skill_yaml(&skill_dir, &["mcp-github", "mcp-slack"]);
+
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let result = activate_plugins(&yaml, &claude_dir).unwrap();
+
+    assert_eq!(result.added, vec!["mcp-github", "mcp-slack"]);
+    assert!(result.skipped.is_empty());
+    let plugins = read_allowed_plugins(&claude_dir);
+    assert!(plugins.contains(&"mcp-github".to_string()));
+    assert!(plugins.contains(&"mcp-slack".to_string()));
+}
+
+#[test]
+fn test_enable_activates_plugins_merges_with_existing() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    let skill_dir = tmp.path().join("my-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_skill_yaml(&skill_dir, &["mcp-github", "mcp-new"]);
+    make_settings_json(
+        &claude_dir,
+        r#"{"allowedPlugins":["mcp-github","mcp-existing"]}"#,
+    );
+
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let result = activate_plugins(&yaml, &claude_dir).unwrap();
+
+    // mcp-github already present → skipped; mcp-new → added
+    assert_eq!(result.added, vec!["mcp-new"]);
+    assert_eq!(result.skipped, vec!["mcp-github"]);
+
+    let plugins = read_allowed_plugins(&claude_dir);
+    assert!(plugins.contains(&"mcp-github".to_string()));
+    assert!(plugins.contains(&"mcp-existing".to_string()));
+    assert!(plugins.contains(&"mcp-new".to_string()));
+}
+
+#[test]
+fn test_enable_activates_plugins_no_plugins_field() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    let skill_dir = tmp.path().join("my-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_skill_yaml(&skill_dir, &[]);
+
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let result = activate_plugins(&yaml, &claude_dir).unwrap();
+
+    assert!(result.added.is_empty());
+    assert!(result.skipped.is_empty());
+    // settings.json should NOT be created when there are no plugins
+    assert!(!claude_dir.join("settings.json").exists());
+}
+
+#[test]
+fn test_enable_activates_plugins_settings_without_allowed_plugins_key() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    let skill_dir = tmp.path().join("my-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_skill_yaml(&skill_dir, &["mcp-jira"]);
+    // settings.json exists but has no allowedPlugins key
+    make_settings_json(&claude_dir, r#"{"mcpServers":{}}"#);
+
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let result = activate_plugins(&yaml, &claude_dir).unwrap();
+
+    assert_eq!(result.added, vec!["mcp-jira"]);
+    let plugins = read_allowed_plugins(&claude_dir);
+    assert!(plugins.contains(&"mcp-jira".to_string()));
+}
+
+#[test]
+fn test_enable_activates_plugins_all_already_present() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    let skill_dir = tmp.path().join("my-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_skill_yaml(&skill_dir, &["mcp-github"]);
+    make_settings_json(&claude_dir, r#"{"allowedPlugins":["mcp-github"]}"#);
+
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let result = activate_plugins(&yaml, &claude_dir).unwrap();
+
+    assert!(result.added.is_empty());
+    assert_eq!(result.skipped, vec!["mcp-github"]);
+    // File content unchanged structurally
+    let plugins = read_allowed_plugins(&claude_dir);
+    assert_eq!(plugins, vec!["mcp-github"]);
+}

--- a/daemon/crates/convergio-cli/src/cli_skill_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_tests.rs
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_skill and cli_skill_transpile modules.
+
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_valid_skill(dir: &std::path::Path) {
+    fs::write(
+        dir.join("skill.yaml"),
+        "\
+name: my-skill\n\
+version: 1.0.0\n\
+description: A test skill\n\
+domain: testing\n\
+constitution-version: 2.0.0\n\
+license: MPL-2.0\n\
+copyright: Roberto D'Angelo, 2026\n",
+    )
+    .unwrap();
+    fs::write(dir.join("SKILL.md"), "# my-skill\n\nDoes things.\n").unwrap();
+}
+
+#[test]
+fn lint_valid_skill_passes() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("my-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_valid_skill(&skill_dir);
+    let result = lint_one(&skill_dir);
+    assert!(
+        result.ok,
+        "expected lint to pass; messages: {:?}",
+        result.messages
+    );
+}
+
+#[test]
+fn lint_missing_yaml_fails() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("bad-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "# bad-skill\n\nContent.\n").unwrap();
+    let result = lint_one(&skill_dir);
+    assert!(!result.ok);
+    assert!(result
+        .messages
+        .iter()
+        .any(|m| m.contains("[FAIL]") && m.contains("skill.yaml missing")));
+}
+
+#[test]
+fn lint_missing_skill_md_fails() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("no-md");
+    fs::create_dir(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("skill.yaml"),
+        "\
+name: no-md\n\
+version: 1.0.0\n\
+description: A skill\n\
+domain: testing\n\
+constitution-version: 2.0.0\n\
+license: MPL-2.0\n\
+copyright: Roberto D'Angelo, 2026\n",
+    )
+    .unwrap();
+    let result = lint_one(&skill_dir);
+    assert!(!result.ok);
+    assert!(result
+        .messages
+        .iter()
+        .any(|m| m.contains("[FAIL]") && m.contains("SKILL.md missing")));
+}
+
+#[test]
+fn lint_old_constitution_version_fails() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("old-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("skill.yaml"),
+        "\
+name: old-skill\n\
+version: 1.0.0\n\
+description: A skill\n\
+domain: testing\n\
+constitution-version: 1.0.0\n\
+license: MPL-2.0\n\
+copyright: Roberto D'Angelo, 2026\n",
+    )
+    .unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "# old-skill\n\nContent.\n").unwrap();
+    let result = lint_one(&skill_dir);
+    assert!(!result.ok);
+    assert!(result
+        .messages
+        .iter()
+        .any(|m| m.contains("[FAIL]") && m.contains("constitution version")));
+}
+
+#[test]
+fn lint_over_token_budget_fails() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("big-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("skill.yaml"),
+        "\
+name: big-skill\n\
+version: 1.0.0\n\
+description: A skill\n\
+domain: testing\n\
+constitution-version: 2.0.0\n\
+license: MPL-2.0\n\
+copyright: Roberto D'Angelo, 2026\n",
+    )
+    .unwrap();
+    fs::write(skill_dir.join("SKILL.md"), &"x".repeat(7000)).unwrap();
+    let result = lint_one(&skill_dir);
+    assert!(!result.ok);
+    assert!(result
+        .messages
+        .iter()
+        .any(|m| m.contains("[FAIL]") && m.contains("token budget")));
+}
+
+#[test]
+fn lint_invalid_name_format_fails() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("BadName");
+    fs::create_dir(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("skill.yaml"),
+        "\
+name: BadName\n\
+version: 1.0.0\n\
+description: A skill\n\
+domain: testing\n\
+constitution-version: 2.0.0\n\
+license: MPL-2.0\n\
+copyright: Roberto D'Angelo, 2026\n",
+    )
+    .unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "# BadName\n\nContent.\n").unwrap();
+    let result = lint_one(&skill_dir);
+    assert!(!result.ok);
+    assert!(result
+        .messages
+        .iter()
+        .any(|m| m.contains("[FAIL]") && m.contains("name format invalid")));
+}
+
+// Helper tests (yaml_get, semver_ge, name_format_valid, etc.) live in cli_skill_validate::tests
+
+fn make_skill_with_yaml(dir: &std::path::Path, extra_yaml: &str) {
+    fs::write(
+        dir.join("skill.yaml"),
+        format!(
+            "\
+name: test-skill\nversion: 1.0.0\ndescription: A skill\ndomain: testing\n\
+constitution-version: 2.0.0\nlicense: MPL-2.0\ncopyright: Roberto D'Angelo, 2026\n{extra_yaml}"
+        ),
+    )
+    .unwrap();
+    fs::write(dir.join("SKILL.md"), "# test-skill\n\nContent.\n").unwrap();
+}
+
+#[test]
+fn lint_no_requires_fields_still_passes() {
+    let tmp = TempDir::new().unwrap();
+    let sd = tmp.path().join("no-req-skill");
+    fs::create_dir(&sd).unwrap();
+    make_skill_with_yaml(&sd, "");
+    let result = lint_one(&sd);
+    assert!(result.ok, "messages: {:?}", result.messages);
+}
+
+#[test]
+fn lint_requires_plugins_empty_fails() {
+    let tmp = TempDir::new().unwrap();
+    let sd = tmp.path().join("empty-plug");
+    fs::create_dir(&sd).unwrap();
+    make_skill_with_yaml(&sd, "requires-plugins: []\n");
+    let r = lint_one(&sd);
+    assert!(!r.ok);
+    assert!(r
+        .messages
+        .iter()
+        .any(|m| m.contains("requires-plugins is empty")));
+}
+
+#[test]
+fn lint_requires_agents_empty_fails() {
+    let tmp = TempDir::new().unwrap();
+    let sd = tmp.path().join("empty-agent");
+    fs::create_dir(&sd).unwrap();
+    make_skill_with_yaml(&sd, "requires-agents: []\n");
+    let r = lint_one(&sd);
+    assert!(!r.ok);
+    assert!(r
+        .messages
+        .iter()
+        .any(|m| m.contains("requires-agents is empty")));
+}
+
+#[test]
+fn skill_commands_enable_variant_exists() {
+    let cmd = SkillCommands::Enable {
+        skill_dir: PathBuf::from("/tmp/skill"),
+        api_url: "http://localhost:8420".into(),
+        human: false,
+    };
+    assert!(matches!(cmd, SkillCommands::Enable { .. }));
+}
+
+#[path = "cli_skill_tests_transpile.rs"]
+mod transpile;

--- a/daemon/crates/convergio-cli/src/cli_skill_tests_transpile.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_tests_transpile.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+#[test]
+fn transpile_claude_creates_file() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("test-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_valid_skill(&skill_dir);
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let md = fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+    let out_dir = tmp.path().join("out");
+    fs::create_dir(&out_dir).unwrap();
+    let path = crate::cli_skill_transpile::transpile_claude(&yaml, &md, &out_dir).unwrap();
+    assert!(path.exists());
+    let content = fs::read_to_string(&path).unwrap();
+    assert!(content.contains("---\nname: my-skill"));
+    assert!(content.contains("<!-- v1.0.0 -->"));
+}
+
+#[test]
+fn transpile_copilot_creates_agent_md() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("test-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_valid_skill(&skill_dir);
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let md = fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+    let out_dir = tmp.path().join("out");
+    fs::create_dir(&out_dir).unwrap();
+    let path = crate::cli_skill_transpile::transpile_copilot(&yaml, &md, &out_dir).unwrap();
+    assert!(path.exists());
+    assert!(path.to_string_lossy().ends_with(".agent.md"));
+    let content = fs::read_to_string(&path).unwrap();
+    assert!(content.contains("# My-skill"));
+}
+
+#[test]
+fn transpile_generic_creates_system_prompt() {
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("test-skill");
+    fs::create_dir(&skill_dir).unwrap();
+    make_valid_skill(&skill_dir);
+    let yaml = fs::read_to_string(skill_dir.join("skill.yaml")).unwrap();
+    let md = fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+    let out_dir = tmp.path().join("out");
+    fs::create_dir(&out_dir).unwrap();
+    let path = crate::cli_skill_transpile::transpile_generic(&yaml, &md, &out_dir).unwrap();
+    assert!(path.exists());
+    assert!(path.to_string_lossy().ends_with(".system-prompt.txt"));
+    let content = fs::read_to_string(&path).unwrap();
+    assert!(content.contains("You are my-skill"));
+    assert!(content.contains("## Instructions"));
+}

--- a/daemon/crates/convergio-cli/src/cli_skill_transpile.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_transpile.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Transpile subcommand implementation — converts skill.yaml + SKILL.md to provider formats.
+
+use crate::cli_error::CliError;
+use crate::message_error::MessageResult;
+use std::path::{Path, PathBuf};
+
+pub fn handle_transpile(
+    skill_dir: &Path,
+    output_dir: &Path,
+    provider: &str,
+    human: bool,
+) -> Result<(), CliError> {
+    let yaml_path = skill_dir.join("skill.yaml");
+    let md_path = skill_dir.join("SKILL.md");
+
+    for p in [&yaml_path, &md_path] {
+        if !p.is_file() {
+            return Err(CliError::InvalidInput(format!("missing: {}", p.display())));
+        }
+    }
+
+    let yaml_content = std::fs::read_to_string(&yaml_path).map_err(CliError::Io)?;
+    let md_content = std::fs::read_to_string(&md_path).map_err(CliError::Io)?;
+
+    let output = match provider {
+        "claude-code" => transpile_claude(&yaml_content, &md_content, output_dir),
+        "copilot-cli" => transpile_copilot(&yaml_content, &md_content, output_dir),
+        "generic-llm" => transpile_generic(&yaml_content, &md_content, output_dir),
+        other => {
+            return Err(CliError::InvalidInput(format!(
+                "unknown provider '{other}'; use: claude-code, copilot-cli, generic-llm"
+            )));
+        }
+    };
+
+    match output {
+        Ok(path) => {
+            if human {
+                println!("Written: {}", path.display());
+            } else {
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "path": path.display().to_string()})
+                );
+            }
+            Ok(())
+        }
+        Err(e) => Err(CliError::ApiCallFailed(e.to_string())),
+    }
+}
+
+pub fn transpile_claude(yaml: &str, md: &str, output_dir: &Path) -> MessageResult<PathBuf> {
+    let name = crate::cli_skill::yaml_get(yaml, "name").ok_or("skill.yaml missing 'name'")?;
+    let version =
+        crate::cli_skill::yaml_get(yaml, "version").ok_or("skill.yaml missing 'version'")?;
+    let description = crate::cli_skill::yaml_get(yaml, "description").unwrap_or_default();
+    let arguments = crate::cli_skill::yaml_get(yaml, "arguments").unwrap_or_default();
+
+    let md_body = crate::cli_skill::strip_h1(md);
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("name: {name}\n"));
+    out.push_str(&format!("version: \"{version}\"\n"));
+    out.push_str("---\n\n");
+    out.push_str(&format!("<!-- v{version} -->\n\n"));
+    out.push_str(&format!("# {name}\n\n"));
+    if !description.is_empty() {
+        out.push_str(&format!("{description}\n\n"));
+    }
+    if !arguments.is_empty() && arguments != "none" {
+        out.push_str(&format!("ARGUMENTS: {arguments}\n\n"));
+    }
+    out.push_str(&md_body);
+
+    let out_path = output_dir.join(format!("{name}.md"));
+    std::fs::write(&out_path, &out).map_err(|e| format!("write error: {e}"))?;
+    Ok(out_path)
+}
+
+pub fn transpile_copilot(yaml: &str, md: &str, output_dir: &Path) -> MessageResult<PathBuf> {
+    let name = crate::cli_skill::yaml_get(yaml, "name").ok_or("skill.yaml missing 'name'")?;
+    let description = crate::cli_skill::yaml_get(yaml, "description").unwrap_or_default();
+    let model = crate::cli_skill::yaml_get(yaml, "model").unwrap_or_default();
+
+    let md_body = crate::cli_skill::strip_h1(md);
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("name: {name}\n"));
+    if !description.is_empty() {
+        out.push_str(&format!("description: {description}\n"));
+    }
+    if !model.is_empty() {
+        out.push_str(&format!("model: {model}\n"));
+    }
+    out.push_str("---\n\n");
+    let cap_name = crate::cli_skill::capitalise(&name);
+    out.push_str(&format!("# {cap_name}\n\n"));
+    out.push_str(&md_body);
+
+    let out_path = output_dir.join(format!("{name}.agent.md"));
+    std::fs::write(&out_path, &out).map_err(|e| format!("write error: {e}"))?;
+    Ok(out_path)
+}
+
+pub fn transpile_generic(yaml: &str, md: &str, output_dir: &Path) -> MessageResult<PathBuf> {
+    let name = crate::cli_skill::yaml_get(yaml, "name").ok_or("skill.yaml missing 'name'")?;
+    let description = crate::cli_skill::yaml_get(yaml, "description").unwrap_or_default();
+    let domain = crate::cli_skill::yaml_get(yaml, "domain").unwrap_or_else(|| "general".into());
+    let const_ver =
+        crate::cli_skill::yaml_get(yaml, "constitution-version").unwrap_or_else(|| "2.0.0".into());
+    let license = crate::cli_skill::yaml_get(yaml, "license").unwrap_or_else(|| "MPL-2.0".into());
+
+    let mut out = String::new();
+    out.push_str(&format!("You are {name}, a {description}.\n\n"));
+    out.push_str(&format!("Domain: {domain}\n"));
+    out.push_str(&format!("Constitution: v{const_ver}\n"));
+    out.push_str(&format!("License: {license}\n\n"));
+    out.push_str("## Instructions\n\n");
+    out.push_str(md);
+    out.push_str("\n\n## Constraints\n");
+    out.push_str(&format!(
+        "- Follow the Convergio Constitution v{const_ver}\n"
+    ));
+    out.push_str(&format!("- {license} licensed\n"));
+
+    let safe_name: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let out_path = output_dir.join(format!("{safe_name}.system-prompt.txt"));
+    std::fs::write(&out_path, &out).map_err(|e| format!("write error: {e}"))?;
+    Ok(out_path)
+}

--- a/daemon/crates/convergio-cli/src/cli_skill_validate.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_validate.rs
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Validation helpers for skill lint — extracted from cli_skill.rs to keep both under 250 lines.
+
+/// Extract a scalar YAML value (single-level key: value, unquoted or quoted).
+pub(crate) fn yaml_get(content: &str, key: &str) -> Option<String> {
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix(&format!("{key}:")) {
+            let val = rest.trim().trim_matches('"').trim_matches('\'').to_string();
+            if !val.is_empty() {
+                return Some(val);
+            }
+        }
+    }
+    None
+}
+
+/// Extract a YAML list field. Supports both inline `[a, b]` and block `- item` forms.
+pub(crate) fn yaml_get_list(content: &str, key: &str) -> Option<Vec<String>> {
+    let mut lines = content.lines().peekable();
+    while let Some(line) = lines.next() {
+        if let Some(rest) = line.strip_prefix(&format!("{key}:")) {
+            let rest = rest.trim();
+            // Inline form: key: [a, b, c]
+            if rest.starts_with('[') && rest.ends_with(']') {
+                let inner = &rest[1..rest.len() - 1];
+                let items: Vec<String> = inner
+                    .split(',')
+                    .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                return Some(items);
+            }
+            // Block form: following lines starting with "  - "
+            if rest.is_empty() {
+                let mut items = Vec::new();
+                while let Some(next) = lines.peek() {
+                    if let Some(item) = next.strip_prefix("  - ") {
+                        items.push(item.trim().trim_matches('"').trim_matches('\'').to_string());
+                        lines.next();
+                    } else if next.starts_with("  ") || next.trim().is_empty() {
+                        lines.next(); // skip blank/indented continuation
+                    } else {
+                        break;
+                    }
+                }
+                return if items.is_empty() { None } else { Some(items) };
+            }
+        }
+    }
+    None
+}
+
+/// Compare semver strings: returns true if `ver >= min`.
+pub(crate) fn semver_ge(ver: &str, min: &str) -> bool {
+    let parse = |s: &str| -> (u32, u32, u32) {
+        let p: Vec<u32> = s
+            .split('.')
+            .filter_map(|p| match p.parse::<u32>() {
+                Ok(v) => Some(v),
+                Err(_) => None,
+            })
+            .collect();
+        (
+            p.first().copied().unwrap_or(0),
+            p.get(1).copied().unwrap_or(0),
+            p.get(2).copied().unwrap_or(0),
+        )
+    };
+    parse(ver) >= parse(min)
+}
+
+/// Validate skill name format: ^[a-z][a-z0-9-]*$
+pub(crate) fn name_format_valid(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Validate semver format: ^[0-9]+\.[0-9]+\.[0-9]+$
+pub(crate) fn version_format_valid(ver: &str) -> bool {
+    let parts: Vec<&str> = ver.split('.').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Validate agent name format: ^[a-z][a-z0-9-]*$
+pub(crate) fn agent_name_valid(name: &str) -> bool {
+    name_format_valid(name)
+}
+
+/// Strip a leading H1 line from Markdown body.
+pub(crate) fn strip_h1(md: &str) -> String {
+    let mut lines = md.lines();
+    match lines.next() {
+        Some(first) if first.starts_with("# ") => lines.collect::<Vec<_>>().join("\n"),
+        Some(first) => {
+            let rest: Vec<_> = lines.collect();
+            if rest.is_empty() {
+                first.to_string()
+            } else {
+                format!("{first}\n{}", rest.join("\n"))
+            }
+        }
+        None => String::new(),
+    }
+}
+
+/// Capitalise first character of a string.
+pub(crate) fn capitalise(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_get_extracts_unquoted() {
+        let content = "name: my-skill\nversion: 1.0.0\n";
+        assert_eq!(yaml_get(content, "name"), Some("my-skill".into()));
+        assert_eq!(yaml_get(content, "version"), Some("1.0.0".into()));
+    }
+
+    #[test]
+    fn yaml_get_list_inline() {
+        let content = "requires-plugins: [plugA, plugB]\nname: foo\n";
+        let items = yaml_get_list(content, "requires-plugins").unwrap();
+        assert_eq!(items, vec!["plugA", "plugB"]);
+    }
+
+    #[test]
+    fn yaml_get_list_block() {
+        let content = "requires-agents:\n  - agent-one\n  - agent-two\nname: foo\n";
+        let items = yaml_get_list(content, "requires-agents").unwrap();
+        assert_eq!(items, vec!["agent-one", "agent-two"]);
+    }
+
+    #[test]
+    fn yaml_get_list_returns_none_when_absent() {
+        let content = "name: foo\n";
+        assert!(yaml_get_list(content, "requires-plugins").is_none());
+    }
+
+    #[test]
+    fn agent_name_valid_cases() {
+        assert!(agent_name_valid("my-agent"));
+        assert!(agent_name_valid("agent123"));
+        assert!(!agent_name_valid("MyAgent"));
+        assert!(!agent_name_valid("-bad"));
+        assert!(!agent_name_valid(""));
+    }
+
+    #[test]
+    fn semver_ge_comparisons() {
+        assert!(semver_ge("2.0.0", "2.0.0"));
+        assert!(semver_ge("3.0.0", "2.0.0"));
+        assert!(!semver_ge("1.9.9", "2.0.0"));
+    }
+
+    #[test]
+    fn name_format_valid_cases() {
+        assert!(name_format_valid("my-skill"));
+        assert!(!name_format_valid("MySkill"));
+        assert!(!name_format_valid(""));
+    }
+
+    #[test]
+    fn strip_h1_removes_title() {
+        assert!(!strip_h1("# title\nbody").contains("# title"));
+    }
+
+    #[test]
+    fn capitalise_first_char() {
+        assert_eq!(capitalise("planner"), "Planner");
+        assert_eq!(capitalise(""), "");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_skill_validators.rs
+++ b/daemon/crates/convergio-cli/src/cli_skill_validators.rs
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Lint validators for skill directories — extracted from cli_skill.rs (Plan F, T4-01).
+
+use crate::cli_skill::{LintResult, MIN_CONSTITUTION_VERSION, TOKEN_BUDGET_BYTES};
+use crate::cli_skill_validate::{
+    name_format_valid, semver_ge, version_format_valid, yaml_get, yaml_get_list,
+};
+use std::path::Path;
+
+const REQUIRED_FIELDS: &[&str] = &[
+    "name",
+    "version",
+    "description",
+    "domain",
+    "constitution-version",
+    "license",
+    "copyright",
+];
+
+pub(crate) fn lint_one(skill_dir: &Path) -> LintResult {
+    let name = skill_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let yaml_path = skill_dir.join("skill.yaml");
+    let md_path = skill_dir.join("SKILL.md");
+    let mut msgs: Vec<String> = Vec::new();
+    let mut failed = false;
+
+    if yaml_path.is_file() {
+        msgs.push(format!("[PASS] {name}: skill.yaml exists"));
+    } else {
+        msgs.push(format!("[FAIL] {name}: skill.yaml missing"));
+        failed = true;
+    }
+
+    if yaml_path.is_file() {
+        let yaml_content = std::fs::read_to_string(&yaml_path).unwrap_or_default();
+        lint_yaml_fields(&name, &yaml_content, &mut msgs, &mut failed);
+        lint_requires_plugins(&name, &yaml_content, &mut msgs, &mut failed);
+        lint_requires_agents(&name, &yaml_content, &mut msgs, &mut failed);
+    }
+
+    if md_path.is_file() {
+        msgs.push(format!("[PASS] {name}: SKILL.md exists"));
+        let byte_size = std::fs::metadata(&md_path).map(|m| m.len()).unwrap_or(0);
+        if byte_size <= TOKEN_BUDGET_BYTES {
+            msgs.push(format!(
+                "[PASS] {name}: token budget ({byte_size}/{TOKEN_BUDGET_BYTES} bytes)"
+            ));
+        } else {
+            msgs.push(format!("[FAIL] {name}: SKILL.md over token budget ({byte_size}/{TOKEN_BUDGET_BYTES} bytes)"));
+            failed = true;
+        }
+    } else {
+        msgs.push(format!("[FAIL] {name}: SKILL.md missing"));
+        failed = true;
+    }
+
+    LintResult {
+        skill: name,
+        ok: !failed,
+        messages: msgs,
+    }
+}
+
+fn lint_yaml_fields(name: &str, yaml: &str, msgs: &mut Vec<String>, failed: &mut bool) {
+    let missing: Vec<&str> = REQUIRED_FIELDS
+        .iter()
+        .filter(|&&f| yaml_get(yaml, f).is_none())
+        .copied()
+        .collect();
+    if missing.is_empty() {
+        msgs.push(format!("[PASS] {name}: required fields present"));
+    } else {
+        msgs.push(format!(
+            "[FAIL] {name}: required fields missing: {}",
+            missing.join(", ")
+        ));
+        *failed = true;
+    }
+    match yaml_get(yaml, "constitution-version") {
+        None => {
+            msgs.push(format!("[FAIL] {name}: constitution-version not set"));
+            *failed = true;
+        }
+        Some(ver) => {
+            if semver_ge(&ver, MIN_CONSTITUTION_VERSION) {
+                msgs.push(format!(
+                    "[PASS] {name}: constitution version {ver} >= {MIN_CONSTITUTION_VERSION}"
+                ));
+            } else {
+                msgs.push(format!(
+                    "[FAIL] {name}: constitution version {ver} < {MIN_CONSTITUTION_VERSION}"
+                ));
+                *failed = true;
+            }
+        }
+    }
+    match yaml_get(yaml, "copyright") {
+        Some(_) => msgs.push(format!("[PASS] {name}: copyright present")),
+        None => {
+            msgs.push(format!("[FAIL] {name}: copyright field missing or empty"));
+            *failed = true;
+        }
+    }
+    match yaml_get(yaml, "name") {
+        Some(n) if name_format_valid(&n) => {
+            msgs.push(format!("[PASS] {name}: name format valid ({n})"))
+        }
+        Some(n) => {
+            msgs.push(format!(
+                "[FAIL] {name}: name format invalid ({n}), must match ^[a-z][a-z0-9-]*$"
+            ));
+            *failed = true;
+        }
+        None => {
+            msgs.push(format!("[FAIL] {name}: name field missing"));
+            *failed = true;
+        }
+    }
+    match yaml_get(yaml, "version") {
+        Some(v) if version_format_valid(&v) => {
+            msgs.push(format!("[PASS] {name}: version format valid ({v})"))
+        }
+        Some(v) => {
+            msgs.push(format!(
+                "[FAIL] {name}: version format invalid ({v}), must be semver"
+            ));
+            *failed = true;
+        }
+        None => {
+            msgs.push(format!("[FAIL] {name}: version field missing"));
+            *failed = true;
+        }
+    }
+}
+
+/// Validate requires-plugins: if present, must be non-empty list of strings.
+fn lint_requires_plugins(name: &str, yaml: &str, msgs: &mut Vec<String>, failed: &mut bool) {
+    if let Some(plugins) = yaml_get_list(yaml, "requires-plugins") {
+        if plugins.is_empty() {
+            msgs.push(format!(
+                "[FAIL] {name}: requires-plugins is empty (remove field or add entries)"
+            ));
+            *failed = true;
+        } else {
+            msgs.push(format!(
+                "[PASS] {name}: requires-plugins valid ({} entries)",
+                plugins.len()
+            ));
+        }
+    }
+}
+
+/// Validate requires-agents: each must match ^[a-z][a-z0-9-]*$.
+fn lint_requires_agents(name: &str, yaml: &str, msgs: &mut Vec<String>, failed: &mut bool) {
+    if let Some(agents) = yaml_get_list(yaml, "requires-agents") {
+        if agents.is_empty() {
+            msgs.push(format!(
+                "[FAIL] {name}: requires-agents is empty (remove field or add entries)"
+            ));
+            *failed = true;
+        } else {
+            let invalid: Vec<&String> = agents.iter().filter(|a| !name_format_valid(a)).collect();
+            if invalid.is_empty() {
+                msgs.push(format!(
+                    "[PASS] {name}: requires-agents valid ({} entries)",
+                    agents.len()
+                ));
+            } else {
+                let bad = invalid
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                msgs.push(format!("[FAIL] {name}: requires-agents invalid names: {bad} (must match ^[a-z][a-z0-9-]*$)"));
+                *failed = true;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_lint_requires_plugins_valid() {
+        let t = TempDir::new().unwrap();
+        let sd = t.path().join("s");
+        fs::create_dir(&sd).unwrap();
+        fs::write(sd.join("skill.yaml"), "name: s\nversion: 1.0.0\ndescription: x\ndomain: y\nconstitution-version: 2.0.0\nlicense: MPL-2.0\ncopyright: x\nrequires-plugins: [mcp-github]\n").unwrap();
+        fs::write(sd.join("SKILL.md"), "# s\n\nx.\n").unwrap();
+        let r = lint_one(&sd);
+        assert!(r.ok, "{:?}", r.messages);
+        assert!(r
+            .messages
+            .iter()
+            .any(|m| m.contains("requires-plugins valid")));
+    }
+
+    #[test]
+    fn test_lint_requires_agents_invalid() {
+        let t = TempDir::new().unwrap();
+        let sd = t.path().join("s");
+        fs::create_dir(&sd).unwrap();
+        fs::write(sd.join("skill.yaml"), "name: s\nversion: 1.0.0\ndescription: x\ndomain: y\nconstitution-version: 2.0.0\nlicense: MPL-2.0\ncopyright: x\nrequires-agents:\n  - Agent_1\n").unwrap();
+        fs::write(sd.join("SKILL.md"), "# s\n\nx.\n").unwrap();
+        let r = lint_one(&sd);
+        assert!(!r.ok);
+        assert!(r
+            .messages
+            .iter()
+            .any(|m| m.contains("requires-agents invalid")));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_status.rs
+++ b/daemon/crates/convergio-cli/src/cli_status.rs
@@ -1,0 +1,174 @@
+use crate::cli_error::CliError;
+
+/// ANSI color helpers (no external crate).
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+pub async fn handle(api_url: &str) -> Result<(), CliError> {
+    let health = fetch_json(&format!("{api_url}/api/health")).await;
+    let plans = fetch_json(&format!("{api_url}/api/plan-db/list")).await;
+    let recent = fetch_json(&format!("{api_url}/api/plan-db/recent")).await;
+    let project = fetch_json(&format!("{api_url}/api/project/convergio/tree")).await;
+    let orgs = fetch_json(&format!("{api_url}/api/orgs")).await;
+
+    let proj_total = project.get("total_tasks").and_then(|v| v.as_i64()).unwrap_or(0);
+    let proj_done = project.get("tasks_done").and_then(|v| v.as_i64()).unwrap_or(0);
+    let proj_plans = project.get("plans").and_then(|v| v.as_array())
+        .map(|a| a.len()).unwrap_or(0);
+    let org_count = orgs.as_array().map(|a| a.len()).unwrap_or(0);
+
+    let version = health.get("version").and_then(|v| v.as_str()).unwrap_or("?");
+    let peers = health.get("peers").and_then(|v| v.as_i64()).unwrap_or(0);
+    let ok = health.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+    let uptime = health.get("uptime_secs").and_then(|v| v.as_i64()).unwrap_or(0);
+    let w = term_width();
+
+    let plan_list = plans.get("plans").and_then(|v| v.as_array());
+    let Some(all) = plan_list else {
+        println!("{RED}ERROR: Cannot reach daemon{RESET}");
+        return Ok(());
+    };
+
+    let (mut active, mut queued): (Vec<_>, Vec<_>) = (Vec::new(), Vec::new());
+    for p in all {
+        match p.get("status").and_then(|v| v.as_str()).unwrap_or("") {
+            "doing" => active.push(p),
+            "draft" | "todo" | "approved" => queued.push(p),
+            _ => {}
+        }
+    }
+
+    println!();
+    border(w, 'T');
+    let (dot, label) = if ok { (GREEN, "online") } else { (RED, "OFFLINE") };
+    row(w, &format!("{BOLD}Convergio Platform{RESET} v{version}"));
+    row(w, &format!(
+        "Status: {dot}\u{25CF}{RESET} {label}  \u{2502}  \
+         Peers: {peers}  \u{2502}  Uptime: {}", fmt_up(uptime),
+    ));
+    border(w, 'M');
+
+    if !active.is_empty() || !queued.is_empty() {
+        row(w, &format!("{BOLD}{CYAN}ACTIVE PLANS{RESET}"));
+        for p in &active { plan_row(w, p, "doing"); }
+        for p in &queued { plan_row(w, p, "queued"); }
+        border(w, 'M');
+    }
+
+    if let Some(list) = recent.get("plans").and_then(|v| v.as_array()) {
+        if !list.is_empty() {
+            row(w, &format!("{BOLD}{CYAN}RECENT{RESET}"));
+            for p in list { plan_row(w, p, "recent"); }
+            border(w, 'M');
+        }
+    }
+
+    row(w, &format!(
+        "{DIM}{proj_done}/{proj_total} tasks  \u{2502}  \
+         {proj_plans} plans  \u{2502}  {org_count} orgs{RESET}",
+    ));
+    border(w, 'B');
+    println!();
+    Ok(())
+}
+
+// -- box drawing ----------------------------------------------------------
+
+fn term_width() -> usize {
+    std::env::var("COLUMNS").ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(60_usize).clamp(50, 120)
+}
+
+fn border(w: usize, kind: char) {
+    let fill = "\u{2550}".repeat(w - 2);
+    match kind {
+        'T' => println!("\u{2554}{fill}\u{2557}"),
+        'M' => println!("\u{2560}{fill}\u{2563}"),
+        _   => println!("\u{255A}{fill}\u{255D}"),
+    }
+}
+
+fn row(w: usize, text: &str) {
+    let vis = visible_len(text);
+    let inner = w.saturating_sub(4);
+    let pad = inner.saturating_sub(vis);
+    println!("\u{2551}  {text}{} \u{2551}", " ".repeat(pad));
+}
+
+fn plan_row(w: usize, p: &serde_json::Value, mode: &str) {
+    let id = p.get("id").and_then(|v| v.as_i64()).unwrap_or(0);
+    let name = p.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+    let status = p.get("status").and_then(|v| v.as_str()).unwrap_or("?");
+    let done = p.get("tasks_done").and_then(|v| v.as_i64()).unwrap_or(0);
+    let total = p.get("tasks_total").and_then(|v| v.as_i64()).unwrap_or(1).max(1);
+    let short: String = name.chars().take(30).collect();
+
+    let line = match mode {
+        "doing" => {
+            let bar = progress_bar(done, total, 8);
+            format!(
+                "{YELLOW}\u{25B8}{RESET} #{id:<5} {short:<30} \
+                 [{done}/{total} {bar}]",
+            )
+        }
+        "queued" => format!(
+            "{DIM}\u{25E6}{RESET} #{id:<5} {short:<30} {DIM}[queued]{RESET}",
+        ),
+        _ => {
+            let icon = match status {
+                "completed" | "done" => format!("{GREEN}\u{2713}{RESET}"),
+                "cancelled" => format!("{RED}\u{2717}{RESET}"),
+                _ => format!("{DIM}\u{2022}{RESET}"),
+            };
+            format!("{icon} #{id:<5} {status:<11} {done:>2}/{total:<3} {short}")
+        }
+    };
+    row(w, &format!("  {line}"));
+}
+
+fn progress_bar(done: i64, total: i64, width: usize) -> String {
+    let ratio = (done as f64) / (total as f64);
+    let filled = (ratio * width as f64).round() as usize;
+    let empty = width.saturating_sub(filled);
+    format!(
+        "{GREEN}{}{RESET}{DIM}{}{RESET}",
+        "\u{2588}".repeat(filled),
+        "\u{2591}".repeat(empty),
+    )
+}
+
+/// Visible length ignoring ANSI escape sequences.
+fn visible_len(s: &str) -> usize {
+    let mut len = 0usize;
+    let mut in_esc = false;
+    for c in s.chars() {
+        if in_esc {
+            if c.is_ascii_alphabetic() { in_esc = false; }
+        } else if c == '\x1b' {
+            in_esc = true;
+        } else {
+            len += 1;
+        }
+    }
+    len
+}
+
+fn fmt_up(secs: i64) -> String {
+    let d = secs / 86400;
+    let h = (secs % 86400) / 3600;
+    let m = (secs % 3600) / 60;
+    if d > 0 { format!("{d}d {h}h") }
+    else if h > 0 { format!("{h}h {m}m") }
+    else { format!("{m}m") }
+}
+
+async fn fetch_json(url: &str) -> serde_json::Value {
+    crate::cli_http::get_and_return(url).await
+        .unwrap_or(serde_json::json!({}))
+}

--- a/daemon/crates/convergio-cli/src/cli_task.rs
+++ b/daemon/crates/convergio-cli/src/cli_task.rs
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Task subcommands for the cvg CLI — delegates to daemon HTTP API via reqwest.
+// JSON output by default; --human flag for readable text.
+
+use clap::Subcommand;
+
+// Re-export for tests that use `super::*`
+#[cfg(test)]
+pub use crate::cli_task_format::print_mechanical_human;
+
+#[derive(Debug, Subcommand)]
+pub enum TaskCommands {
+    /// Update a task status
+    Update {
+        /// Task DB ID
+        task_id: i64,
+        /// New status (e.g. in_progress, done, blocked)
+        status: String,
+        /// Optional summary message
+        #[arg(long)]
+        summary: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Validate a task (Thor gate)
+    Validate {
+        /// Task DB ID
+        task_id: i64,
+        /// Plan ID
+        plan_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Search the knowledge base
+    KbSearch {
+        /// Search query
+        query: String,
+        /// Maximum results to return
+        #[arg(long, default_value_t = 5)]
+        limit: u32,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a new task in an existing plan/wave
+    Create {
+        /// Plan DB ID
+        plan_id: i64,
+        /// Wave DB ID (wave_id_fk)
+        wave_db_id: i64,
+        /// Task string identifier (e.g. T1-01)
+        task_id: String,
+        /// Task title
+        title: String,
+        /// Priority (default: P2)
+        #[arg(long, default_value = "P2")]
+        priority: String,
+        /// Task type (default: feature)
+        #[arg(long = "type", default_value = "feature")]
+        task_type: String,
+        /// Model override
+        #[arg(long, default_value = "")]
+        model: String,
+        /// Task description
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Approve the deliverable linked to a task
+    Approve {
+        /// Task DB ID
+        task_id: i64,
+        /// Approver name or comment
+        #[arg(long)]
+        comment: Option<String>,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: TaskCommands) -> Result<(), crate::cli_error::CliError> {
+    match cmd {
+        TaskCommands::Update {
+            task_id,
+            status,
+            summary,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "task_id": task_id,
+                "status": status,
+                "summary": summary,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/task/update"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        TaskCommands::Validate {
+            task_id,
+            plan_id,
+            human,
+            api_url,
+        } => {
+            let url = format!("{api_url}/api/plan-db/validate-task/{task_id}/{plan_id}");
+            let resp = reqwest::get(&url).await.map_err(|e| {
+                crate::cli_error::CliError::ApiCallFailed(format!(
+                    "error connecting to daemon: {e}"
+                ))
+            })?;
+            let val: serde_json::Value = resp.json().await.map_err(|e| {
+                crate::cli_error::CliError::ApiCallFailed(format!("error parsing response: {e}"))
+            })?;
+            if human {
+                crate::cli_task_format::print_mechanical_human(&val);
+            } else {
+                println!("{val}");
+            }
+            // Return error if mechanical gates rejected
+            let rejected = val
+                .get("mechanical")
+                .and_then(|m| m.get("status"))
+                .and_then(serde_json::Value::as_str)
+                == Some("REJECTED");
+            if rejected {
+                return Err(crate::cli_error::CliError::ValidationRejected(
+                    "mechanical gates rejected".into(),
+                ));
+            }
+        }
+        TaskCommands::KbSearch {
+            query,
+            limit,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/kb-search?q={query}&limit={limit}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        TaskCommands::Create {
+            plan_id,
+            wave_db_id,
+            task_id,
+            title,
+            priority,
+            task_type,
+            model,
+            description,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "plan_id": plan_id,
+                "wave_id_fk": wave_db_id,
+                "task_id": task_id,
+                "title": title,
+                "priority": priority,
+                "type": task_type,
+                "model": model,
+                "description": description,
+            });
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/task/create"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        TaskCommands::Approve {
+            task_id,
+            comment,
+            human,
+            api_url,
+        } => {
+            crate::cli_task_approve::handle(task_id, comment, human, &api_url).await?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "cli_task_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_task_approve.rs
+++ b/daemon/crates/convergio-cli/src/cli_task_approve.rs
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Handler for `cvg task approve <task_id>` — finds deliverable linked to task,
+// then approves it via the daemon HTTP API.
+
+use crate::cli_error::CliError;
+use crate::message_error::MessageResult;
+use serde_json::Value;
+
+/// Approve the deliverable linked to a task.
+/// Flow: GET /api/deliverables?task_id=<id> → find deliverable → POST approve.
+pub async fn handle(
+    task_id: i64,
+    comment: Option<String>,
+    human: bool,
+    api_url: &str,
+) -> Result<(), CliError> {
+    let deliverable = find_deliverable(task_id, api_url)
+        .await
+        .map_err(|e| CliError::NotFound(e.to_string()))?;
+
+    let id = deliverable["id"].as_i64().unwrap_or(0);
+    let approved_by = comment.unwrap_or_else(|| "cli".to_string());
+
+    let body = serde_json::json!({ "approved_by": approved_by });
+    let url = format!("{api_url}/api/deliverables/{id}/approve");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+
+    let status = resp.status();
+    let val: Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+
+    if human {
+        print_approval_human(&val);
+    } else {
+        println!("{val}");
+    }
+
+    if !status.is_success() {
+        return Err(CliError::NotFound(format!(
+            "daemon returned status {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Find the deliverable linked to a task via GET /api/deliverables?task_id=<id>.
+/// Returns the first deliverable or an error message.
+async fn find_deliverable(task_id: i64, api_url: &str) -> MessageResult<Value> {
+    let url = format!("{api_url}/api/deliverables?task_id={task_id}");
+    let resp = reqwest::get(&url)
+        .await
+        .map_err(|e| format!("error connecting to daemon: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("daemon returned status {}", resp.status()).into());
+    }
+
+    let list: Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("error parsing deliverables response: {e}"))?;
+
+    let arr = list
+        .as_array()
+        .ok_or_else(|| "unexpected response format: expected array".to_string())?;
+
+    if arr.is_empty() {
+        return Err(format!(
+            "no deliverable linked to task {task_id}. \
+             Create one first with: cvg deliverable create --task-id {task_id}"
+        )
+        .into());
+    }
+
+    // Return the most recent (first, since ordered by id DESC)
+    Ok(arr[0].clone())
+}
+
+/// Human-readable output for deliverable approval confirmation.
+fn print_approval_human(val: &Value) {
+    let name = val["name"].as_str().unwrap_or("(unknown)");
+    let path = val["output_path"].as_str().unwrap_or("(none)");
+    let version = val["version"].as_i64().unwrap_or(0);
+    let status = val["status"].as_str().unwrap_or("approved");
+
+    println!("Deliverable approved:");
+    println!("  Name:    {name}");
+    println!("  Path:    {path}");
+    println!("  Version: v{version}");
+    println!("  Status:  {status}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn print_approval_human_formats_correctly() {
+        let val = serde_json::json!({
+            "id": 42,
+            "name": "analysis-report",
+            "output_path": "/data/output/2026-03-22_analysis-report_v1",
+            "version": 1,
+            "status": "approved",
+        });
+        // Should not panic
+        print_approval_human(&val);
+    }
+
+    #[test]
+    fn print_approval_human_handles_missing_fields() {
+        let val = serde_json::json!({"id": 1});
+        // Should not panic; uses defaults
+        print_approval_human(&val);
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_task_format.rs
+++ b/daemon/crates/convergio-cli/src/cli_task_format.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Human-readable formatting helpers for task CLI output.
+
+/// Human-readable output for mechanical gate validation results.
+pub fn print_mechanical_human(val: &serde_json::Value) {
+    let mechanical = match val.get("mechanical") {
+        Some(m) => m,
+        None => {
+            println!("{}", serde_json::to_string_pretty(val).unwrap_or_default());
+            return;
+        }
+    };
+
+    let status = mechanical
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("UNKNOWN");
+    let note = mechanical
+        .get("note")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    println!("Mechanical Validation: {status}");
+    println!();
+
+    if let Some(gates) = mechanical.get("gates").and_then(|g| g.as_array()) {
+        for gate in gates {
+            let name = gate.get("gate").and_then(|g| g.as_str()).unwrap_or("?");
+            let passed = gate
+                .get("passed")
+                .and_then(|p| p.as_bool())
+                .unwrap_or(false);
+            let icon = if passed { "PASS" } else { "FAIL" };
+            println!("  [{icon}] {name}");
+            if let Some(details) = gate.get("details").and_then(|d| d.as_array()) {
+                for d in details {
+                    if let Some(s) = d.as_str() {
+                        println!("         {s}");
+                    }
+                }
+            }
+        }
+    }
+
+    if !note.is_empty() {
+        println!();
+        println!("{note}");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_task_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_task_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+#[test]
+fn task_commands_update_variant_exists() {
+    let cmd = TaskCommands::Update {
+        task_id: 100,
+        status: "done".to_string(),
+        summary: Some("finished".to_string()),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, TaskCommands::Update { task_id: 100, .. }));
+}
+
+#[test]
+fn task_commands_validate_variant_exists() {
+    let cmd = TaskCommands::Validate {
+        task_id: 1,
+        plan_id: 685,
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, TaskCommands::Validate { plan_id: 685, .. }));
+}
+
+#[test]
+fn task_commands_kb_search_variant_exists() {
+    let cmd = TaskCommands::KbSearch {
+        query: "test".to_string(),
+        limit: 5,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, TaskCommands::KbSearch { .. }));
+}
+
+#[test]
+fn task_commands_approve_variant_exists() {
+    let cmd = TaskCommands::Approve {
+        task_id: 50,
+        comment: Some("looks good".to_string()),
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, TaskCommands::Approve { task_id: 50, .. }));
+}
+
+#[test]
+fn print_value_json_compact() {
+    let val = serde_json::json!({"ok": true, "data": [1, 2]});
+    let compact = val.to_string();
+    assert!(!compact.is_empty());
+}
+
+#[test]
+fn print_value_json_pretty() {
+    let val = serde_json::json!({"ok": true});
+    let pretty = serde_json::to_string_pretty(&val).unwrap();
+    assert!(pretty.contains('\n'));
+}
+
+#[test]
+fn mechanical_human_output_handles_approved() {
+    let val = serde_json::json!({
+        "ok": true,
+        "mechanical": {
+            "status": "APPROVED",
+            "phase": "mechanical",
+            "gates": [
+                {"gate": "status_check", "passed": true, "details": []},
+                {"gate": "test_criteria", "passed": true, "details": []},
+            ],
+            "thor_invoked": false,
+            "note": "mechanical gates passed, Thor validation at wave level"
+        }
+    });
+    print_mechanical_human(&val);
+}
+
+#[test]
+fn mechanical_human_output_handles_rejected() {
+    let val = serde_json::json!({
+        "ok": false,
+        "mechanical": {
+            "status": "REJECTED",
+            "phase": "mechanical",
+            "gates": [
+                {"gate": "status_check", "passed": false, "details": ["status is 'pending', expected 'submitted'"]},
+            ],
+            "thor_invoked": false,
+            "note": "mechanical gates failed"
+        }
+    });
+    print_mechanical_human(&val);
+}
+
+#[test]
+fn mechanical_human_output_handles_missing_mechanical() {
+    let val = serde_json::json!({"ok": true});
+    print_mechanical_human(&val);
+}

--- a/daemon/crates/convergio-cli/src/cli_voice.rs
+++ b/daemon/crates/convergio-cli/src/cli_voice.rs
@@ -1,0 +1,65 @@
+// NOTE: Watchdog monitoring (previously partly overlapping with voice pipeline)
+// has been superseded by the kernel module. Use `cvg kernel` for health monitoring.
+// This module remains for voice pipeline management (start/stop/status/test).
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+const DEFAULT_API: &str = "http://127.0.0.1:8420";
+
+#[derive(Debug, Subcommand)]
+pub enum VoiceCommands {
+    /// Start voice listening (cvg voice start)
+    Start {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Stop voice listening (cvg voice stop)
+    Stop {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+    /// Show voice pipeline status (cvg voice status)
+    Status {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+        #[arg(long)]
+        human: bool,
+    },
+    /// Test audio setup (cvg voice test)
+    Test {
+        #[arg(long, default_value = DEFAULT_API)]
+        api_url: String,
+    },
+}
+
+/// Dispatch voice pipeline commands.
+///
+/// Health monitoring previously accessible via related watchdog commands is now
+/// available through `cvg kernel`. This handler is for voice pipeline only.
+pub async fn handle(cmd: VoiceCommands) -> Result<(), CliError> {
+    // Deprecation notice: watchdog monitoring moved to `cvg kernel`.
+    // Voice pipeline management (start/stop/status/test) continues here.
+    match cmd {
+        VoiceCommands::Start { api_url } => {
+            let body = serde_json::json!({});
+            let url = format!("{api_url}/api/voice/start");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        VoiceCommands::Stop { api_url } => {
+            let body = serde_json::json!({});
+            let url = format!("{api_url}/api/voice/stop");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+        VoiceCommands::Status { api_url, human } => {
+            crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/voice/status"),
+                human,
+            ).await
+        }
+        VoiceCommands::Test { api_url } => {
+            let body = serde_json::json!({});
+            let url = format!("{api_url}/api/voice/test");
+            crate::cli_http::post_and_print(&url, &body, false).await
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_wave.rs
+++ b/daemon/crates/convergio-cli/src/cli_wave.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Wave subcommands for the cvg CLI — delegates to daemon HTTP API via reqwest.
+// JSON output by default; --human flag for readable text.
+// Handler implementations live in cli_wave_handlers.rs (250-line split).
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum WaveCommands {
+    /// Update wave status
+    Update {
+        /// Wave DB ID
+        wave_id: i64,
+        /// New status (e.g. in_progress, done, blocked)
+        status: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show context for a plan (waves + tasks summary)
+    Context {
+        /// Plan ID
+        plan_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a new wave for a plan (also provisions a workspace)
+    Create {
+        /// Plan ID
+        plan_id: i64,
+        /// Wave ID (human-readable, e.g. W1, W2)
+        wave_id: String,
+        /// Wave name/description
+        name: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Merge a completed wave via the workspace release pipeline
+    Merge {
+        /// Plan ID
+        plan_id: i64,
+        /// Wave DB ID
+        wave_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Validate a wave: quality gates first, then Thor (Opus, wave-level)
+    Validate {
+        /// Wave DB ID
+        wave_id: i64,
+        /// Plan ID
+        plan_id: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Release a wave workspace (alias for workspace release pipeline)
+    Release {
+        /// Wave DB ID
+        wave_id: i64,
+        /// Plan ID
+        plan_id: i64,
+        /// GitHub repo slug (owner/repo)
+        #[arg(long)]
+        repo: String,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: WaveCommands) -> Result<(), CliError> {
+    match cmd {
+        WaveCommands::Update {
+            wave_id,
+            status,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({
+                "wave_id": wave_id,
+                "status": status,
+            });
+            crate::cli_http::post_and_print(
+                &format!("{api_url}/api/plan-db/wave/update"),
+                &body,
+                human,
+            )
+            .await?;
+        }
+        WaveCommands::Context {
+            plan_id,
+            human,
+            api_url,
+        } => {
+            crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/plan-db/context/{plan_id}"),
+                human,
+            )
+            .await?;
+        }
+        WaveCommands::Create {
+            plan_id,
+            wave_id,
+            name,
+            human,
+            api_url,
+        } => {
+            crate::cli_wave_handlers::handle_create(plan_id, wave_id, name, human, api_url).await?;
+        }
+        WaveCommands::Merge {
+            plan_id,
+            wave_id,
+            human,
+            api_url,
+        } => {
+            crate::cli_wave_handlers::handle_merge(plan_id, wave_id, human, api_url).await?;
+        }
+        WaveCommands::Validate {
+            wave_id,
+            plan_id,
+            human,
+            api_url,
+        } => {
+            crate::cli_wave_handlers::handle_validate(wave_id, plan_id, human, api_url).await?;
+        }
+        WaveCommands::Release {
+            wave_id,
+            plan_id,
+            repo,
+            human,
+            api_url,
+        } => {
+            crate::cli_wave_handlers::handle_release(wave_id, plan_id, repo, human, api_url)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wave_commands_update_variant_exists() {
+        let cmd = WaveCommands::Update {
+            wave_id: 1,
+            status: "done".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, WaveCommands::Update { wave_id: 1, .. }));
+    }
+
+    #[test]
+    fn wave_commands_context_variant_exists() {
+        let cmd = WaveCommands::Context {
+            plan_id: 685,
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, WaveCommands::Context { plan_id: 685, .. }));
+    }
+
+    #[test]
+    fn wave_commands_validate_variant_exists() {
+        let cmd = WaveCommands::Validate {
+            wave_id: 3,
+            plan_id: 685,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, WaveCommands::Validate { wave_id: 3, .. }));
+    }
+
+    #[test]
+    fn wave_commands_create_variant_exists() {
+        let cmd = WaveCommands::Create {
+            plan_id: 687,
+            wave_id: "W1".to_string(),
+            name: "Foundation".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, WaveCommands::Create { plan_id: 687, .. }));
+    }
+
+    #[test]
+    fn wave_commands_merge_variant_exists() {
+        let cmd = WaveCommands::Merge {
+            plan_id: 687,
+            wave_id: 2088,
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, WaveCommands::Merge { wave_id: 2088, .. }));
+    }
+
+    #[test]
+    fn wave_commands_release_variant_exists() {
+        let cmd = WaveCommands::Release {
+            wave_id: 42,
+            plan_id: 698,
+            repo: "org/convergio".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(
+            cmd,
+            WaveCommands::Release {
+                wave_id: 42,
+                plan_id: 698,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn wave_update_body_shape() {
+        let body = serde_json::json!({
+            "wave_id": 2_i64,
+            "status": "in_progress",
+        });
+        assert_eq!(body["wave_id"], 2);
+        assert_eq!(body["status"], "in_progress");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_wave_handlers.rs
+++ b/daemon/crates/convergio-cli/src/cli_wave_handlers.rs
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Wave CLI handler implementations — called from cli_wave::handle().
+// Split from cli_wave.rs to stay under the 250-line file limit.
+
+use crate::cli_error::CliError;
+
+/// Look up the active workspace_id for a given wave in a plan.
+/// Returns None (and prints an error) if not found.
+async fn find_workspace_id(api_url: &str, plan_id: i64, wave_id: i64) -> Option<String> {
+    let list_url = format!("{api_url}/api/workspace/list?plan_id={plan_id}");
+    let list_resp = match crate::cli_http::get_and_return(&list_url).await {
+        Ok(v) => v,
+        Err(code) => {
+            eprintln!("error listing workspaces (exit {code})");
+            return None;
+        }
+    };
+    list_resp
+        .get("workspaces")
+        .and_then(|ws| ws.as_array())
+        .and_then(|arr| {
+            arr.iter().find(|w| {
+                (w.get("wave_db_id").and_then(|v| v.as_i64()) == Some(wave_id))
+                    && w.get("status")
+                        .and_then(|v| v.as_str())
+                        .is_none_or(|s| s == "active")
+            })
+        })
+        .and_then(|w| w.get("workspace_id"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+}
+
+/// Create wave in plan-db, then provision a workspace for the new wave.
+pub async fn handle_create(
+    plan_id: i64,
+    wave_id: String,
+    name: String,
+    human: bool,
+    api_url: String,
+) -> Result<(), CliError> {
+    let create_body = serde_json::json!({
+        "plan_id": plan_id,
+        "wave_id": wave_id,
+        "name": name,
+    });
+    let wave_resp = crate::cli_http::post_and_return(
+        &format!("{api_url}/api/plan-db/wave/create"),
+        &create_body,
+    )
+    .await
+    .map_err(|code| CliError::ApiCallFailed(format!("wave create failed (exit {code})")))?;
+
+    // Provision workspace using the wave_db_id returned by the create endpoint.
+    if let Some(wave_db_id) = wave_resp.get("wave_db_id").and_then(|v| v.as_i64()) {
+        let ws_body = serde_json::json!({
+            "plan_id": plan_id,
+            "wave_db_id": wave_db_id,
+        });
+        match crate::cli_http::post_and_return(&format!("{api_url}/api/workspace/create"), &ws_body)
+            .await
+        {
+            Ok(ws_resp) => {
+                let combined = serde_json::json!({
+                    "ok": true,
+                    "wave": wave_resp,
+                    "workspace": ws_resp.get("workspace"),
+                });
+                crate::cli_http::print_value(&combined, human);
+            }
+            Err(code) => {
+                eprintln!("warning: wave created but workspace provisioning failed (exit {code})");
+                crate::cli_http::print_value(&wave_resp, human);
+            }
+        }
+    } else {
+        crate::cli_http::print_value(&wave_resp, human);
+    }
+    Ok(())
+}
+
+/// Trigger the workspace release pipeline instead of the legacy wave/merge endpoint.
+pub async fn handle_merge(
+    plan_id: i64,
+    wave_id: i64,
+    human: bool,
+    api_url: String,
+) -> Result<(), CliError> {
+    let workspace_id = find_workspace_id(&api_url, plan_id, wave_id)
+        .await
+        .ok_or_else(|| {
+            CliError::NotFound(format!(
+                "no active workspace found for wave {wave_id} in plan {plan_id}"
+            ))
+        })?;
+    let release_body = serde_json::json!({"workspace_id": workspace_id});
+    crate::cli_http::post_and_print(
+        &format!("{api_url}/api/workspace/release"),
+        &release_body,
+        human,
+    )
+    .await
+}
+
+/// Run mechanical quality gates first; only call Thor if all gates pass.
+pub async fn handle_validate(
+    wave_id: i64,
+    plan_id: i64,
+    human: bool,
+    api_url: String,
+) -> Result<(), CliError> {
+    let workspace_id = find_workspace_id(&api_url, plan_id, wave_id).await;
+    if let Some(ws_id) = workspace_id {
+        let qg_body = serde_json::json!({"workspace_id": ws_id});
+        match crate::cli_http::post_and_return(
+            &format!("{api_url}/api/workspace/quality-gate"),
+            &qg_body,
+        )
+        .await
+        {
+            Ok(qg_resp) => {
+                let all_passed = qg_resp
+                    .get("all_passed")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if !all_passed {
+                    crate::cli_http::print_value(&qg_resp, human);
+                    return Err(CliError::NotFound(
+                        "quality gates failed — Thor validation blocked".into(),
+                    ));
+                }
+            }
+            Err(code) => {
+                eprintln!("quality gate check failed (exit {code}); proceeding to Thor anyway");
+            }
+        }
+    } else {
+        eprintln!("no workspace found for wave {wave_id}; skipping quality gates");
+    }
+    let thor_body = serde_json::json!({"wave_id": wave_id, "scope": "wave"});
+    crate::cli_http::post_and_print(
+        &format!("{api_url}/api/plans/{plan_id}/validate"),
+        &thor_body,
+        human,
+    )
+    .await
+}
+
+/// Release alias — convenience wrapper around the workspace release pipeline.
+pub async fn handle_release(
+    wave_id: i64,
+    plan_id: i64,
+    repo: String,
+    human: bool,
+    api_url: String,
+) -> Result<(), CliError> {
+    let workspace_id = find_workspace_id(&api_url, plan_id, wave_id)
+        .await
+        .ok_or_else(|| {
+            CliError::NotFound(format!(
+                "no active workspace found for wave {wave_id} in plan {plan_id}"
+            ))
+        })?;
+    let release_body = serde_json::json!({"workspace_id": workspace_id, "repo": repo});
+    crate::cli_http::post_and_print(
+        &format!("{api_url}/api/workspace/release"),
+        &release_body,
+        human,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn quality_gate_body_shape() {
+        let body = serde_json::json!({"workspace_id": "ws-abc-0001"});
+        assert_eq!(body["workspace_id"], "ws-abc-0001");
+    }
+
+    #[test]
+    fn release_body_shape() {
+        let body = serde_json::json!({"workspace_id": "ws-xyz-0042", "repo": "org/repo"});
+        assert_eq!(body["workspace_id"], "ws-xyz-0042");
+        assert_eq!(body["repo"], "org/repo");
+    }
+
+    #[test]
+    fn workspace_list_filter_finds_active_wave() {
+        let list = serde_json::json!({
+            "workspaces": [
+                {"workspace_id": "ws-old", "wave_db_id": 5, "status": "merged"},
+                {"workspace_id": "ws-active", "wave_db_id": 5, "status": "active"},
+                {"workspace_id": "ws-other", "wave_db_id": 9, "status": "active"},
+            ]
+        });
+        let wave_id: i64 = 5;
+        let found = list
+            .get("workspaces")
+            .and_then(|ws| ws.as_array())
+            .and_then(|arr| {
+                arr.iter().find(|w| {
+                    w.get("wave_db_id")
+                        .and_then(|v| v.as_i64())
+                        .map_or(false, |id| id == wave_id)
+                        && w.get("status")
+                            .and_then(|v| v.as_str())
+                            .map_or(true, |s| s == "active")
+                })
+            })
+            .and_then(|w| w.get("workspace_id"))
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        assert_eq!(found, Some("ws-active".to_string()));
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_who.rs
+++ b/daemon/crates/convergio-cli/src/cli_who.rs
@@ -1,0 +1,179 @@
+// cvg who — show active agents, delegations, and what's being worked on.
+// Why: Plan 706 — no way to know who's working on what. This is the answer.
+
+use crate::cli_error::CliError;
+use crate::cli_http;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum WhoCommands {
+    /// Show all active agents across all nodes
+    Agents,
+    /// Show who is working on a specific plan
+    Plan { plan_id: i64 },
+    /// Prune stale/zombie workers
+    Prune,
+}
+
+fn api_err(code: i32) -> CliError {
+    CliError::ApiCallFailed(format!("daemon returned error (code {code})"))
+}
+
+pub async fn handle(cmd: WhoCommands, api_url: &str) -> Result<(), CliError> {
+    match cmd {
+        WhoCommands::Agents => {
+            let url = format!("{api_url}/api/workers");
+            let body = cli_http::get_and_return(&url).await.map_err(api_err)?;
+            let workers = body.get("workers").and_then(|w| w.as_array());
+            match workers {
+                Some(list) if !list.is_empty() => {
+                    println!(
+                        "{:<30} {:<15} {:<10} {:<8} DESCRIPTION",
+                        "AGENT", "HOST", "MODEL", "PLAN"
+                    );
+                    println!("{}", "-".repeat(90));
+                    for w in list {
+                        let agent = w["agent_id"].as_str().unwrap_or("?");
+                        let host = w["host"].as_str().unwrap_or("?");
+                        let model = w["model"].as_str().unwrap_or("?");
+                        let plan = w["plan_id"]
+                            .as_i64()
+                            .map(|v| v.to_string())
+                            .unwrap_or("-".into());
+                        let desc = w["description"].as_str().unwrap_or("");
+                        println!(
+                            "{:<30} {:<15} {:<10} {:<8} {}",
+                            agent,
+                            host,
+                            model,
+                            plan,
+                            &desc[..desc.len().min(40)]
+                        );
+                    }
+                }
+                _ => println!("No active workers."),
+            }
+            // IPC agent tree (parentage hierarchy)
+            let tree_url = format!("{api_url}/api/ipc/agents/tree");
+            if let Ok(tb) = cli_http::get_and_return(&tree_url).await {
+                if let Some(tree) = tb["tree"].as_array() {
+                    if !tree.is_empty() {
+                        println!("\nIPC Agent Tree ({} registered):", tb["total"].as_i64().unwrap_or(0));
+                        for node in tree {
+                            print_tree_node(node, 0);
+                        }
+                    }
+                }
+            }
+            // Online peers
+            let peers_url = format!("{api_url}/api/heartbeat/status");
+            if let Ok(pb) = cli_http::get_and_return(&peers_url).await {
+                if let Some(peers) = pb["peers"].as_array() {
+                    let online: Vec<_> = peers
+                        .iter()
+                        .filter(|p| p["age_secs"].as_i64().map(|a| a < 300).unwrap_or(false))
+                        .collect();
+                    if !online.is_empty() {
+                        println!("\nOnline peers ({}):", online.len());
+                        for p in &online {
+                            println!(
+                                "  {} ({}s ago)",
+                                p["peer_name"].as_str().unwrap_or("?"),
+                                p["age_secs"].as_i64().unwrap_or(0)
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        WhoCommands::Plan { plan_id } => {
+            // Workers on this plan
+            let url = format!("{api_url}/api/workers");
+            let body = cli_http::get_and_return(&url).await.map_err(api_err)?;
+            if let Some(list) = body["workers"].as_array() {
+                let active: Vec<_> = list
+                    .iter()
+                    .filter(|w| w["plan_id"].as_i64() == Some(plan_id))
+                    .collect();
+                if active.is_empty() {
+                    println!("No active workers on plan {plan_id}.");
+                } else {
+                    println!("Workers on plan {plan_id}:");
+                    for w in &active {
+                        println!(
+                            "  {} on {} ({})",
+                            w["agent_id"].as_str().unwrap_or("?"),
+                            w["host"].as_str().unwrap_or("?"),
+                            w["model"].as_str().unwrap_or("?")
+                        );
+                    }
+                }
+            }
+            // In-progress tasks
+            let tree_url = format!("{api_url}/api/plan-db/json/{plan_id}");
+            if let Ok(ctx) = cli_http::get_and_return(&tree_url).await {
+                if let Some(tasks) = ctx["tasks"].as_array() {
+                    let active: Vec<_> = tasks
+                        .iter()
+                        .filter(|t| t["status"].as_str() == Some("in_progress"))
+                        .collect();
+                    if !active.is_empty() {
+                        println!("\nTasks in progress:");
+                        for t in &active {
+                            let title = t["title"].as_str().unwrap_or("");
+                            println!(
+                                "  {} [{}]: {}...",
+                                t["task_id"].as_str().unwrap_or("?"),
+                                t["executor_host"].as_str().unwrap_or("local"),
+                                &title[..title.len().min(60)]
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        WhoCommands::Prune => {
+            let url = format!("{api_url}/api/workers");
+            let body = cli_http::get_and_return(&url).await.map_err(api_err)?;
+            if let Some(list) = body["workers"].as_array() {
+                let mut pruned = 0;
+                for w in list {
+                    let agent = w["agent_id"].as_str().unwrap_or("?");
+                    let complete_url = format!("{api_url}/api/plan-db/agent/complete");
+                    let payload = serde_json::json!({"agent_id": agent, "status": "pruned"});
+                    if cli_http::post_and_return(&complete_url, &payload)
+                        .await
+                        .is_ok()
+                    {
+                        pruned += 1;
+                        println!("  pruned: {agent}");
+                    }
+                }
+                println!("Pruned {pruned} stale workers.");
+            }
+            Ok(())
+        }
+    }
+}
+
+fn print_tree_node(node: &serde_json::Value, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let prefix = if depth == 0 { "●" } else { "└──" };
+    let name = node["name"].as_str().unwrap_or("?");
+    let kind = node["type"].as_str().unwrap_or("?");
+    let status = node["status"].as_str().unwrap_or("?");
+    let host = node["host"].as_str().unwrap_or("");
+    let status_icon = match status {
+        "active" => "✓",
+        "inactive" => "✗",
+        _ => "?",
+    };
+    println!("  {indent}{prefix} {name} [{kind}] {status_icon} {host}");
+    if let Some(children) = node["children"].as_array() {
+        for child in children {
+            print_tree_node(child, depth + 1);
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_workspace.rs
+++ b/daemon/crates/convergio-cli/src/cli_workspace.rs
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Workspace subcommands for the cvg CLI — delegates to daemon HTTP API via reqwest.
+// JSON output by default; --human flag for readable text.
+
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum WorkspaceCommands {
+    /// Create a plan/wave workspace
+    Create {
+        /// Plan ID
+        #[arg(long)]
+        plan: Option<i64>,
+        /// Wave DB ID
+        #[arg(long)]
+        wave: Option<i64>,
+        /// Human-readable output
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Create a feature branch workspace
+    CreateFeature {
+        /// Branch name
+        branch: String,
+        /// Human-readable output
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Delete a workspace
+    Delete {
+        /// Workspace ID
+        workspace_id: String,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List workspaces
+    List {
+        /// Filter by plan ID
+        #[arg(long)]
+        plan: Option<i64>,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show workspace status
+    Status {
+        /// Workspace ID
+        workspace_id: String,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Show workspace events
+    Events {
+        /// Workspace ID
+        workspace_id: String,
+        /// Max events to return
+        #[arg(long, default_value = "20")]
+        limit: i64,
+        #[arg(long)]
+        human: bool,
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: WorkspaceCommands) {
+    match cmd {
+        WorkspaceCommands::Create {
+            plan,
+            wave,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({"plan_id": plan, "wave_db_id": wave});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/workspace/create"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        WorkspaceCommands::CreateFeature {
+            branch,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({"feature": true, "branch": branch});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/workspace/create"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        WorkspaceCommands::Delete {
+            workspace_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({"workspace_id": workspace_id});
+            if let Err(e) = crate::cli_http::post_and_print(
+                &format!("{api_url}/api/workspace/delete"),
+                &body,
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        WorkspaceCommands::List {
+            plan,
+            human,
+            api_url,
+        } => {
+            let url = if let Some(pid) = plan {
+                format!("{api_url}/api/workspace/list?plan_id={pid}")
+            } else {
+                format!("{api_url}/api/workspace/list")
+            };
+            if let Err(e) = crate::cli_http::fetch_and_print(&url, human).await {
+                eprintln!("error: {e}");
+            }
+        }
+        WorkspaceCommands::Status {
+            workspace_id,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!("{api_url}/api/workspace/status/{workspace_id}"),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+        WorkspaceCommands::Events {
+            workspace_id,
+            limit,
+            human,
+            api_url,
+        } => {
+            if let Err(e) = crate::cli_http::fetch_and_print(
+                &format!(
+                    "{api_url}/api/workspace/events?workspace_id={workspace_id}&limit={limit}"
+                ),
+                human,
+            )
+            .await
+            {
+                eprintln!("error: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cli_workspace_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-cli/src/cli_workspace_tests.rs
+++ b/daemon/crates/convergio-cli/src/cli_workspace_tests.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Tests for cli_workspace module — extracted from cli_workspace.rs (Plan F, T4-04).
+
+use super::*;
+
+#[test]
+fn workspace_create_with_plan_and_wave() {
+    let cmd = WorkspaceCommands::Create {
+        plan: Some(698),
+        wave: Some(100),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(
+        cmd,
+        WorkspaceCommands::Create {
+            plan: Some(698),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn workspace_create_feature_variant() {
+    let cmd = WorkspaceCommands::CreateFeature {
+        branch: "feat/new-thing".to_string(),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, WorkspaceCommands::CreateFeature { .. }));
+}
+
+#[test]
+fn workspace_delete_variant() {
+    let cmd = WorkspaceCommands::Delete {
+        workspace_id: "ws-12345-abcd".to_string(),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, WorkspaceCommands::Delete { .. }));
+}
+
+#[test]
+fn workspace_list_filtered_by_plan() {
+    let cmd = WorkspaceCommands::List {
+        plan: Some(698),
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(
+        cmd,
+        WorkspaceCommands::List {
+            plan: Some(698),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn workspace_status_variant() {
+    let cmd = WorkspaceCommands::Status {
+        workspace_id: "ws-abc123".to_string(),
+        human: true,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, WorkspaceCommands::Status { .. }));
+}
+
+#[test]
+fn workspace_events_variant() {
+    let cmd = WorkspaceCommands::Events {
+        workspace_id: "ws-abc123".to_string(),
+        limit: 50,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    assert!(matches!(cmd, WorkspaceCommands::Events { limit: 50, .. }));
+}
+
+#[test]
+fn workspace_create_body_shape() {
+    let body = serde_json::json!({"plan_id": 698_i64, "wave_db_id": 100_i64});
+    assert_eq!(body["plan_id"], 698);
+    assert_eq!(body["wave_db_id"], 100);
+}
+
+#[test]
+fn workspace_create_feature_body_shape() {
+    let body = serde_json::json!({"feature": true, "branch": "feat/my-feature"});
+    assert_eq!(body["feature"], true);
+    assert_eq!(body["branch"], "feat/my-feature");
+}
+
+#[test]
+fn workspace_delete_body_shape() {
+    let body = serde_json::json!({"workspace_id": "ws-12345-abcd"});
+    assert_eq!(body["workspace_id"], "ws-12345-abcd");
+}
+
+#[test]
+fn workspace_events_default_limit_is_20() {
+    // Clap default_value = "20"; verify enum carries it through.
+    let cmd = WorkspaceCommands::Events {
+        workspace_id: "ws-test".to_string(),
+        limit: 20,
+        human: false,
+        api_url: "http://localhost:8420".to_string(),
+    };
+    if let WorkspaceCommands::Events { limit, .. } = cmd {
+        assert_eq!(limit, 20);
+    }
+}

--- a/daemon/crates/convergio-cli/src/dispatch.rs
+++ b/daemon/crates/convergio-cli/src/dispatch.rs
@@ -1,0 +1,193 @@
+// Command dispatch — routes parsed CLI commands to handlers.
+// Pure HTTP client: no daemon internals.
+
+use crate::cli_commands::Commands;
+use crate::cli_error::CliError;
+use crate::{
+    cli_agent_format, cli_ask, cli_audit, cli_audit_project, cli_bus, cli_capability,
+    cli_channel, cli_chat, cli_checkpoint, cli_delegation, cli_domain, cli_kb, cli_kernel,
+    cli_launch, cli_lock, cli_memory, cli_ops, cli_org, cli_plan, cli_project, cli_reap,
+    cli_repo, cli_review, cli_run, cli_setup, cli_skill, cli_status, cli_task, cli_voice,
+    cli_wave, cli_who, cli_workspace,
+};
+use std::process::ExitCode;
+
+pub async fn dispatch(command: Commands) -> ExitCode {
+    match command {
+        Commands::Setup { defaults } => {
+            exit_on_err(cli_setup::handle_setup(defaults).await)
+        }
+        Commands::Plan { command } => {
+            exit_on_err(cli_plan::handle(command).await)
+        }
+        Commands::Task { command } => {
+            exit_on_err(cli_task::handle(command).await)
+        }
+        Commands::Wave { command } => {
+            exit_on_err(cli_wave::handle(command).await)
+        }
+        Commands::Agent { command } => {
+            exit_on_err(cli_agent_format::dispatch(command).await)
+        }
+        Commands::Kb { command } => {
+            exit_on_err(cli_kb::handle(command).await)
+        }
+        Commands::Status { api_url } => {
+            exit_on_err(cli_status::handle(&api_url).await)
+        }
+        Commands::Chat { message, api_url } => {
+            exit_on_err(cli_chat::handle(&api_url, message).await)
+        }
+        Commands::Channel { command } => {
+            exit_on_err(cli_channel::handle(command).await)
+        }
+        Commands::Capability { command } => {
+            exit_on_err(cli_capability::handle(command).await)
+        }
+        Commands::Voice { command } => {
+            exit_on_err(cli_voice::handle(command).await)
+        }
+        Commands::Memory { command } => {
+            exit_on_err(cli_memory::handle(command).await)
+        }
+        Commands::Run { command } => {
+            exit_on_err(cli_run::handle(command).await)
+        }
+        Commands::Mesh { command } => {
+            cli_ops::handle_mesh(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Session { command } => {
+            cli_ops::handle_session(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Checkpoint { command } => {
+            cli_checkpoint::handle(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Lock { command } => {
+            cli_lock::handle(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Review { command } => {
+            cli_review::handle(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Audit {
+            path,
+            project,
+            output,
+            yes,
+            api_url,
+        } => {
+            if let Some(project_id) = project {
+                exit_on_err(
+                    cli_audit_project::handle(&project_id, output, yes, &api_url).await,
+                )
+            } else {
+                exit_on_err(cli_audit::handle(path))
+            }
+        }
+        Commands::Skill { command } => {
+            exit_on_err(cli_skill::handle(command).await)
+        }
+        Commands::Bus { command } => {
+            cli_bus::handle(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Project { command } => {
+            exit_on_err(cli_project::handle(command).await)
+        }
+        Commands::Metrics { command } => {
+            cli_ops::handle_metrics(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Alert { command } => {
+            cli_ops::handle_alert(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Domain { command } => {
+            exit_on_err(cli_domain::dispatch(command).await)
+        }
+        Commands::Org { command } => {
+            exit_on_err(cli_org::handle(command).await)
+        }
+        Commands::Workspace { command } => {
+            cli_workspace::handle(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Who { command } => {
+            exit_on_err(
+                cli_who::handle(command, "http://localhost:8420").await,
+            )
+        }
+        Commands::Delegation { command } => {
+            exit_on_err(
+                cli_delegation::handle(command, "http://localhost:8420").await,
+            )
+        }
+        Commands::Reap { command } => {
+            cli_reap::handle(command).await;
+            ExitCode::SUCCESS
+        }
+        Commands::Repo { command } => {
+            exit_on_err(cli_repo::handle(command).await)
+        }
+        Commands::Kernel { command } => cli_kernel::dispatch(command).await,
+        Commands::Cheatsheet => {
+            crate::cli_cheatsheet::print_cheatsheet();
+            ExitCode::SUCCESS
+        }
+        Commands::Api => {
+            crate::cli_api_list::print_api_list();
+            ExitCode::SUCCESS
+        }
+        Commands::Cleanup => {
+            exit_on_err(crate::cli_cleanup::handle().await)
+        }
+        Commands::Claude {
+            name,
+            parent,
+            api_url,
+        } => exit_on_err(
+            cli_launch::handle(cli_launch::LaunchCommands::Claude {
+                name,
+                parent,
+                api_url,
+            })
+            .await,
+        ),
+        Commands::Copilot {
+            name,
+            parent,
+            api_url,
+        } => exit_on_err(
+            cli_launch::handle(cli_launch::LaunchCommands::Copilot {
+                name,
+                parent,
+                api_url,
+            })
+            .await,
+        ),
+        Commands::Ask {
+            alias,
+            message,
+            list,
+            set,
+            agent,
+            api_url,
+        } => exit_on_err(
+            cli_ask::handle(alias, message, list, set, agent, &api_url).await,
+        ),
+    }
+}
+
+fn exit_on_err(result: Result<(), CliError>) -> ExitCode {
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("{e}");
+            ExitCode::from(e.exit_code() as u8)
+        }
+    }
+}

--- a/daemon/crates/convergio-cli/src/lib.rs
+++ b/daemon/crates/convergio-cli/src/lib.rs
@@ -1,3 +1,74 @@
 //! convergio-cli — cvg CLI, pure HTTP client.
 //!
 //! Zero internal imports. Talks to the daemon exclusively via HTTP API.
+
+// Core infrastructure
+pub mod cli_error;
+pub mod cli_http;
+pub mod message_error;
+pub mod paths;
+pub mod transpiler;
+
+// Command enum + dispatch
+pub mod cli_commands;
+pub mod dispatch;
+
+// Command modules — each defines subcommand enums + handlers
+pub mod cli_agent;
+pub mod cli_agent_format;
+pub mod cli_agent_history;
+mod cli_agents;
+pub mod cli_api_list;
+pub mod cli_ask;
+pub mod cli_audit;
+pub mod cli_audit_project;
+pub mod cli_bus;
+pub mod cli_bus_ask;
+pub mod cli_bus_org;
+pub mod cli_bus_watch;
+pub mod cli_capability;
+pub mod cli_channel;
+pub mod cli_chat;
+pub mod cli_cheatsheet;
+pub mod cli_checkpoint;
+pub mod cli_cleanup;
+pub mod cli_create_org;
+pub mod cli_delegation;
+pub mod cli_domain;
+pub mod cli_kb;
+pub mod cli_kernel;
+pub mod cli_launch;
+pub mod cli_lock;
+pub mod cli_memory;
+pub mod cli_mesh_join;
+pub mod cli_ops;
+pub mod cli_org;
+pub mod cli_org_show;
+pub mod cli_plan;
+pub mod cli_plan_handlers;
+pub mod cli_plan_show;
+pub mod cli_plan_template;
+pub mod cli_plan_tree_fmt;
+pub mod cli_project;
+pub mod cli_project_tree;
+pub mod cli_reap;
+pub mod cli_repo;
+pub mod cli_review;
+pub mod cli_run;
+pub mod cli_setup;
+pub mod cli_setup_steps;
+pub mod cli_skill;
+pub mod cli_skill_disable;
+pub mod cli_skill_enable;
+pub mod cli_skill_transpile;
+pub mod cli_skill_validate;
+pub mod cli_skill_validators;
+pub mod cli_status;
+pub mod cli_task;
+pub mod cli_task_approve;
+pub mod cli_task_format;
+pub mod cli_voice;
+pub mod cli_wave;
+pub mod cli_wave_handlers;
+pub mod cli_who;
+pub mod cli_workspace;

--- a/daemon/crates/convergio-cli/src/main.rs
+++ b/daemon/crates/convergio-cli/src/main.rs
@@ -1,3 +1,71 @@
-fn main() {
-    println!("cvg CLI — not yet implemented");
+use clap::Parser;
+use convergio_cli::cli_commands::Commands;
+use std::env;
+use std::process::ExitCode;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "cvg",
+    version,
+    about = "Convergio Platform CLI — orchestrate agents, plans, and infrastructure",
+    long_about = "Convergio Platform CLI — pure HTTP client.\n\n\
+        Quick start:\n  cvg status              # Platform overview\n  \
+        cvg plan list             # List execution plans\n  \
+        cvg who agents            # See active agents\n  \
+        cvg org list              # List organizations\n  \
+        cvg cheatsheet            # Full command reference"
+)]
+struct Cli {
+    #[arg(long, default_value_t = false)]
+    version_json: bool,
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    // Load ~/.convergio/env for auth tokens
+    let env_path = convergio_cli::paths::convergio_dir().join("env");
+    if let Ok(contents) = std::fs::read_to_string(&env_path) {
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((k, v)) = line.split_once('=') {
+                if env::var(k.trim()).is_err() {
+                    env::set_var(k.trim(), v.trim());
+                }
+            }
+        }
+    }
+
+    let cli = Cli::parse();
+
+    if cli.version_json {
+        let payload = serde_json::json!({
+            "binary": "cvg",
+            "version": env!("CARGO_PKG_VERSION")
+        });
+        println!("{payload}");
+        return ExitCode::SUCCESS;
+    }
+
+    // First-run hint
+    if let Some(ref command) = cli.command {
+        if !matches!(command, Commands::Setup { .. })
+            && !convergio_cli::paths::config_path().exists()
+        {
+            eprintln!(
+                "hint: First time? Run `cvg setup` to configure Convergio."
+            );
+        }
+    }
+
+    if let Some(command) = cli.command {
+        return convergio_cli::dispatch::dispatch(command).await;
+    }
+
+    println!("cvg — Convergio Platform CLI. Use --help for commands.");
+    ExitCode::SUCCESS
 }

--- a/daemon/crates/convergio-cli/src/message_error.rs
+++ b/daemon/crates/convergio-cli/src/message_error.rs
@@ -1,0 +1,36 @@
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{0}")]
+pub struct MessageError(pub String);
+
+pub type MessageResult<T> = Result<T, MessageError>;
+
+impl From<String> for MessageError {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for MessageError {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+macro_rules! impl_message_error_from {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl From<$ty> for MessageError {
+                fn from(value: $ty) -> Self {
+                    Self(value.to_string())
+                }
+            }
+        )*
+    };
+}
+
+impl_message_error_from!(
+    std::io::Error,
+    std::net::AddrParseError,
+    reqwest::Error,
+    serde_json::Error,
+);

--- a/daemon/crates/convergio-cli/src/paths.rs
+++ b/daemon/crates/convergio-cli/src/paths.rs
@@ -1,0 +1,39 @@
+// Local path helpers — replaces convergio_core::platform_paths and config.
+// CLI is a pure HTTP client; these are the only local filesystem paths it needs.
+
+use std::path::PathBuf;
+
+/// Root directory for Convergio local data: ~/.convergio
+pub fn convergio_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".convergio")
+}
+
+/// Path to the main config file: ~/.convergio/config.toml
+pub fn config_path() -> PathBuf {
+    convergio_dir().join("config.toml")
+}
+
+/// Output directory for a project: ~/.convergio/projects/{name}/output
+pub fn project_output_dir(name: &str) -> PathBuf {
+    convergio_dir().join("projects").join(name).join("output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_path_ends_with_config_toml() {
+        let p = config_path();
+        assert!(p.ends_with("config.toml"));
+    }
+
+    #[test]
+    fn project_output_dir_contains_project_name() {
+        let p = project_output_dir("acme");
+        assert!(p.to_string_lossy().contains("acme"));
+        assert!(p.ends_with("output"));
+    }
+}

--- a/daemon/crates/convergio-cli/src/transpiler.rs
+++ b/daemon/crates/convergio-cli/src/transpiler.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Roberto D'Angelo. All rights reserved.
+// Multi-provider agent transpiler: one agent record in DB -> N provider format files.
+// Distinct from cli_skill_transpile which operates on skill.yaml + SKILL.md directories.
+
+/// Generate Claude Code .agent.md format with YAML frontmatter.
+pub fn transpile_claude_code(name: &str, description: &str, model: &str, tools: &str) -> String {
+    let mut out = String::new();
+    out.push_str("---\n");
+    out.push_str(&format!("name: {name}\n"));
+    out.push_str(&format!("description: \"{description}\"\n"));
+    out.push_str(&format!("model: {model}\n"));
+    out.push_str("tools:\n");
+    for tool in tools.split(',') {
+        let tool = tool.trim();
+        if !tool.is_empty() {
+            out.push_str(&format!("  - {tool}\n"));
+        }
+    }
+    out.push_str("---\n\n");
+    out.push_str(&format!("# {name}\n\n"));
+    out.push_str(description);
+    out.push('\n');
+    out
+}
+
+/// Generate GitHub Copilot CLI format (no YAML frontmatter).
+pub fn transpile_copilot_cli(name: &str, description: &str, model: &str, tools: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# {name}\n\n"));
+    out.push_str(&format!("**Model**: {model}\n"));
+    out.push_str(&format!("**Tools**: {tools}\n\n"));
+    out.push_str(description);
+    out.push('\n');
+    out
+}
+
+/// Generate plain system prompt for generic LLM providers.
+pub fn transpile_generic_llm(name: &str, description: &str, model: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("You are {name}. {description}\n\n"));
+    out.push_str(&format!("Model: {model}\n"));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_claude_code_has_yaml_frontmatter() {
+        let result = transpile_claude_code(
+            "code-reviewer",
+            "Reviews pull requests for quality",
+            "claude-sonnet-4-6",
+            "view,edit,bash",
+        );
+        assert!(
+            result.starts_with("---\n"),
+            "must start with YAML frontmatter delimiter"
+        );
+        // Frontmatter must close before body
+        let second_delimiter = result[4..].find("---\n");
+        assert!(
+            second_delimiter.is_some(),
+            "must have closing frontmatter delimiter"
+        );
+        assert!(result.contains("name: code-reviewer"));
+        assert!(result.contains("model: claude-sonnet-4-6"));
+        assert!(result.contains("description: \"Reviews pull requests for quality\""));
+    }
+
+    #[test]
+    fn test_claude_code_has_tools() {
+        let result = transpile_claude_code(
+            "debugger",
+            "Debugging agent",
+            "claude-opus-4-6",
+            "view,edit,bash,grep",
+        );
+        assert!(result.contains("  - view\n"), "must list view tool");
+        assert!(result.contains("  - edit\n"), "must list edit tool");
+        assert!(result.contains("  - bash\n"), "must list bash tool");
+        assert!(result.contains("  - grep\n"), "must list grep tool");
+    }
+
+    #[test]
+    fn test_copilot_cli_no_frontmatter() {
+        let result =
+            transpile_copilot_cli("planner", "Creates execution plans", "gpt-4o", "view,bash");
+        assert!(
+            !result.starts_with("---"),
+            "copilot CLI format must NOT have YAML frontmatter"
+        );
+        assert!(result.starts_with("# planner\n"));
+        assert!(result.contains("**Model**: gpt-4o"));
+        assert!(result.contains("**Tools**: view,bash"));
+        assert!(result.contains("Creates execution plans"));
+    }
+
+    #[test]
+    fn test_generic_llm_system_prompt() {
+        let result = transpile_generic_llm(
+            "architect",
+            "Designs system architecture",
+            "claude-opus-4-6",
+        );
+        assert!(result.starts_with("You are architect."));
+        assert!(result.contains("Designs system architecture"));
+        assert!(result.contains("Model: claude-opus-4-6"));
+        // Must NOT have frontmatter or markdown headers
+        assert!(!result.contains("---"));
+        assert!(!result.contains("# "));
+    }
+}


### PR DESCRIPTION
## Summary
- 75 modules migrated from ConvergioPlatform, adapted as pure HTTP client
- Zero internal imports — talks to daemon exclusively via HTTP API
- Server-side commands excluded (Serve, Db, Hook, Daemon, Ipc, Tui)
- 5 files adapted to remove daemon dependencies (cli_setup, cli_project, cli_audit_project → crate::paths, cli_reap/cli_create_org → HTTP API)
- 209 tests passing, cargo check clean

## Test plan
- [x] `cargo check -p convergio-cli` — 0 errors
- [x] `cargo test -p convergio-cli` — 209 passed
- [x] `cargo test --workspace` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)