### PR TITLE
feat: fase 9 — convergio-server (routing shell)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,7 +182,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -196,6 +214,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -324,6 +348,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +376,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convergio-agents"
@@ -502,13 +549,24 @@ name = "convergio-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
+ "constant_time_eq",
  "convergio-db",
+ "convergio-security",
  "convergio-telemetry",
  "convergio-types",
+ "notify",
+ "r2d2",
+ "r2d2_sqlite",
+ "rusqlite",
  "serde",
  "serde_json",
  "tokio",
+ "toml",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -569,6 +627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -729,10 +796,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -747,6 +835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1178,6 +1275,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1335,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,7 +1378,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1316,6 +1456,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1486,25 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1386,7 +1567,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1408,6 +1589,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1632,7 +1819,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1705,8 +1901,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
- "tower-http",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1736,7 +1932,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1756,7 +1952,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1809,6 +2005,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scheduled-thread-pool"
@@ -1971,6 +2176,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2169,7 +2380,7 @@ checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2266,6 +2477,19 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -2282,18 +2506,38 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "async-compression",
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -2518,6 +2762,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,7 +2900,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2679,6 +2933,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3038,7 +3301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/daemon/crates/convergio-server/Cargo.toml
+++ b/daemon/crates/convergio-server/Cargo.toml
@@ -9,8 +9,22 @@ license.workspace = true
 convergio-types = { path = "../convergio-types" }
 convergio-db = { path = "../convergio-db" }
 convergio-telemetry = { path = "../convergio-telemetry" }
+convergio-security = { path = "../convergio-security" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+r2d2 = { workspace = true }
+r2d2_sqlite = { workspace = true }
+rusqlite = { workspace = true }
+toml = "0.8"
+notify = "6"
+tower-http = { version = "0.5", features = ["cors", "compression-gzip", "timeout", "limit"] }
+tower = { version = "0.4", features = ["timeout"] }
+constant_time_eq = "0.3"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/daemon/crates/convergio-server/src/config.rs
+++ b/daemon/crates/convergio-server/src/config.rs
@@ -1,0 +1,92 @@
+//! Config loading from ~/.convergio/config.toml.
+//!
+//! Types live in convergio-types. This module handles I/O:
+//! reading, parsing, writing defaults.
+
+use convergio_types::config::ConvergioConfig;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Path to the config file. Overridable via `CONVERGIO_CONFIG` env var.
+pub fn config_path() -> PathBuf {
+    if let Ok(p) = std::env::var("CONVERGIO_CONFIG") {
+        if !p.is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    dirs_path().join("config.toml")
+}
+
+fn dirs_path() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(".convergio")
+}
+
+/// Load config from disk. Falls back to defaults when the file is missing
+/// or empty. Logs a warning on parse errors and returns defaults.
+pub fn load_config() -> ConvergioConfig {
+    let path = config_path();
+    match std::fs::read_to_string(&path) {
+        Ok(contents) if !contents.trim().is_empty() => {
+            match toml::from_str::<ConvergioConfig>(&contents) {
+                Ok(cfg) => {
+                    tracing::info!("[config] Loaded from {}", path.display());
+                    cfg
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "[config] Parse error in {}: {e} — using defaults",
+                        path.display()
+                    );
+                    ConvergioConfig::default()
+                }
+            }
+        }
+        Ok(_) => {
+            tracing::info!("[config] {} is empty, using defaults", path.display());
+            ConvergioConfig::default()
+        }
+        Err(_) => {
+            tracing::info!("[config] No config.toml found, using defaults");
+            ConvergioConfig::default()
+        }
+    }
+}
+
+/// Write a well-commented default config template to the given path.
+pub fn write_default_config(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, super::config_defaults::DEFAULT_CONFIG_TEMPLATE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn load_from_custom_path() {
+        let dir = std::env::temp_dir().join("cvg-cfg-test");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "[daemon]\nport = 9999").unwrap();
+        std::env::set_var("CONVERGIO_CONFIG", path.to_str().unwrap());
+        let cfg = load_config();
+        assert_eq!(cfg.daemon.port, 9999);
+        std::env::remove_var("CONVERGIO_CONFIG");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_file_returns_defaults() {
+        std::env::set_var("CONVERGIO_CONFIG", "/tmp/nonexistent.toml");
+        let cfg = load_config();
+        assert_eq!(cfg.daemon.port, 8420);
+        std::env::remove_var("CONVERGIO_CONFIG");
+    }
+}

--- a/daemon/crates/convergio-server/src/config_defaults.rs
+++ b/daemon/crates/convergio-server/src/config_defaults.rs
@@ -1,0 +1,50 @@
+//! Default config.toml template — the first thing users see.
+
+/// Commented TOML template written by `write_default_config`.
+/// Every field shows its default so users know what to tweak.
+pub const DEFAULT_CONFIG_TEMPLATE: &str = r#"# Convergio Daemon Configuration
+# Docs: https://github.com/Roberdan/convergio
+#
+# All values below are defaults. Uncomment and edit to customize.
+# An empty file is valid — every field has a sensible default.
+
+[node]
+# name = "my-machine"          # auto-detected from hostname if omitted
+role = "standalone"             # standalone | coordinator | worker
+
+[daemon]
+port = 8420
+auto_update = true
+# quiet_hours = "23:00-07:00"  # suppresses non-critical notifications
+# timezone = "Europe/Rome"     # IANA timezone for quiet_hours
+
+[mesh]
+transport = "lan"               # lan | tailscale | manual
+discovery = "mdns"              # mdns | static | tailscale
+# peers = ["192.168.1.10:8420"] # explicit peer addresses (static mode)
+
+# [mesh.tailscale]
+# enabled = false
+# auth_key = ""                 # or set TAILSCALE_AUTH_KEY env var
+
+[inference]
+default_model = "claude-sonnet-4-6"
+api_key_env = "ANTHROPIC_API_KEY"  # env var name holding the API key
+
+[inference.fallback]
+max_attempts = 3
+t1 = ["local", "haiku", "sonnet"]
+t2 = ["haiku", "local", "sonnet"]
+t3 = ["sonnet", "opus"]
+t4 = ["opus", "sonnet"]
+
+[kernel]
+model = "none"                  # "none" disables local kernel
+# model_path = ""               # path to local model weights
+# escalation_model = ""         # model used when kernel escalates
+max_tokens = 2048
+
+[telegram]
+enabled = false
+# token_keychain = ""           # macOS Keychain item name for bot token
+"#;

--- a/daemon/crates/convergio-server/src/config_validation.rs
+++ b/daemon/crates/convergio-server/src/config_validation.rs
@@ -1,0 +1,139 @@
+//! Config validation — helpful messages that tell users what to fix.
+
+use convergio_types::config::ConvergioConfig;
+
+const KNOWN_ROLES: &[&str] = &["standalone", "coordinator", "worker"];
+const KNOWN_TRANSPORTS: &[&str] = &["lan", "tailscale", "manual"];
+const KNOWN_DISCOVERY: &[&str] = &["mdns", "static", "tailscale"];
+
+/// Validate a loaded config and return human-readable warnings.
+/// An empty Vec means everything looks good.
+pub fn validate(config: &ConvergioConfig) -> Vec<String> {
+    let mut issues: Vec<String> = Vec::new();
+
+    if !KNOWN_ROLES.contains(&config.node.role.as_str()) {
+        issues.push(format!(
+            "[node] role '{}' is not recognized. Expected: {}",
+            config.node.role,
+            KNOWN_ROLES.join(", ")
+        ));
+    }
+    if config.daemon.port < 1024 {
+        issues.push(format!(
+            "[daemon] port {} is below 1024. Use 1024-65535.",
+            config.daemon.port
+        ));
+    }
+    if let Some(ref tz) = config.daemon.timezone {
+        if !looks_like_iana_tz(tz) {
+            issues.push(format!(
+                "[daemon] timezone '{tz}' doesn't look like IANA (expected Area/City)."
+            ));
+        }
+    }
+    if let Some(ref qh) = config.daemon.quiet_hours {
+        if !looks_like_time_range(qh) {
+            issues.push(format!(
+                "[daemon] quiet_hours '{qh}' should be HH:MM-HH:MM."
+            ));
+        }
+    }
+    if !KNOWN_TRANSPORTS.contains(&config.mesh.transport.as_str()) {
+        issues.push(format!(
+            "[mesh] transport '{}' is not recognized. Expected: {}",
+            config.mesh.transport,
+            KNOWN_TRANSPORTS.join(", ")
+        ));
+    }
+    if !KNOWN_DISCOVERY.contains(&config.mesh.discovery.as_str()) {
+        issues.push(format!(
+            "[mesh] discovery '{}' is not recognized. Expected: {}",
+            config.mesh.discovery,
+            KNOWN_DISCOVERY.join(", ")
+        ));
+    }
+    if config.kernel.max_tokens == 0 {
+        issues.push("[kernel] max_tokens must be > 0.".to_string());
+    }
+    issues
+}
+
+fn looks_like_iana_tz(s: &str) -> bool {
+    s.contains('/') && !s.contains(' ') && s.len() >= 5
+}
+
+fn looks_like_time_range(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    parts.iter().all(|p| {
+        let hm: Vec<&str> = p.split(':').collect();
+        if hm.len() != 2 {
+            return false;
+        }
+        let h = hm[0].parse::<u32>();
+        let m = hm[1].parse::<u32>();
+        matches!((h, m), (Ok(0..=23), Ok(0..=59)))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use convergio_types::config::ConvergioConfig;
+
+    #[test]
+    fn valid_defaults_no_warnings() {
+        assert!(validate(&ConvergioConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn bad_port_caught() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.daemon.port = 80;
+        assert!(validate(&cfg).iter().any(|i| i.contains("port")));
+    }
+
+    #[test]
+    fn bad_role_caught() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.node.role = "boss".to_string();
+        assert!(validate(&cfg).iter().any(|i| i.contains("role")));
+    }
+
+    #[test]
+    fn bad_timezone_caught() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.daemon.timezone = Some("nope".to_string());
+        assert!(validate(&cfg).iter().any(|i| i.contains("timezone")));
+    }
+
+    #[test]
+    fn bad_quiet_hours_caught() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.daemon.quiet_hours = Some("midnight".to_string());
+        assert!(validate(&cfg).iter().any(|i| i.contains("quiet_hours")));
+    }
+
+    #[test]
+    fn valid_quiet_hours_accepted() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.daemon.quiet_hours = Some("23:00-07:00".to_string());
+        assert!(!validate(&cfg).iter().any(|i| i.contains("quiet_hours")));
+    }
+
+    #[test]
+    fn bad_transport_caught() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.mesh.transport = "pigeon".to_string();
+        assert!(validate(&cfg).iter().any(|i| i.contains("transport")));
+    }
+
+    #[test]
+    fn zero_max_tokens_caught() {
+        let mut cfg = ConvergioConfig::default();
+        cfg.kernel.max_tokens = 0;
+        assert!(validate(&cfg).iter().any(|i| i.contains("max_tokens")));
+    }
+}

--- a/daemon/crates/convergio-server/src/config_watcher.rs
+++ b/daemon/crates/convergio-server/src/config_watcher.rs
@@ -40,15 +40,39 @@ pub fn diff_configs(old: &ConvergioConfig, new: &ConvergioConfig) -> Vec<ConfigC
     cmp!("node.role", old.node.role, new.node.role);
     cmp!("node.name", old.node.name, new.node.name);
     cmp!("daemon.port", old.daemon.port, new.daemon.port);
-    cmp!("daemon.quiet_hours", old.daemon.quiet_hours, new.daemon.quiet_hours);
+    cmp!(
+        "daemon.quiet_hours",
+        old.daemon.quiet_hours,
+        new.daemon.quiet_hours
+    );
     cmp!("daemon.timezone", old.daemon.timezone, new.daemon.timezone);
-    cmp!("daemon.auto_update", old.daemon.auto_update, new.daemon.auto_update);
+    cmp!(
+        "daemon.auto_update",
+        old.daemon.auto_update,
+        new.daemon.auto_update
+    );
     cmp!("mesh.transport", old.mesh.transport, new.mesh.transport);
     cmp!("mesh.peers", old.mesh.peers, new.mesh.peers);
-    cmp!("inference.default_model", old.inference.default_model, new.inference.default_model);
-    cmp!("inference.fallback", old.inference.fallback, new.inference.fallback);
-    cmp!("kernel.max_tokens", old.kernel.max_tokens, new.kernel.max_tokens);
-    cmp!("telegram.enabled", old.telegram.enabled, new.telegram.enabled);
+    cmp!(
+        "inference.default_model",
+        old.inference.default_model,
+        new.inference.default_model
+    );
+    cmp!(
+        "inference.fallback",
+        old.inference.fallback,
+        new.inference.fallback
+    );
+    cmp!(
+        "kernel.max_tokens",
+        old.kernel.max_tokens,
+        new.kernel.max_tokens
+    );
+    cmp!(
+        "telegram.enabled",
+        old.telegram.enabled,
+        new.telegram.enabled
+    );
     changes
 }
 
@@ -79,9 +103,15 @@ pub fn spawn_config_watcher(config: Arc<RwLock<ConvergioConfig>>) -> Result<(), 
         .ok_or_else(|| "config path has no parent directory".to_string())?
         .to_path_buf();
     if !watch_dir.exists() {
-        return Err(format!("config dir does not exist: {}", watch_dir.display()));
+        return Err(format!(
+            "config dir does not exist: {}",
+            watch_dir.display()
+        ));
     }
-    let file_name = path.file_name().map(|f| f.to_os_string()).unwrap_or_default();
+    let file_name = path
+        .file_name()
+        .map(|f| f.to_os_string())
+        .unwrap_or_default();
 
     let cfg = Arc::clone(&config);
     let last_reload = Arc::new(std::sync::Mutex::new(Instant::now()));

--- a/daemon/crates/convergio-server/src/config_watcher.rs
+++ b/daemon/crates/convergio-server/src/config_watcher.rs
@@ -1,0 +1,210 @@
+//! Filesystem watcher for config hot-reload with debounce and diff.
+
+use convergio_types::config::ConvergioConfig;
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+/// Fields that can be updated at runtime without a restart.
+const HOT_RELOADABLE: &[&str] = &[
+    "daemon.quiet_hours",
+    "daemon.timezone",
+    "daemon.auto_update",
+    "inference.default_model",
+    "inference.fallback",
+    "kernel.max_tokens",
+    "mesh.peers",
+    "telegram.enabled",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigChange {
+    pub field: String,
+    pub reloadable: bool,
+}
+
+/// Compare two configs and return changed fields.
+pub fn diff_configs(old: &ConvergioConfig, new: &ConvergioConfig) -> Vec<ConfigChange> {
+    let mut changes = Vec::new();
+    macro_rules! cmp {
+        ($field:expr, $a:expr, $b:expr) => {
+            if $a != $b {
+                let name: &str = $field;
+                changes.push(ConfigChange {
+                    field: name.to_string(),
+                    reloadable: HOT_RELOADABLE.contains(&name),
+                });
+            }
+        };
+    }
+    cmp!("node.role", old.node.role, new.node.role);
+    cmp!("node.name", old.node.name, new.node.name);
+    cmp!("daemon.port", old.daemon.port, new.daemon.port);
+    cmp!("daemon.quiet_hours", old.daemon.quiet_hours, new.daemon.quiet_hours);
+    cmp!("daemon.timezone", old.daemon.timezone, new.daemon.timezone);
+    cmp!("daemon.auto_update", old.daemon.auto_update, new.daemon.auto_update);
+    cmp!("mesh.transport", old.mesh.transport, new.mesh.transport);
+    cmp!("mesh.peers", old.mesh.peers, new.mesh.peers);
+    cmp!("inference.default_model", old.inference.default_model, new.inference.default_model);
+    cmp!("inference.fallback", old.inference.fallback, new.inference.fallback);
+    cmp!("kernel.max_tokens", old.kernel.max_tokens, new.kernel.max_tokens);
+    cmp!("telegram.enabled", old.telegram.enabled, new.telegram.enabled);
+    changes
+}
+
+fn apply_reloadable(current: &mut ConvergioConfig, new: &ConvergioConfig) {
+    current.daemon.quiet_hours = new.daemon.quiet_hours.clone();
+    current.daemon.timezone = new.daemon.timezone.clone();
+    current.daemon.auto_update = new.daemon.auto_update;
+    current.inference.default_model = new.inference.default_model.clone();
+    current.inference.fallback = new.inference.fallback.clone();
+    current.kernel.max_tokens = new.kernel.max_tokens;
+    current.mesh.peers = new.mesh.peers.clone();
+    current.telegram.enabled = new.telegram.enabled;
+}
+
+const DEBOUNCE_MS: u128 = 500;
+
+fn should_reload(last: &Instant) -> bool {
+    last.elapsed().as_millis() >= DEBOUNCE_MS
+}
+
+/// Spawn a background thread that watches the config file for changes.
+/// On modify, debounces 500 ms, re-parses, diffs, and applies
+/// reloadable fields. Parse errors are logged, current config kept.
+pub fn spawn_config_watcher(config: Arc<RwLock<ConvergioConfig>>) -> Result<(), String> {
+    let path = super::config::config_path();
+    let watch_dir = path
+        .parent()
+        .ok_or_else(|| "config path has no parent directory".to_string())?
+        .to_path_buf();
+    if !watch_dir.exists() {
+        return Err(format!("config dir does not exist: {}", watch_dir.display()));
+    }
+    let file_name = path.file_name().map(|f| f.to_os_string()).unwrap_or_default();
+
+    let cfg = Arc::clone(&config);
+    let last_reload = Arc::new(std::sync::Mutex::new(Instant::now()));
+    let lr = Arc::clone(&last_reload);
+    let fname = file_name.clone();
+    let cfg_path = path.clone();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: Result<notify::Event, notify::Error>| {
+            let event = match res {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("[config] watcher error: {e}");
+                    return;
+                }
+            };
+            if !matches!(event.kind, EventKind::Modify(_)) {
+                return;
+            }
+            let is_target = event
+                .paths
+                .iter()
+                .any(|p| p.file_name().map(|f| f == fname).unwrap_or(false));
+            if !is_target {
+                return;
+            }
+            let mut last = lr.lock().unwrap_or_else(|e| e.into_inner());
+            if !should_reload(&last) {
+                return;
+            }
+            *last = Instant::now();
+            drop(last);
+            reload_config(&cfg, &cfg_path);
+        },
+        Config::default(),
+    )
+    .map_err(|e| format!("watcher init failed: {e}"))?;
+
+    watcher
+        .watch(&watch_dir, RecursiveMode::NonRecursive)
+        .map_err(|e| format!("watch failed: {e}"))?;
+
+    // Leak the watcher so it lives for the process lifetime.
+    std::mem::forget(watcher);
+    tracing::info!("[config] Watching {} for changes", path.display());
+    Ok(())
+}
+
+fn reload_config(config: &Arc<RwLock<ConvergioConfig>>, path: &std::path::Path) {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("[config] Failed to read {}: {e}", path.display());
+            return;
+        }
+    };
+    let new_cfg = match toml::from_str::<ConvergioConfig>(&contents) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("[config] Parse error in {}: {e}", path.display());
+            return;
+        }
+    };
+    let mut guard = match config.write() {
+        Ok(g) => g,
+        Err(e) => {
+            tracing::warn!("[config] RwLock poisoned: {e}");
+            return;
+        }
+    };
+    let changes = diff_configs(&guard, &new_cfg);
+    if changes.is_empty() {
+        return;
+    }
+    for change in &changes {
+        if change.reloadable {
+            tracing::info!("[config] Reloaded: {} changed", change.field);
+        } else {
+            tracing::warn!("[config] {} changed — requires restart", change.field);
+        }
+    }
+    apply_reloadable(&mut guard, &new_cfg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_detects_port_change() {
+        let old = ConvergioConfig::default();
+        let mut new = ConvergioConfig::default();
+        new.daemon.port = 9999;
+        let changes = diff_configs(&old, &new);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].field, "daemon.port");
+        assert!(!changes[0].reloadable);
+    }
+
+    #[test]
+    fn diff_detects_reloadable_change() {
+        let old = ConvergioConfig::default();
+        let mut new = ConvergioConfig::default();
+        new.kernel.max_tokens = 4096;
+        let changes = diff_configs(&old, &new);
+        assert_eq!(changes.len(), 1);
+        assert!(changes[0].reloadable);
+    }
+
+    #[test]
+    fn diff_no_changes() {
+        let cfg = ConvergioConfig::default();
+        assert!(diff_configs(&cfg, &cfg).is_empty());
+    }
+
+    #[test]
+    fn apply_only_touches_reloadable() {
+        let mut current = ConvergioConfig::default();
+        let mut new = ConvergioConfig::default();
+        new.daemon.port = 9999; // NOT reloadable
+        new.kernel.max_tokens = 4096; // reloadable
+        apply_reloadable(&mut current, &new);
+        assert_eq!(current.daemon.port, 8420); // unchanged
+        assert_eq!(current.kernel.max_tokens, 4096); // applied
+    }
+}

--- a/daemon/crates/convergio-server/src/lib.rs
+++ b/daemon/crates/convergio-server/src/lib.rs
@@ -1,4 +1,22 @@
 //! convergio-server — Axum routing shell, extension wiring, middleware.
 //!
 //! Collects Extension::routes() from all registered extensions,
-//! applies middleware, serves the unified API.
+//! applies middleware (auth, audit, telemetry, rate-limit, CORS),
+//! serves the unified API. Zero business logic — that lives in crates.
+
+pub mod config;
+pub mod config_defaults;
+pub mod config_validation;
+pub mod config_watcher;
+pub mod middleware_audit;
+pub mod middleware_auth;
+pub mod middleware_telemetry;
+pub mod rate_limiter;
+pub mod router;
+pub mod runner;
+pub mod state;
+
+pub use config::{config_path, load_config, write_default_config};
+pub use router::build_router;
+pub use runner::run_server;
+pub use state::ServerState;

--- a/daemon/crates/convergio-server/src/middleware_audit.rs
+++ b/daemon/crates/convergio-server/src/middleware_audit.rs
@@ -93,7 +93,10 @@ mod tests {
 
     #[test]
     fn extract_agent_no_header() {
-        let req = Request::builder().uri("/api/test").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/api/test")
+            .body(Body::empty())
+            .unwrap();
         assert_eq!(extract_agent(&req), "dev-mode");
     }
 
@@ -119,7 +122,10 @@ mod tests {
 
     #[test]
     fn extract_ip_none() {
-        let req = Request::builder().uri("/api/test").body(Body::empty()).unwrap();
+        let req = Request::builder()
+            .uri("/api/test")
+            .body(Body::empty())
+            .unwrap();
         assert_eq!(extract_ip(&req), None);
     }
 
@@ -131,14 +137,24 @@ mod tests {
                 id INTEGER PRIMARY KEY, agent TEXT, action TEXT NOT NULL,
                 resource TEXT, detail TEXT, ip_addr TEXT,
                 timestamp TEXT DEFAULT (datetime('now'))
-             );"
-        ).unwrap();
+             );",
+        )
+        .unwrap();
         conn.execute(
             "INSERT INTO audit_log (agent, action, resource, detail, ip_addr)
              VALUES (?1, ?2, ?3, ?4, ?5)",
-            rusqlite::params!["dev-mode", "POST", "/api/plans", "201", Option::<&str>::None],
-        ).unwrap();
-        let count: i64 = conn.query_row("SELECT COUNT(*) FROM audit_log", [], |r| r.get(0)).unwrap();
+            rusqlite::params![
+                "dev-mode",
+                "POST",
+                "/api/plans",
+                "201",
+                Option::<&str>::None
+            ],
+        )
+        .unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM audit_log", [], |r| r.get(0))
+            .unwrap();
         assert_eq!(count, 1);
     }
 }

--- a/daemon/crates/convergio-server/src/middleware_audit.rs
+++ b/daemon/crates/convergio-server/src/middleware_audit.rs
@@ -1,0 +1,144 @@
+//! Audit middleware: records POST/PUT/DELETE mutations to audit_log.
+//! Runs after response — never blocks the request path.
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Method, Request};
+use axum::middleware::Next;
+use axum::response::Response;
+use std::net::SocketAddr;
+
+fn extract_agent(req: &Request<Body>) -> String {
+    let header = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+    let Some(value) = header else {
+        return "dev-mode".to_string();
+    };
+    let Some(token) = value.strip_prefix("Bearer ") else {
+        return "legacy".to_string();
+    };
+    if token.matches('.').count() == 2 {
+        match convergio_security::jwt::validate_token(token) {
+            Ok(claims) => claims.sub,
+            Err(_) => "unknown".to_string(),
+        }
+    } else {
+        "legacy".to_string()
+    }
+}
+
+fn extract_ip(req: &Request<Body>) -> Option<String> {
+    if let Some(addr) = req.extensions().get::<ConnectInfo<SocketAddr>>() {
+        return Some(addr.0.ip().to_string());
+    }
+    req.headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.split(',').next().unwrap_or(v).trim().to_string())
+}
+
+fn is_mutation(method: &Method) -> bool {
+    matches!(*method, Method::POST | Method::PUT | Method::DELETE)
+}
+
+/// Axum middleware that appends a row to `audit_log` for successful
+/// POST, PUT, and DELETE requests.
+pub async fn audit_mutations(
+    axum::extract::State(state): axum::extract::State<super::state::ServerState>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let method = req.method().clone();
+    let resource = req.uri().path().to_string();
+    let agent = extract_agent(&req);
+    let ip = extract_ip(&req);
+
+    let resp = next.run(req).await;
+
+    if is_mutation(&method) && resp.status().is_success() {
+        let action = method.as_str().to_string();
+        let detail = resp.status().as_u16().to_string();
+        match state.get_conn() {
+            Ok(conn) => {
+                if let Err(e) = conn.execute(
+                    "INSERT INTO audit_log (agent, action, resource, detail, ip_addr) \
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    rusqlite::params![agent, action, resource, detail, ip],
+                ) {
+                    tracing::warn!(agent=%agent, resource=%resource, "audit insert failed: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(agent=%agent, resource=%resource, "audit pool exhausted: {e}");
+            }
+        }
+    }
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+
+    #[test]
+    fn mutation_methods() {
+        assert!(is_mutation(&Method::POST));
+        assert!(is_mutation(&Method::PUT));
+        assert!(is_mutation(&Method::DELETE));
+        assert!(!is_mutation(&Method::GET));
+    }
+
+    #[test]
+    fn extract_agent_no_header() {
+        let req = Request::builder().uri("/api/test").body(Body::empty()).unwrap();
+        assert_eq!(extract_agent(&req), "dev-mode");
+    }
+
+    #[test]
+    fn extract_agent_legacy_bearer() {
+        let req = Request::builder()
+            .uri("/api/test")
+            .header("authorization", "Bearer no-dots")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(extract_agent(&req), "legacy");
+    }
+
+    #[test]
+    fn extract_ip_forwarded() {
+        let req = Request::builder()
+            .uri("/api/test")
+            .header("x-forwarded-for", "203.0.113.1, 10.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(extract_ip(&req), Some("203.0.113.1".to_string()));
+    }
+
+    #[test]
+    fn extract_ip_none() {
+        let req = Request::builder().uri("/api/test").body(Body::empty()).unwrap();
+        assert_eq!(extract_ip(&req), None);
+    }
+
+    #[test]
+    fn audit_log_insert_logic() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE audit_log (
+                id INTEGER PRIMARY KEY, agent TEXT, action TEXT NOT NULL,
+                resource TEXT, detail TEXT, ip_addr TEXT,
+                timestamp TEXT DEFAULT (datetime('now'))
+             );"
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO audit_log (agent, action, resource, detail, ip_addr)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params!["dev-mode", "POST", "/api/plans", "201", Option::<&str>::None],
+        ).unwrap();
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM audit_log", [], |r| r.get(0)).unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/daemon/crates/convergio-server/src/middleware_auth.rs
+++ b/daemon/crates/convergio-server/src/middleware_auth.rs
@@ -43,10 +43,7 @@ fn is_localhost(req: &Request<Body>) -> bool {
     false
 }
 
-fn authenticate(
-    header_value: Option<&str>,
-    dev_mode: bool,
-) -> Result<Option<AgentClaims>, ()> {
+fn authenticate(header_value: Option<&str>, dev_mode: bool) -> Result<Option<AgentClaims>, ()> {
     if let Some(token) = header_value.and_then(|v| v.strip_prefix("Bearer ")) {
         // JWT tokens have 2 dots; legacy tokens do not
         if token.matches('.').count() == 2 {
@@ -138,7 +135,10 @@ pub async fn require_auth_stateless(req: Request<Body>, next: Next) -> Response 
 /// Cache-Control header middleware.
 pub async fn set_cache_headers(req: Request<Body>, next: Next) -> Response {
     let mut res = next.run(req).await;
-    if !res.headers().contains_key(axum::http::header::CACHE_CONTROL) {
+    if !res
+        .headers()
+        .contains_key(axum::http::header::CACHE_CONTROL)
+    {
         res.headers_mut().insert(
             axum::http::header::CACHE_CONTROL,
             axum::http::HeaderValue::from_static("private, max-age=10"),
@@ -158,7 +158,11 @@ pub fn cors_layer() -> CorsLayer {
                 .filter(|o| !o.is_empty())
                 .filter_map(|o| axum::http::HeaderValue::from_str(o).ok())
                 .collect();
-            if parsed.is_empty() { None } else { Some(parsed) }
+            if parsed.is_empty() {
+                None
+            } else {
+                Some(parsed)
+            }
         })
         .unwrap_or_else(|| {
             vec![

--- a/daemon/crates/convergio-server/src/middleware_auth.rs
+++ b/daemon/crates/convergio-server/src/middleware_auth.rs
@@ -1,0 +1,201 @@
+//! Authentication middleware — JWT, legacy Bearer, dev-mode, localhost bypass.
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Method, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use constant_time_eq::constant_time_eq;
+use convergio_security::jwt::{self, AgentClaims};
+use convergio_security::rbac;
+use std::env;
+use std::sync::OnceLock;
+use tower_http::cors::CorsLayer;
+
+static AUTH_TOKEN: OnceLock<Option<String>> = OnceLock::new();
+
+fn get_auth_token() -> &'static Option<String> {
+    AUTH_TOKEN.get_or_init(|| match env::var("CONVERGIO_AUTH_TOKEN") {
+        Ok(t) if !t.is_empty() => Some(t),
+        _ => None,
+    })
+}
+
+fn compare_tokens(a: &str, b: &str) -> bool {
+    constant_time_eq(a.as_bytes(), b.as_bytes())
+}
+
+/// Routes that never require auth.
+const EXEMPT_ROUTES: &[&str] = &["/api/health"];
+
+fn needs_auth(path: &str) -> bool {
+    !EXEMPT_ROUTES.contains(&path)
+}
+
+fn is_localhost(req: &Request<Body>) -> bool {
+    if req.headers().contains_key("x-forwarded-for") {
+        return false;
+    }
+    if let Some(addr) = req.extensions().get::<ConnectInfo<std::net::SocketAddr>>() {
+        return addr.0.ip().is_loopback();
+    }
+    false
+}
+
+fn authenticate(
+    header_value: Option<&str>,
+    dev_mode: bool,
+) -> Result<Option<AgentClaims>, ()> {
+    if let Some(token) = header_value.and_then(|v| v.strip_prefix("Bearer ")) {
+        // JWT tokens have 2 dots; legacy tokens do not
+        if token.matches('.').count() == 2 {
+            return match jwt::validate_token(token) {
+                Ok(claims) => Ok(Some(claims)),
+                Err(e) => {
+                    tracing::warn!("JWT validation failed: {e}");
+                    Err(())
+                }
+            };
+        }
+        // Legacy shared bearer token
+        if let Some(expected) = get_auth_token() {
+            if compare_tokens(token, expected.as_str()) {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                return Ok(Some(AgentClaims {
+                    sub: "system-bearer".to_string(),
+                    role: jwt::AgentRole::Coordinator,
+                    cap: vec!["*".to_string()],
+                    iat: now,
+                    exp: u64::MAX,
+                }));
+            }
+        }
+        return Err(());
+    }
+    // No Authorization header
+    match get_auth_token() {
+        None if dev_mode => Ok(None),
+        _ => Err(()),
+    }
+}
+
+/// Axum middleware: authenticates via JWT, legacy bearer, or dev-mode.
+/// /api/health is exempt. Localhost skips auth.
+/// Extracts ServerState from tower Extension layer (not Axum State).
+pub async fn require_auth_stateless(req: Request<Body>, next: Next) -> Response {
+    let path = req.uri().path().to_string();
+    if !needs_auth(&path) {
+        return next.run(req).await;
+    }
+    if is_localhost(&req) {
+        return next.run(req).await;
+    }
+    let dev_mode = req
+        .extensions()
+        .get::<super::state::ServerState>()
+        .map(|s| s.dev_mode)
+        .unwrap_or(false);
+    let auth_header = req
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    match authenticate(auth_header.as_deref(), dev_mode) {
+        Ok(Some(claims)) => {
+            if !rbac::role_can_access(&claims.role, &path) {
+                tracing::warn!(
+                    agent = %claims.sub, role = %claims.role,
+                    path = %path, "RBAC denied"
+                );
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "Forbidden",
+                        "message": format!("Role '{}' cannot access {path}", claims.role)
+                    })),
+                )
+                    .into_response();
+            }
+            next.run(req).await
+        }
+        Ok(None) => next.run(req).await,
+        Err(()) => (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": "Unauthorized",
+                "message": "Valid Bearer token required"
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// Cache-Control header middleware.
+pub async fn set_cache_headers(req: Request<Body>, next: Next) -> Response {
+    let mut res = next.run(req).await;
+    if !res.headers().contains_key(axum::http::header::CACHE_CONTROL) {
+        res.headers_mut().insert(
+            axum::http::header::CACHE_CONTROL,
+            axum::http::HeaderValue::from_static("private, max-age=10"),
+        );
+    }
+    res
+}
+
+/// Build the CORS layer from env or defaults.
+pub fn cors_layer() -> CorsLayer {
+    let origins = env::var("CONVERGIO_CORS_ORIGINS")
+        .ok()
+        .and_then(|value| {
+            let parsed: Vec<_> = value
+                .split(',')
+                .map(str::trim)
+                .filter(|o| !o.is_empty())
+                .filter_map(|o| axum::http::HeaderValue::from_str(o).ok())
+                .collect();
+            if parsed.is_empty() { None } else { Some(parsed) }
+        })
+        .unwrap_or_else(|| {
+            vec![
+                axum::http::HeaderValue::from_static("http://localhost:8420"),
+                axum::http::HeaderValue::from_static("http://127.0.0.1:8420"),
+                axum::http::HeaderValue::from_static("http://localhost:3000"),
+                axum::http::HeaderValue::from_static("tauri://localhost"),
+            ]
+        });
+
+    CorsLayer::new()
+        .allow_origin(origins)
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            axum::http::header::CONTENT_TYPE,
+            axum::http::header::AUTHORIZATION,
+            axum::http::header::ACCEPT,
+        ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exempt_routes_skip_auth() {
+        assert!(!needs_auth("/api/health"));
+    }
+
+    #[test]
+    fn normal_routes_need_auth() {
+        assert!(needs_auth("/api/plans"));
+    }
+}

--- a/daemon/crates/convergio-server/src/middleware_telemetry.rs
+++ b/daemon/crates/convergio-server/src/middleware_telemetry.rs
@@ -1,0 +1,187 @@
+//! Request telemetry: counters, response time histogram, endpoint metrics.
+
+use axum::body::Body;
+use axum::http::header::HeaderName;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+use std::time::Instant;
+
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+
+static TOTAL_REQUESTS: AtomicU64 = AtomicU64::new(0);
+static TOTAL_ERRORS: AtomicU64 = AtomicU64::new(0);
+static ENDPOINT_METRICS: RwLock<Option<HashMap<String, EndpointStats>>> =
+    RwLock::new(None);
+
+const HISTOGRAM_BUCKETS: &[u64] = &[5, 10, 25, 50, 100, 250, 500, 1000, 5000];
+
+#[derive(Debug, Clone)]
+pub struct EndpointStats {
+    pub count: u64,
+    pub errors: u64,
+    pub total_ms: u64,
+    pub max_ms: u64,
+    pub histogram: Vec<u64>,
+}
+
+impl EndpointStats {
+    fn new() -> Self {
+        Self {
+            count: 0,
+            errors: 0,
+            total_ms: 0,
+            max_ms: 0,
+            histogram: vec![0; HISTOGRAM_BUCKETS.len()],
+        }
+    }
+
+    fn record(&mut self, duration_ms: u64, is_error: bool) {
+        self.count += 1;
+        self.total_ms += duration_ms;
+        if duration_ms > self.max_ms {
+            self.max_ms = duration_ms;
+        }
+        if is_error {
+            self.errors += 1;
+        }
+        for (i, &boundary) in HISTOGRAM_BUCKETS.iter().enumerate() {
+            if duration_ms <= boundary {
+                self.histogram[i] += 1;
+            }
+        }
+    }
+
+    pub fn avg_ms(&self) -> f64 {
+        if self.count == 0 { 0.0 } else { self.total_ms as f64 / self.count as f64 }
+    }
+}
+
+pub fn record_request(path: &str, duration_ms: u64, is_error: bool) {
+    TOTAL_REQUESTS.fetch_add(1, Ordering::Relaxed);
+    if is_error {
+        TOTAL_ERRORS.fetch_add(1, Ordering::Relaxed);
+    }
+    let normalised = normalise_path(path);
+    if let Ok(mut guard) = ENDPOINT_METRICS.write() {
+        let map = guard.get_or_insert_with(HashMap::new);
+        map.entry(normalised)
+            .or_insert_with(EndpointStats::new)
+            .record(duration_ms, is_error);
+    }
+}
+
+fn normalise_path(path: &str) -> String {
+    path.split('/')
+        .map(|seg| {
+            if !seg.is_empty() && seg.chars().all(|c| c.is_ascii_digit()) {
+                ":id"
+            } else {
+                seg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// JSON snapshot of all telemetry data.
+pub fn snapshot() -> Value {
+    let total = TOTAL_REQUESTS.load(Ordering::Relaxed);
+    let errors = TOTAL_ERRORS.load(Ordering::Relaxed);
+    let endpoints: Vec<Value> = match ENDPOINT_METRICS.read() {
+        Ok(guard) => guard
+            .as_ref()
+            .map(|map| {
+                let mut entries: Vec<_> = map.iter().collect();
+                entries.sort_by(|a, b| b.1.count.cmp(&a.1.count));
+                entries
+                    .iter()
+                    .map(|(path, stats)| {
+                        json!({
+                            "path": path,
+                            "count": stats.count,
+                            "errors": stats.errors,
+                            "avg_ms": (stats.avg_ms() * 100.0).round() / 100.0,
+                            "max_ms": stats.max_ms,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Err(_) => vec![],
+    };
+    json!({
+        "total_requests": total,
+        "total_errors": errors,
+        "error_rate": if total > 0 {
+            (errors as f64 / total as f64 * 10000.0).round() / 100.0
+        } else { 0.0 },
+        "endpoints": endpoints,
+    })
+}
+
+/// Reset all counters (for testing).
+pub fn reset() {
+    TOTAL_REQUESTS.store(0, Ordering::Relaxed);
+    TOTAL_ERRORS.store(0, Ordering::Relaxed);
+    if let Ok(mut guard) = ENDPOINT_METRICS.write() {
+        *guard = None;
+    }
+}
+
+/// Axum middleware: records request count and response time.
+pub async fn telemetry_layer(mut req: Request<Body>, next: Next) -> Response {
+    let path = req.uri().path().to_string();
+    let request_id = req
+        .headers()
+        .get(REQUEST_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| !v.trim().is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    req.extensions_mut().insert(request_id.clone());
+    let start = Instant::now();
+    let mut response = next.run(req).await;
+    let duration_ms = start.elapsed().as_millis() as u64;
+    let is_error = response.status().is_client_error() || response.status().is_server_error();
+    if let Ok(hv) = request_id.parse() {
+        response
+            .headers_mut()
+            .insert(HeaderName::from_static(REQUEST_ID_HEADER), hv);
+    }
+    record_request(&path, duration_ms, is_error);
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_normalisation() {
+        assert_eq!(normalise_path("/api/plans/42"), "/api/plans/:id");
+        assert_eq!(normalise_path("/api/health"), "/api/health");
+    }
+
+    #[test]
+    fn record_and_snapshot() {
+        reset();
+        record_request("/api/plans", 50, false);
+        record_request("/api/plans", 200, true);
+        let snap = snapshot();
+        assert_eq!(snap["total_requests"], 2);
+        assert_eq!(snap["total_errors"], 1);
+    }
+
+    #[test]
+    fn endpoint_stats_avg() {
+        let mut stats = EndpointStats::new();
+        stats.record(100, false);
+        stats.record(200, false);
+        assert!((stats.avg_ms() - 150.0).abs() < 0.01);
+    }
+}

--- a/daemon/crates/convergio-server/src/middleware_telemetry.rs
+++ b/daemon/crates/convergio-server/src/middleware_telemetry.rs
@@ -15,8 +15,7 @@ pub const REQUEST_ID_HEADER: &str = "x-request-id";
 
 static TOTAL_REQUESTS: AtomicU64 = AtomicU64::new(0);
 static TOTAL_ERRORS: AtomicU64 = AtomicU64::new(0);
-static ENDPOINT_METRICS: RwLock<Option<HashMap<String, EndpointStats>>> =
-    RwLock::new(None);
+static ENDPOINT_METRICS: RwLock<Option<HashMap<String, EndpointStats>>> = RwLock::new(None);
 
 const HISTOGRAM_BUCKETS: &[u64] = &[5, 10, 25, 50, 100, 250, 500, 1000, 5000];
 
@@ -57,7 +56,11 @@ impl EndpointStats {
     }
 
     pub fn avg_ms(&self) -> f64 {
-        if self.count == 0 { 0.0 } else { self.total_ms as f64 / self.count as f64 }
+        if self.count == 0 {
+            0.0
+        } else {
+            self.total_ms as f64 / self.count as f64
+        }
     }
 }
 

--- a/daemon/crates/convergio-server/src/rate_limiter.rs
+++ b/daemon/crates/convergio-server/src/rate_limiter.rs
@@ -68,9 +68,18 @@ mod tests {
     async fn rate_limiter_allows_within_limit() {
         let rl = RateLimiter::default();
         let window = Duration::from_secs(60);
-        assert!(rl.allow("api:test".into(), "127.0.0.1".into(), 2, window).await);
-        assert!(rl.allow("api:test".into(), "127.0.0.1".into(), 2, window).await);
-        assert!(!rl.allow("api:test".into(), "127.0.0.1".into(), 2, window).await);
+        assert!(
+            rl.allow("api:test".into(), "127.0.0.1".into(), 2, window)
+                .await
+        );
+        assert!(
+            rl.allow("api:test".into(), "127.0.0.1".into(), 2, window)
+                .await
+        );
+        assert!(
+            !rl.allow("api:test".into(), "127.0.0.1".into(), 2, window)
+                .await
+        );
     }
 
     #[tokio::test]

--- a/daemon/crates/convergio-server/src/rate_limiter.rs
+++ b/daemon/crates/convergio-server/src/rate_limiter.rs
@@ -1,0 +1,83 @@
+//! Per-client, per-category rate limiter with sliding window.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+type BucketKey = (String, String);
+
+#[derive(Clone)]
+pub struct RateLimiter {
+    buckets: Arc<Mutex<HashMap<BucketKey, Vec<Instant>>>>,
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self {
+            buckets: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl RateLimiter {
+    pub async fn allow(
+        &self,
+        category: String,
+        client_ip: String,
+        limit: usize,
+        window: Duration,
+    ) -> bool {
+        let now = Instant::now();
+        let mut buckets = self.buckets.lock().await;
+        let key: BucketKey = (category, client_ip);
+        let entries = buckets.entry(key).or_default();
+        entries.retain(|seen| now.duration_since(*seen) <= window);
+        if entries.len() >= limit {
+            return false;
+        }
+        entries.push(now);
+        if buckets.len() > 10_000 {
+            buckets.retain(|_, v| !v.is_empty());
+        }
+        true
+    }
+}
+
+pub fn endpoint_category(path: &str) -> String {
+    let mut segments = path.split('/').filter(|s| !s.is_empty());
+    match (segments.next(), segments.next()) {
+        (Some("api"), Some(cat)) => format!("api:{cat}"),
+        (Some(seg), _) => seg.to_string(),
+        _ => "root".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_extraction() {
+        assert_eq!(endpoint_category("/api/plans/1"), "api:plans");
+        assert_eq!(endpoint_category("/health"), "health");
+        assert_eq!(endpoint_category("/"), "root");
+    }
+
+    #[tokio::test]
+    async fn rate_limiter_allows_within_limit() {
+        let rl = RateLimiter::default();
+        let window = Duration::from_secs(60);
+        assert!(rl.allow("api:test".into(), "127.0.0.1".into(), 2, window).await);
+        assert!(rl.allow("api:test".into(), "127.0.0.1".into(), 2, window).await);
+        assert!(!rl.allow("api:test".into(), "127.0.0.1".into(), 2, window).await);
+    }
+
+    #[tokio::test]
+    async fn different_clients_independent() {
+        let rl = RateLimiter::default();
+        let window = Duration::from_secs(60);
+        assert!(rl.allow("cat".into(), "10.0.0.1".into(), 1, window).await);
+        assert!(rl.allow("cat".into(), "10.0.0.2".into(), 1, window).await);
+    }
+}

--- a/daemon/crates/convergio-server/src/router.rs
+++ b/daemon/crates/convergio-server/src/router.rs
@@ -48,7 +48,9 @@ pub fn build_router(
         .layer(middleware::from_fn(
             crate::middleware_auth::require_auth_stateless,
         ))
-        .layer(middleware::from_fn(crate::middleware_auth::set_cache_headers))
+        .layer(middleware::from_fn(
+            crate::middleware_auth::set_cache_headers,
+        ))
         .layer(RequestBodyLimitLayer::new(1_048_576)) // 1 MB
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
         .layer(crate::middleware_auth::cors_layer())

--- a/daemon/crates/convergio-server/src/router.rs
+++ b/daemon/crates/convergio-server/src/router.rs
@@ -1,0 +1,165 @@
+//! Router builder — wires extensions, applies middleware stack.
+//!
+//! All routes are `Router<()>`. ServerState is injected via tower
+//! `Extension` layer so extension routes and system routes compose freely.
+
+use crate::middleware_telemetry::telemetry_layer;
+use crate::rate_limiter::{endpoint_category, RateLimiter};
+use crate::state::ServerState;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use convergio_types::extension::{AppContext, Extension};
+use std::sync::Arc;
+use std::time::Duration;
+use tower_http::compression::CompressionLayer;
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::timeout::TimeoutLayer;
+
+/// Build the full Axum router: system routes + extension routes + middleware.
+pub fn build_router(
+    state: ServerState,
+    extensions: &[Arc<dyn Extension>],
+    ctx: &AppContext,
+) -> Router {
+    let mut app = Router::new();
+
+    // System routes
+    app = app
+        .route("/api/health", get(health_handler))
+        .route("/api/telemetry", get(telemetry_handler))
+        .route("/api/health/deep", get(deep_health_handler))
+        .route("/api/metrics", get(metrics_handler));
+
+    // Merge extension routes (all Router<()>)
+    for ext in extensions {
+        if let Some(ext_router) = ext.routes(ctx) {
+            app = app.merge(ext_router);
+        }
+    }
+
+    // Middleware stack (first registered = outermost = last to execute)
+    // State is available in handlers via axum::Extension<ServerState>
+    app.layer(middleware::from_fn(audit_layer))
+        .layer(middleware::from_fn(basic_rate_limit))
+        .layer(middleware::from_fn(
+            crate::middleware_auth::require_auth_stateless,
+        ))
+        .layer(middleware::from_fn(crate::middleware_auth::set_cache_headers))
+        .layer(RequestBodyLimitLayer::new(1_048_576)) // 1 MB
+        .layer(TimeoutLayer::new(Duration::from_secs(30)))
+        .layer(crate::middleware_auth::cors_layer())
+        .layer(CompressionLayer::new().gzip(true))
+        .layer(middleware::from_fn(telemetry_layer))
+        .layer(axum::Extension(state))
+}
+
+async fn health_handler() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "status": "ok",
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+async fn telemetry_handler() -> Json<serde_json::Value> {
+    Json(crate::middleware_telemetry::snapshot())
+}
+
+async fn deep_health_handler(
+    axum::Extension(state): axum::Extension<ServerState>,
+) -> Json<serde_json::Value> {
+    let components = state.health.check_all();
+    Json(serde_json::json!({
+        "components": components.iter().map(|c| {
+            serde_json::json!({
+                "name": c.name,
+                "status": format!("{:?}", c.status),
+            })
+        }).collect::<Vec<_>>(),
+    }))
+}
+
+async fn metrics_handler(
+    axum::Extension(state): axum::Extension<ServerState>,
+) -> Json<serde_json::Value> {
+    let collected = state.metrics.collect_all();
+    Json(serde_json::json!({ "metrics": collected }))
+}
+
+/// Rate limit middleware.
+async fn basic_rate_limit(req: Request<Body>, next: Next) -> Response {
+    static LIMITER: std::sync::OnceLock<RateLimiter> = std::sync::OnceLock::new();
+    let limiter = LIMITER.get_or_init(RateLimiter::default);
+
+    let path = req.uri().path().to_string();
+    if path.starts_with("/ws/") || path.contains("/stream") {
+        return next.run(req).await;
+    }
+    let category = endpoint_category(&path);
+    let (limit, window) = match *req.method() {
+        Method::GET => (600, Duration::from_secs(60)),
+        _ => (300, Duration::from_secs(60)),
+    };
+    let client_ip = "unknown".to_string();
+    if !limiter.allow(category, client_ip, limit, window).await {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({ "error": "Rate limit exceeded" })),
+        )
+            .into_response();
+    }
+    next.run(req).await
+}
+
+/// Audit wrapper: extracts state from Extension layer.
+async fn audit_layer(req: Request<Body>, next: Next) -> Response {
+    let state = req.extensions().get::<ServerState>().cloned();
+    let method = req.method().clone();
+    let resource = req.uri().path().to_string();
+
+    let resp = next.run(req).await;
+
+    if let Some(state) = state {
+        if matches!(method, Method::POST | Method::PUT | Method::DELETE)
+            && resp.status().is_success()
+        {
+            let action = method.as_str().to_string();
+            let detail = resp.status().as_u16().to_string();
+            if let Ok(conn) = state.get_conn() {
+                let _ = conn.execute(
+                    "INSERT INTO audit_log (agent, action, resource, detail) \
+                     VALUES ('system', ?1, ?2, ?3)",
+                    rusqlite::params![action, resource, detail],
+                );
+            }
+        }
+    }
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn router_builds_without_extensions() {
+        use super::*;
+        use convergio_db::pool::create_memory_pool;
+        use convergio_telemetry::health::HealthRegistry;
+        use convergio_telemetry::metrics::MetricsCollector;
+        use convergio_types::config::ConvergioConfig;
+        use std::sync::RwLock;
+
+        let pool = create_memory_pool().unwrap();
+        let state = ServerState::new(
+            pool,
+            Arc::new(RwLock::new(ConvergioConfig::default())),
+            Arc::new(HealthRegistry::new()),
+            Arc::new(MetricsCollector::new()),
+            true,
+        );
+        let ctx = AppContext::new();
+        let _router = build_router(state, &[], &ctx);
+    }
+}

--- a/daemon/crates/convergio-server/src/runner.rs
+++ b/daemon/crates/convergio-server/src/runner.rs
@@ -1,0 +1,86 @@
+//! HTTP server runner with graceful shutdown.
+
+use crate::state::ApiError;
+use axum::Router;
+
+/// Run the Axum server on the given bind address with graceful shutdown.
+pub async fn run_server(bind_addr: &str, router: Router) -> Result<(), ApiError> {
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .map_err(|e| ApiError::internal(format!("bind failed on {bind_addr}: {e}")))?;
+    tracing::info!("[server] Listening on {bind_addr}");
+    axum::serve(listener, router.into_make_service())
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .map_err(|e| ApiError::internal(format!("server runtime failed: {e}")))
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::warn!("ctrl_c signal handler failed: {e}");
+        }
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{signal, SignalKind};
+        if let Ok(mut sigterm) = signal(SignalKind::terminate()) {
+            sigterm.recv().await;
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+    tracing::info!("[server] Shutdown signal received");
+}
+
+/// Determine the effective bind address (dev-mode safety check).
+pub fn resolve_bind_addr(requested: &str, dev_mode: bool) -> String {
+    let has_token = std::env::var("CONVERGIO_AUTH_TOKEN")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    resolve_bind_addr_inner(requested, dev_mode, has_token)
+}
+
+fn resolve_bind_addr_inner(requested: &str, dev_mode: bool, has_token: bool) -> String {
+    if dev_mode && !has_token && !requested.starts_with("127.0.0.1") {
+        tracing::warn!(
+            "dev-mode without CONVERGIO_AUTH_TOKEN: binding to {requested} \
+             exposes an unauthenticated server"
+        );
+    }
+    requested.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_mode_no_token_respects_requested() {
+        let addr = resolve_bind_addr_inner("0.0.0.0:8420", true, false);
+        assert_eq!(addr, "0.0.0.0:8420");
+    }
+
+    #[test]
+    fn dev_mode_with_token_keeps_addr() {
+        let addr = resolve_bind_addr_inner("0.0.0.0:8420", true, true);
+        assert_eq!(addr, "0.0.0.0:8420");
+    }
+
+    #[test]
+    fn production_mode_keeps_addr() {
+        let addr = resolve_bind_addr_inner("0.0.0.0:8420", false, false);
+        assert_eq!(addr, "0.0.0.0:8420");
+    }
+
+    #[test]
+    fn localhost_in_dev_mode_safe() {
+        let addr = resolve_bind_addr_inner("127.0.0.1:8420", true, false);
+        assert_eq!(addr, "127.0.0.1:8420");
+    }
+}

--- a/daemon/crates/convergio-server/src/state.rs
+++ b/daemon/crates/convergio-server/src/state.rs
@@ -1,0 +1,109 @@
+//! Server state shared across all handlers.
+
+use convergio_db::pool::ConnPool;
+use convergio_telemetry::health::HealthRegistry;
+use convergio_telemetry::metrics::MetricsCollector;
+use convergio_types::config::ConvergioConfig;
+use std::sync::{Arc, RwLock};
+
+/// Shared state for the Axum router, injected into all handlers.
+#[derive(Clone)]
+pub struct ServerState {
+    pool: ConnPool,
+    pub config: Arc<RwLock<ConvergioConfig>>,
+    pub health: Arc<HealthRegistry>,
+    pub metrics: Arc<MetricsCollector>,
+    pub dev_mode: bool,
+}
+
+impl ServerState {
+    pub fn new(
+        pool: ConnPool,
+        config: Arc<RwLock<ConvergioConfig>>,
+        health: Arc<HealthRegistry>,
+        metrics: Arc<MetricsCollector>,
+        dev_mode: bool,
+    ) -> Self {
+        Self { pool, config, health, metrics, dev_mode }
+    }
+
+    /// Get a pooled database connection.
+    pub fn get_conn(
+        &self,
+    ) -> Result<r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>, r2d2::Error> {
+        self.pool.get()
+    }
+
+    pub fn pool(&self) -> &ConnPool {
+        &self.pool
+    }
+}
+
+/// Standardized API error response.
+#[derive(Debug)]
+pub enum ApiError {
+    BadRequest(String),
+    NotFound(String),
+    Forbidden(String),
+    RateLimited(String),
+    Conflict(String),
+    Internal(String),
+}
+
+impl ApiError {
+    pub fn bad_request(msg: impl Into<String>) -> Self {
+        Self::BadRequest(msg.into())
+    }
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        Self::NotFound(msg.into())
+    }
+    pub fn forbidden(msg: impl Into<String>) -> Self {
+        Self::Forbidden(msg.into())
+    }
+    pub fn rate_limited(msg: impl Into<String>) -> Self {
+        Self::RateLimited(msg.into())
+    }
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::Internal(msg.into())
+    }
+}
+
+impl axum::response::IntoResponse for ApiError {
+    fn into_response(self) -> axum::response::Response {
+        use axum::http::StatusCode;
+        use axum::Json;
+
+        let (status, message) = match self {
+            Self::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+            Self::NotFound(m) => (StatusCode::NOT_FOUND, m),
+            Self::Forbidden(m) => (StatusCode::FORBIDDEN, m),
+            Self::RateLimited(m) => (StatusCode::TOO_MANY_REQUESTS, m),
+            Self::Conflict(m) => (StatusCode::CONFLICT, m),
+            Self::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
+        };
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let body = serde_json::json!({
+            "error": {
+                "code": status.as_u16(),
+                "message": message,
+                "request_id": request_id,
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+            }
+        });
+        (status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_error_variants() {
+        let _ = ApiError::bad_request("test");
+        let _ = ApiError::not_found("test");
+        let _ = ApiError::forbidden("test");
+        let _ = ApiError::rate_limited("test");
+        let _ = ApiError::internal("test");
+    }
+}

--- a/daemon/crates/convergio-server/src/state.rs
+++ b/daemon/crates/convergio-server/src/state.rs
@@ -24,7 +24,13 @@ impl ServerState {
         metrics: Arc<MetricsCollector>,
         dev_mode: bool,
     ) -> Self {
-        Self { pool, config, health, metrics, dev_mode }
+        Self {
+            pool,
+            config,
+            health,
+            metrics,
+            dev_mode,
+        }
     }
 
     /// Get a pooled database connection.

--- a/daemon/crates/convergio-types/src/extension.rs
+++ b/daemon/crates/convergio-types/src/extension.rs
@@ -107,17 +107,46 @@ pub trait Extension: Send + Sync {
 
 /// Shared application context passed to extensions.
 ///
-/// Contains the database pool, event bus handle, and configuration.
-/// Extensions receive this at startup and when building routes.
-#[derive(Default)]
+/// Type-erased resource map: the server fills it with concrete types
+/// (ConnPool, config, health registry, …) and extensions retrieve
+/// them by type via `get::<T>()`.
 pub struct AppContext {
-    // Will hold: db pool, event bus sender, config, telemetry handle
-    // Filled in during Fase 2-3 when convergio-db and convergio-telemetry exist.
-    _placeholder: (),
+    resources: std::collections::HashMap<
+        std::any::TypeId,
+        std::sync::Arc<dyn std::any::Any + Send + Sync>,
+    >,
+}
+
+impl Default for AppContext {
+    fn default() -> Self {
+        Self {
+            resources: std::collections::HashMap::new(),
+        }
+    }
 }
 
 impl AppContext {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Insert a resource. Overwrites any previous value of the same type.
+    pub fn insert<T: 'static + Send + Sync>(&mut self, val: T) {
+        self.resources
+            .insert(std::any::TypeId::of::<T>(), std::sync::Arc::new(val));
+    }
+
+    /// Retrieve a shared reference to a resource by type.
+    pub fn get<T: 'static + Send + Sync>(&self) -> Option<&T> {
+        self.resources
+            .get(&std::any::TypeId::of::<T>())
+            .and_then(|v| v.downcast_ref())
+    }
+
+    /// Retrieve an `Arc<T>` clone for a resource.
+    pub fn get_arc<T: 'static + Send + Sync>(&self) -> Option<std::sync::Arc<T>> {
+        self.resources
+            .get(&std::any::TypeId::of::<T>())
+            .and_then(|v| v.clone().downcast().ok())
     }
 }

--- a/daemon/crates/convergio-types/src/extension.rs
+++ b/daemon/crates/convergio-types/src/extension.rs
@@ -110,19 +110,12 @@ pub trait Extension: Send + Sync {
 /// Type-erased resource map: the server fills it with concrete types
 /// (ConnPool, config, health registry, …) and extensions retrieve
 /// them by type via `get::<T>()`.
+#[derive(Default)]
 pub struct AppContext {
     resources: std::collections::HashMap<
         std::any::TypeId,
         std::sync::Arc<dyn std::any::Any + Send + Sync>,
     >,
-}
-
-impl Default for AppContext {
-    fn default() -> Self {
-        Self {
-            resources: std::collections::HashMap::new(),
-        }
-    }
 }
 
 impl AppContext {


### PR DESCRIPTION
## Summary
- Implement `convergio-server` crate: Axum routing shell with extension wiring
- 12 modules: config (load/validate/hot-reload), middleware (auth/audit/telemetry), rate limiter, router builder, server runner
- Upgrade `AppContext` in convergio-types from placeholder to typed resource map (`insert<T>/get<T>/get_arc<T>`)
- Auth: JWT + legacy Bearer + dev-mode + localhost bypass + RBAC
- Middleware stack: telemetry → compression → CORS → timeout → body limit → cache → auth → rate limit → audit
- Extensions compose freely via `Router<()>` with `tower::Extension<ServerState>` for DI

## Test plan
- [x] 34 unit tests pass (`cargo test -p convergio-server`)
- [x] 374 workspace tests pass (`cargo test --workspace`), 0 failures
- [x] `cargo check --workspace` clean
- [x] Config validation: port, role, timezone, quiet_hours, transport, discovery, max_tokens
- [x] Rate limiter: sliding window, per-client isolation
- [x] Router builds with zero extensions
- [x] Audit log insert logic verified against in-memory SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)