### PR TITLE
feat: fase 12 — convergio-prompts

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -536,6 +536,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-prompts"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "convergio-db",
+ "convergio-telemetry",
+ "convergio-types",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "convergio-security"
 version = "0.1.0"
 dependencies = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/convergio-kernel",
     "crates/convergio-org",
     "crates/convergio-voice",
+    "crates/convergio-prompts",
 ]
 
 [package]

--- a/daemon/crates/convergio-prompts/Cargo.toml
+++ b/daemon/crates/convergio-prompts/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "convergio-prompts"
+description = "Prompt management, template rendering, skill registry, A/B testing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
+convergio-telemetry = { path = "../convergio-telemetry" }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+rusqlite = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+axum = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/daemon/crates/convergio-prompts/src/ab_test.rs
+++ b/daemon/crates/convergio-prompts/src/ab_test.rs
@@ -69,7 +69,10 @@ pub fn get_test(conn: &Connection, test_id: &str) -> rusqlite::Result<AbTestResu
 }
 
 /// List all tests for a given task reference.
-pub fn list_tests_for_task(conn: &Connection, task_ref: &str) -> rusqlite::Result<Vec<AbTestResult>> {
+pub fn list_tests_for_task(
+    conn: &Connection,
+    task_ref: &str,
+) -> rusqlite::Result<Vec<AbTestResult>> {
     let mut stmt = conn.prepare(
         "SELECT test_id, prompt_a_id, prompt_b_id, task_ref, winner,
                 tokens_a, tokens_b, score_a, score_b, created_at

--- a/daemon/crates/convergio-prompts/src/ab_test.rs
+++ b/daemon/crates/convergio-prompts/src/ab_test.rs
@@ -1,0 +1,146 @@
+//! A/B testing for prompts — run the same task with different prompts, compare.
+
+use rusqlite::{params, Connection};
+
+use crate::types::AbTestResult;
+
+/// Create an A/B test entry.
+pub fn create_test(
+    conn: &Connection,
+    prompt_a_id: &str,
+    prompt_b_id: &str,
+    task_ref: &str,
+) -> rusqlite::Result<String> {
+    let test_id = format!("ab-{}", uuid_short());
+    conn.execute(
+        "INSERT INTO prompt_ab_tests (test_id, prompt_a_id, prompt_b_id, task_ref)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![test_id, prompt_a_id, prompt_b_id, task_ref],
+    )?;
+    Ok(test_id)
+}
+
+/// Record results for variant A.
+pub fn record_variant_a(
+    conn: &Connection,
+    test_id: &str,
+    tokens: u64,
+    score: f64,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE prompt_ab_tests SET tokens_a = ?1, score_a = ?2 WHERE test_id = ?3",
+        params![tokens, score, test_id],
+    )?;
+    Ok(())
+}
+
+/// Record results for variant B.
+pub fn record_variant_b(
+    conn: &Connection,
+    test_id: &str,
+    tokens: u64,
+    score: f64,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE prompt_ab_tests SET tokens_b = ?1, score_b = ?2 WHERE test_id = ?3",
+        params![tokens, score, test_id],
+    )?;
+    Ok(())
+}
+
+/// Declare a winner for the test.
+pub fn declare_winner(conn: &Connection, test_id: &str, winner: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE prompt_ab_tests SET winner = ?1 WHERE test_id = ?2",
+        params![winner, test_id],
+    )?;
+    Ok(())
+}
+
+/// Get a test result by ID.
+pub fn get_test(conn: &Connection, test_id: &str) -> rusqlite::Result<AbTestResult> {
+    conn.query_row(
+        "SELECT test_id, prompt_a_id, prompt_b_id, task_ref, winner,
+                tokens_a, tokens_b, score_a, score_b, created_at
+         FROM prompt_ab_tests WHERE test_id = ?1",
+        params![test_id],
+        row_to_ab_result,
+    )
+}
+
+/// List all tests for a given task reference.
+pub fn list_tests_for_task(conn: &Connection, task_ref: &str) -> rusqlite::Result<Vec<AbTestResult>> {
+    let mut stmt = conn.prepare(
+        "SELECT test_id, prompt_a_id, prompt_b_id, task_ref, winner,
+                tokens_a, tokens_b, score_a, score_b, created_at
+         FROM prompt_ab_tests WHERE task_ref = ?1 ORDER BY created_at DESC",
+    )?;
+    let rows = stmt.query_map(params![task_ref], row_to_ab_result)?;
+    rows.collect()
+}
+
+fn row_to_ab_result(row: &rusqlite::Row) -> rusqlite::Result<AbTestResult> {
+    Ok(AbTestResult {
+        test_id: row.get(0)?,
+        prompt_a_id: row.get(1)?,
+        prompt_b_id: row.get(2)?,
+        task_ref: row.get(3)?,
+        winner: row.get(4)?,
+        tokens_a: row.get::<_, i64>(5)? as u64,
+        tokens_b: row.get::<_, i64>(6)? as u64,
+        score_a: row.get(7)?,
+        score_b: row.get(8)?,
+        created_at: row.get(9)?,
+    })
+}
+
+fn uuid_short() -> String {
+    uuid::Uuid::new_v4().to_string()[..8].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
+            .unwrap();
+        // Insert prompt templates so FKs pass.
+        conn.execute(
+            "INSERT INTO prompt_templates (id, name, version, body) VALUES ('pa', 'a', 1, 'A')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO prompt_templates (id, name, version, body) VALUES ('pb', 'b', 1, 'B')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn full_ab_lifecycle() {
+        let conn = setup();
+        let tid = create_test(&conn, "pa", "pb", "task-42").unwrap();
+        record_variant_a(&conn, &tid, 500, 0.85).unwrap();
+        record_variant_b(&conn, &tid, 350, 0.90).unwrap();
+        declare_winner(&conn, &tid, "pb").unwrap();
+        let result = get_test(&conn, &tid).unwrap();
+        assert_eq!(result.winner.as_deref(), Some("pb"));
+        assert_eq!(result.tokens_a, 500);
+        assert_eq!(result.tokens_b, 350);
+    }
+
+    #[test]
+    fn list_tests_by_task() {
+        let conn = setup();
+        create_test(&conn, "pa", "pb", "task-99").unwrap();
+        create_test(&conn, "pa", "pb", "task-99").unwrap();
+        create_test(&conn, "pa", "pb", "task-other").unwrap();
+        let results = list_tests_for_task(&conn, "task-99").unwrap();
+        assert_eq!(results.len(), 2);
+    }
+}

--- a/daemon/crates/convergio-prompts/src/ext.rs
+++ b/daemon/crates/convergio-prompts/src/ext.rs
@@ -120,14 +120,8 @@ impl HealthCheck for PromptsExtension {
 
     fn check(&self) -> ComponentHealth {
         let (status, message) = match (self.prompt_count(), self.skill_count()) {
-            (Ok(p), Ok(s)) => (
-                Health::Ok,
-                Some(format!("{p} templates, {s} skills")),
-            ),
-            (Err(e), _) | (_, Err(e)) => (
-                Health::Degraded { reason: e.clone() },
-                None,
-            ),
+            (Ok(p), Ok(s)) => (Health::Ok, Some(format!("{p} templates, {s} skills"))),
+            (Err(e), _) | (_, Err(e)) => (Health::Degraded { reason: e.clone() }, None),
         };
         ComponentHealth {
             name: "prompts".into(),

--- a/daemon/crates/convergio-prompts/src/ext.rs
+++ b/daemon/crates/convergio-prompts/src/ext.rs
@@ -1,0 +1,148 @@
+//! Extension trait implementation for convergio-prompts.
+
+use convergio_db::pool::ConnPool;
+use convergio_telemetry::health::{ComponentHealth, HealthCheck};
+use convergio_telemetry::metrics::MetricSource;
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric, Migration};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+/// The prompts extension — prompt management and skill registry.
+pub struct PromptsExtension {
+    pool: ConnPool,
+}
+
+impl PromptsExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &ConnPool {
+        &self.pool
+    }
+
+    fn prompt_count(&self) -> Result<u64, String> {
+        let conn = self.pool.get().map_err(|e| e.to_string())?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM prompt_templates WHERE active = 1",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(count as u64)
+    }
+
+    fn skill_count(&self) -> Result<u64, String> {
+        let conn = self.pool.get().map_err(|e| e.to_string())?;
+        let count: i64 = conn
+            .query_row("SELECT count(*) FROM prompt_skills", [], |r| r.get(0))
+            .map_err(|e| e.to_string())?;
+        Ok(count as u64)
+    }
+}
+
+impl Extension for PromptsExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-prompts".into(),
+            description: "Prompt management, skill registry, A/B testing".into(),
+            version: "0.1.0".into(),
+            kind: ModuleKind::Platform,
+            provides: vec![
+                Capability {
+                    name: "prompt-templates".into(),
+                    version: "0.1.0".into(),
+                    description: "Versioned prompt templates with variable substitution".into(),
+                },
+                Capability {
+                    name: "skill-registry".into(),
+                    version: "0.1.0".into(),
+                    description: "Agent skill declaration and discovery".into(),
+                },
+                Capability {
+                    name: "prompt-ab-testing".into(),
+                    version: "0.1.0".into(),
+                    description: "A/B testing for prompt comparison".into(),
+                },
+            ],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn health(&self) -> Health {
+        match (self.prompt_count(), self.skill_count()) {
+            (Ok(_), Ok(_)) => Health::Ok,
+            (Err(e), _) | (_, Err(e)) => Health::Degraded {
+                reason: format!("prompts health check failed: {e}"),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let mut metrics = vec![];
+        if let Ok(n) = self.prompt_count() {
+            metrics.push(Metric {
+                name: "prompts_active_templates".into(),
+                value: n as f64,
+                labels: vec![],
+            });
+        }
+        if let Ok(n) = self.skill_count() {
+            metrics.push(Metric {
+                name: "prompts_registered_skills".into(),
+                value: n as f64,
+                labels: vec![],
+            });
+        }
+        metrics
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("Prompts extension started");
+        Ok(())
+    }
+
+    fn on_shutdown(&self) -> ExtResult<()> {
+        tracing::info!("Prompts extension shutdown");
+        Ok(())
+    }
+}
+
+impl HealthCheck for PromptsExtension {
+    fn name(&self) -> &str {
+        "prompts"
+    }
+
+    fn check(&self) -> ComponentHealth {
+        let (status, message) = match (self.prompt_count(), self.skill_count()) {
+            (Ok(p), Ok(s)) => (
+                Health::Ok,
+                Some(format!("{p} templates, {s} skills")),
+            ),
+            (Err(e), _) | (_, Err(e)) => (
+                Health::Degraded { reason: e.clone() },
+                None,
+            ),
+        };
+        ComponentHealth {
+            name: "prompts".into(),
+            status,
+            message,
+        }
+    }
+}
+
+impl MetricSource for PromptsExtension {
+    fn name(&self) -> &str {
+        "prompts"
+    }
+
+    fn collect(&self) -> Vec<Metric> {
+        self.metrics()
+    }
+}

--- a/daemon/crates/convergio-prompts/src/lib.rs
+++ b/daemon/crates/convergio-prompts/src/lib.rs
@@ -1,0 +1,16 @@
+//! convergio-prompts — Prompt management, skill registry, A/B testing.
+//!
+//! Provides versioned prompt templates with variable substitution,
+//! skill registry for agent capability discovery, token optimization,
+//! A/B testing, and immutable prompt injection at agent spawn.
+
+pub mod ab_test;
+pub mod ext;
+pub mod optimizer;
+pub mod render;
+pub mod routes;
+pub mod schema;
+pub mod skills;
+pub mod spawn;
+pub mod store;
+pub mod types;

--- a/daemon/crates/convergio-prompts/src/optimizer.rs
+++ b/daemon/crates/convergio-prompts/src/optimizer.rs
@@ -1,0 +1,104 @@
+//! Token usage tracking and prompt optimization suggestions.
+
+use rusqlite::{params, Connection};
+
+use crate::render::estimate_tokens;
+use crate::types::TokenStats;
+
+/// Record token usage for a prompt.
+pub fn record_usage(conn: &Connection, prompt_id: &str, tokens: u64) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO prompt_token_usage (prompt_id, tokens) VALUES (?1, ?2)",
+        params![prompt_id, tokens],
+    )?;
+    Ok(())
+}
+
+/// Get aggregated token stats for a prompt.
+pub fn get_stats(conn: &Connection, prompt_id: &str) -> rusqlite::Result<TokenStats> {
+    conn.query_row(
+        "SELECT prompt_id, COALESCE(SUM(tokens), 0), COUNT(*), COALESCE(AVG(tokens), 0)
+         FROM prompt_token_usage WHERE prompt_id = ?1
+         GROUP BY prompt_id",
+        params![prompt_id],
+        |row| {
+            Ok(TokenStats {
+                prompt_id: row.get(0)?,
+                total_tokens: row.get::<_, i64>(1)? as u64,
+                usage_count: row.get::<_, i64>(2)? as u64,
+                avg_tokens: row.get(3)?,
+            })
+        },
+    )
+}
+
+/// Analyze a prompt body and return optimization suggestions.
+pub fn suggest_optimizations(body: &str) -> Vec<String> {
+    let mut suggestions = Vec::new();
+    let token_count = estimate_tokens(body);
+
+    if token_count > 2000 {
+        suggestions.push(format!(
+            "Prompt is ~{token_count} tokens. Consider splitting into smaller templates."
+        ));
+    }
+    if body.lines().filter(|l| l.trim().is_empty()).count() > 5 {
+        suggestions.push("Excessive blank lines detected. Remove to save tokens.".into());
+    }
+    // Detect repeated phrases (simple heuristic).
+    let words: Vec<&str> = body.split_whitespace().collect();
+    if words.len() > 20 {
+        let unique = words.iter().collect::<std::collections::HashSet<_>>().len();
+        let ratio = unique as f64 / words.len() as f64;
+        if ratio < 0.5 {
+            suggestions.push(
+                "High word repetition detected. Consider using variables or references.".into(),
+            );
+        }
+    }
+    suggestions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
+            .unwrap();
+        // Insert a prompt so FK is satisfied.
+        conn.execute(
+            "INSERT INTO prompt_templates (id, name, version, body) VALUES ('pt-test', 'test', 1, 'body')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn record_and_get_stats() {
+        let conn = setup();
+        record_usage(&conn, "pt-test", 100).unwrap();
+        record_usage(&conn, "pt-test", 200).unwrap();
+        let stats = get_stats(&conn, "pt-test").unwrap();
+        assert_eq!(stats.total_tokens, 300);
+        assert_eq!(stats.usage_count, 2);
+        assert!((stats.avg_tokens - 150.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn suggest_on_long_prompt() {
+        let long_body = "word ".repeat(3000);
+        let suggestions = suggest_optimizations(&long_body);
+        assert!(!suggestions.is_empty());
+        assert!(suggestions[0].contains("tokens"));
+    }
+
+    #[test]
+    fn no_suggestions_for_short_prompt() {
+        let suggestions = suggest_optimizations("You are an engineer.");
+        assert!(suggestions.is_empty());
+    }
+}

--- a/daemon/crates/convergio-prompts/src/render.rs
+++ b/daemon/crates/convergio-prompts/src/render.rs
@@ -36,7 +36,7 @@ pub fn render(
 pub fn estimate_tokens(text: &str) -> u64 {
     let chars = text.len() as u64;
     // Rough approximation: 1 token ~ 4 characters.
-    (chars + 3) / 4
+    chars.div_ceil(4)
 }
 
 #[cfg(test)]

--- a/daemon/crates/convergio-prompts/src/render.rs
+++ b/daemon/crates/convergio-prompts/src/render.rs
@@ -1,0 +1,104 @@
+//! Template rendering — substitutes `{{variable}}` placeholders with values.
+
+use std::collections::HashMap;
+
+use crate::types::PromptVariable;
+
+/// Render a template body by substituting `{{var}}` placeholders.
+///
+/// Returns an error string if a required variable is missing and has no default.
+pub fn render(
+    body: &str,
+    variables: &[PromptVariable],
+    values: &HashMap<String, String>,
+) -> Result<String, String> {
+    let mut result = body.to_string();
+
+    for var in variables {
+        let placeholder = format!("{{{{{}}}}}", var.name);
+        if let Some(value) = values.get(&var.name) {
+            result = result.replace(&placeholder, value);
+        } else if let Some(ref default) = var.default_value {
+            result = result.replace(&placeholder, default);
+        } else if var.required {
+            return Err(format!("missing required variable: {}", var.name));
+        }
+        // Optional without default: leave placeholder removed.
+        else {
+            result = result.replace(&placeholder, "");
+        }
+    }
+    Ok(result)
+}
+
+/// Count the approximate number of tokens in a string.
+/// Uses a simple heuristic: ~4 chars per token for English text.
+pub fn estimate_tokens(text: &str) -> u64 {
+    let chars = text.len() as u64;
+    // Rough approximation: 1 token ~ 4 characters.
+    (chars + 3) / 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn var(name: &str, required: bool, default: Option<&str>) -> PromptVariable {
+        PromptVariable {
+            name: name.into(),
+            description: String::new(),
+            required,
+            default_value: default.map(String::from),
+        }
+    }
+
+    #[test]
+    fn basic_substitution() {
+        let body = "You are {{role}} at {{org}}.";
+        let vars = vec![var("role", true, None), var("org", true, None)];
+        let mut values = HashMap::new();
+        values.insert("role".into(), "engineer".into());
+        values.insert("org".into(), "Convergio".into());
+        let result = render(body, &vars, &values).unwrap();
+        assert_eq!(result, "You are engineer at Convergio.");
+    }
+
+    #[test]
+    fn default_value_used() {
+        let body = "Hello {{name}}, welcome to {{place}}.";
+        let vars = vec![
+            var("name", true, None),
+            var("place", false, Some("the system")),
+        ];
+        let mut values = HashMap::new();
+        values.insert("name".into(), "Elena".into());
+        let result = render(body, &vars, &values).unwrap();
+        assert_eq!(result, "Hello Elena, welcome to the system.");
+    }
+
+    #[test]
+    fn missing_required_fails() {
+        let body = "{{agent}} does {{task}}";
+        let vars = vec![var("agent", true, None), var("task", true, None)];
+        let values = HashMap::new();
+        let err = render(body, &vars, &values).unwrap_err();
+        assert!(err.contains("agent"));
+    }
+
+    #[test]
+    fn optional_without_default_removed() {
+        let body = "prefix{{opt}}suffix";
+        let vars = vec![var("opt", false, None)];
+        let values = HashMap::new();
+        let result = render(body, &vars, &values).unwrap();
+        assert_eq!(result, "prefixsuffix");
+    }
+
+    #[test]
+    fn estimate_tokens_reasonable() {
+        let text = "This is a test sentence with about ten tokens.";
+        let tokens = estimate_tokens(text);
+        // ~47 chars / 4 = ~12, should be in 10-15 range.
+        assert!(tokens >= 8 && tokens <= 20, "got {tokens}");
+    }
+}

--- a/daemon/crates/convergio-prompts/src/routes.rs
+++ b/daemon/crates/convergio-prompts/src/routes.rs
@@ -26,25 +26,20 @@ async fn create_prompt(
     State(pool): State<ConnPool>,
     Json(input): Json<PromptInput>,
 ) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let id = crate::store::create_prompt(&conn, &input).map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let id = crate::store::create_prompt(&conn, &input)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok::<_, (StatusCode, String)>((StatusCode::CREATED, Json(serde_json::json!({ "id": id }))))
 }
 
-async fn get_prompt(
-    State(pool): State<ConnPool>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let prompt = crate::store::get_prompt(&conn, &id).map_err(|_| {
-        (StatusCode::NOT_FOUND, "prompt not found".to_string())
-    })?;
+async fn get_prompt(State(pool): State<ConnPool>, Path(id): Path<String>) -> impl IntoResponse {
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let prompt = crate::store::get_prompt(&conn, &id)
+        .map_err(|_| (StatusCode::NOT_FOUND, "prompt not found".to_string()))?;
     Ok::<_, (StatusCode, String)>(Json(prompt))
 }
 
@@ -52,12 +47,11 @@ async fn get_active_prompt(
     State(pool): State<ConnPool>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let prompt = crate::store::get_active_prompt(&conn, &name).map_err(|_| {
-        (StatusCode::NOT_FOUND, "no active prompt".to_string())
-    })?;
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let prompt = crate::store::get_active_prompt(&conn, &name)
+        .map_err(|_| (StatusCode::NOT_FOUND, "no active prompt".to_string()))?;
     Ok::<_, (StatusCode, String)>(Json(prompt))
 }
 
@@ -65,25 +59,20 @@ async fn list_prompts(
     State(pool): State<ConnPool>,
     Query(query): Query<PromptQuery>,
 ) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let prompts = crate::store::list_prompts(&conn, &query).map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let prompts = crate::store::list_prompts(&conn, &query)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok::<_, (StatusCode, String)>(Json(prompts))
 }
 
-async fn delete_prompt(
-    State(pool): State<ConnPool>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let deleted = crate::store::delete_prompt(&conn, &id).map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
+async fn delete_prompt(State(pool): State<ConnPool>, Path(id): Path<String>) -> impl IntoResponse {
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let deleted = crate::store::delete_prompt(&conn, &id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     if deleted {
         Ok::<_, (StatusCode, String)>(StatusCode::NO_CONTENT)
     } else {
@@ -95,12 +84,11 @@ async fn register_skill(
     State(pool): State<ConnPool>,
     Json(input): Json<SkillInput>,
 ) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let id = crate::skills::register_skill(&conn, &input).map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let id = crate::skills::register_skill(&conn, &input)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok::<_, (StatusCode, String)>((StatusCode::CREATED, Json(serde_json::json!({ "id": id }))))
 }
 
@@ -108,12 +96,11 @@ async fn search_skills(
     State(pool): State<ConnPool>,
     Query(query): Query<SkillQuery>,
 ) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let skills = crate::skills::search_skills(&conn, &query).map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let skills = crate::skills::search_skills(&conn, &query)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok::<_, (StatusCode, String)>(Json(skills))
 }
 
@@ -121,11 +108,10 @@ async fn search_skills_query(
     State(pool): State<ConnPool>,
     Query(query): Query<SkillQuery>,
 ) -> impl IntoResponse {
-    let conn = pool.get().map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
-    let skills = crate::skills::search_skills(&conn, &query).map_err(|e| {
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-    })?;
+    let conn = pool
+        .get()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let skills = crate::skills::search_skills(&conn, &query)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok::<_, (StatusCode, String)>(Json(skills))
 }

--- a/daemon/crates/convergio-prompts/src/routes.rs
+++ b/daemon/crates/convergio-prompts/src/routes.rs
@@ -1,0 +1,131 @@
+//! HTTP routes for prompt management and skill registry.
+//!
+//! Mounts under `/api/prompts` and `/api/skills`.
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_db::pool::ConnPool;
+
+use crate::types::{PromptInput, PromptQuery, SkillInput, SkillQuery};
+
+/// Build all prompt + skill routes.
+pub fn routes(pool: ConnPool) -> Router {
+    Router::new()
+        .route("/api/prompts", post(create_prompt).get(list_prompts))
+        .route("/api/prompts/{id}", get(get_prompt).delete(delete_prompt))
+        .route("/api/prompts/active/{name}", get(get_active_prompt))
+        .route("/api/skills", post(register_skill).get(search_skills))
+        .route("/api/skills/search", get(search_skills_query))
+        .with_state(pool)
+}
+
+async fn create_prompt(
+    State(pool): State<ConnPool>,
+    Json(input): Json<PromptInput>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let id = crate::store::create_prompt(&conn, &input).map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>((StatusCode::CREATED, Json(serde_json::json!({ "id": id }))))
+}
+
+async fn get_prompt(
+    State(pool): State<ConnPool>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let prompt = crate::store::get_prompt(&conn, &id).map_err(|_| {
+        (StatusCode::NOT_FOUND, "prompt not found".to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>(Json(prompt))
+}
+
+async fn get_active_prompt(
+    State(pool): State<ConnPool>,
+    Path(name): Path<String>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let prompt = crate::store::get_active_prompt(&conn, &name).map_err(|_| {
+        (StatusCode::NOT_FOUND, "no active prompt".to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>(Json(prompt))
+}
+
+async fn list_prompts(
+    State(pool): State<ConnPool>,
+    Query(query): Query<PromptQuery>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let prompts = crate::store::list_prompts(&conn, &query).map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>(Json(prompts))
+}
+
+async fn delete_prompt(
+    State(pool): State<ConnPool>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let deleted = crate::store::delete_prompt(&conn, &id).map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    if deleted {
+        Ok::<_, (StatusCode, String)>(StatusCode::NO_CONTENT)
+    } else {
+        Err((StatusCode::NOT_FOUND, "prompt not found".to_string()))
+    }
+}
+
+async fn register_skill(
+    State(pool): State<ConnPool>,
+    Json(input): Json<SkillInput>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let id = crate::skills::register_skill(&conn, &input).map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>((StatusCode::CREATED, Json(serde_json::json!({ "id": id }))))
+}
+
+async fn search_skills(
+    State(pool): State<ConnPool>,
+    Query(query): Query<SkillQuery>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let skills = crate::skills::search_skills(&conn, &query).map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>(Json(skills))
+}
+
+async fn search_skills_query(
+    State(pool): State<ConnPool>,
+    Query(query): Query<SkillQuery>,
+) -> impl IntoResponse {
+    let conn = pool.get().map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    let skills = crate::skills::search_skills(&conn, &query).map_err(|e| {
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+    Ok::<_, (StatusCode, String)>(Json(skills))
+}

--- a/daemon/crates/convergio-prompts/src/schema.rs
+++ b/daemon/crates/convergio-prompts/src/schema.rs
@@ -94,8 +94,7 @@ mod tests {
     fn migrations_apply_cleanly() {
         let conn = Connection::open_in_memory().unwrap();
         convergio_db::migration::ensure_registry(&conn).unwrap();
-        let applied =
-            convergio_db::migration::apply_migrations(&conn, "prompts", &migrations());
+        let applied = convergio_db::migration::apply_migrations(&conn, "prompts", &migrations());
         assert_eq!(applied.unwrap(), 3);
     }
 
@@ -104,8 +103,7 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         convergio_db::migration::ensure_registry(&conn).unwrap();
         convergio_db::migration::apply_migrations(&conn, "prompts", &migrations()).unwrap();
-        let applied =
-            convergio_db::migration::apply_migrations(&conn, "prompts", &migrations());
+        let applied = convergio_db::migration::apply_migrations(&conn, "prompts", &migrations());
         assert_eq!(applied.unwrap(), 0);
     }
 }

--- a/daemon/crates/convergio-prompts/src/schema.rs
+++ b/daemon/crates/convergio-prompts/src/schema.rs
@@ -1,0 +1,111 @@
+//! Database migrations for prompt management and skill registry.
+
+use convergio_types::extension::Migration;
+
+pub fn migrations() -> Vec<Migration> {
+    vec![
+        Migration {
+            version: 1,
+            description: "prompt templates and skill registry",
+            up: "
+CREATE TABLE IF NOT EXISTS prompt_templates (
+    id          TEXT PRIMARY KEY NOT NULL,
+    name        TEXT NOT NULL,
+    version     INTEGER NOT NULL DEFAULT 1,
+    body        TEXT NOT NULL,
+    variables   TEXT NOT NULL DEFAULT '[]',
+    category    TEXT,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
+    updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
+    UNIQUE(name, version)
+);
+CREATE INDEX IF NOT EXISTS idx_prompt_name ON prompt_templates(name, active);
+CREATE INDEX IF NOT EXISTS idx_prompt_category ON prompt_templates(category);
+
+CREATE TABLE IF NOT EXISTS prompt_skills (
+    id              TEXT PRIMARY KEY NOT NULL,
+    agent           TEXT NOT NULL,
+    host            TEXT NOT NULL,
+    capability      TEXT NOT NULL,
+    confidence      REAL NOT NULL DEFAULT 0.5,
+    description     TEXT NOT NULL DEFAULT '',
+    last_used       TEXT,
+    registered_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
+    UNIQUE(agent, host, capability)
+);
+CREATE INDEX IF NOT EXISTS idx_skill_cap ON prompt_skills(capability, confidence DESC);
+CREATE INDEX IF NOT EXISTS idx_skill_agent ON prompt_skills(agent);
+",
+        },
+        Migration {
+            version: 2,
+            description: "A/B testing and token tracking",
+            up: "
+CREATE TABLE IF NOT EXISTS prompt_ab_tests (
+    test_id     TEXT PRIMARY KEY NOT NULL,
+    prompt_a_id TEXT NOT NULL REFERENCES prompt_templates(id),
+    prompt_b_id TEXT NOT NULL REFERENCES prompt_templates(id),
+    task_ref    TEXT NOT NULL,
+    winner      TEXT,
+    tokens_a    INTEGER NOT NULL DEFAULT 0,
+    tokens_b    INTEGER NOT NULL DEFAULT 0,
+    score_a     REAL NOT NULL DEFAULT 0.0,
+    score_b     REAL NOT NULL DEFAULT 0.0,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ab_task ON prompt_ab_tests(task_ref);
+
+CREATE TABLE IF NOT EXISTS prompt_token_usage (
+    id          INTEGER PRIMARY KEY,
+    prompt_id   TEXT NOT NULL REFERENCES prompt_templates(id),
+    tokens      INTEGER NOT NULL,
+    recorded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_token_prompt ON prompt_token_usage(prompt_id);
+",
+        },
+        Migration {
+            version: 3,
+            description: "spawned prompt snapshots for immutability",
+            up: "
+CREATE TABLE IF NOT EXISTS prompt_spawned (
+    spawn_id            TEXT PRIMARY KEY NOT NULL,
+    agent               TEXT NOT NULL,
+    task_id             TEXT NOT NULL,
+    rendered_body       TEXT NOT NULL,
+    prompt_template_id  TEXT NOT NULL,
+    prompt_version      INTEGER NOT NULL,
+    spawned_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_spawned_agent ON prompt_spawned(agent, task_id);
+CREATE INDEX IF NOT EXISTS idx_spawned_task ON prompt_spawned(task_id);
+",
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn migrations_apply_cleanly() {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        let applied =
+            convergio_db::migration::apply_migrations(&conn, "prompts", &migrations());
+        assert_eq!(applied.unwrap(), 3);
+    }
+
+    #[test]
+    fn migrations_are_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "prompts", &migrations()).unwrap();
+        let applied =
+            convergio_db::migration::apply_migrations(&conn, "prompts", &migrations());
+        assert_eq!(applied.unwrap(), 0);
+    }
+}

--- a/daemon/crates/convergio-prompts/src/skills.rs
+++ b/daemon/crates/convergio-prompts/src/skills.rs
@@ -1,0 +1,215 @@
+//! Skill registry — agents declare capabilities, system does discovery.
+
+use rusqlite::{params, Connection};
+
+use crate::types::{Skill, SkillInput, SkillQuery};
+
+/// Register or update a skill for an agent.
+pub fn register_skill(conn: &Connection, input: &SkillInput) -> rusqlite::Result<String> {
+    let id = format!("sk-{}", &uuid_short());
+    conn.execute(
+        "INSERT INTO prompt_skills (id, agent, host, capability, confidence, description)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(agent, host, capability)
+         DO UPDATE SET confidence = excluded.confidence,
+                       description = excluded.description,
+                       last_used = strftime('%Y-%m-%dT%H:%M:%f','now')",
+        params![id, input.agent, input.host, input.capability, input.confidence, input.description],
+    )?;
+    // Return the actual ID (may be the existing one on conflict).
+    let actual_id: String = conn.query_row(
+        "SELECT id FROM prompt_skills WHERE agent = ?1 AND host = ?2 AND capability = ?3",
+        params![input.agent, input.host, input.capability],
+        |r| r.get(0),
+    )?;
+    Ok(actual_id)
+}
+
+/// Remove all skills for an agent on a host.
+pub fn unregister_agent(conn: &Connection, agent: &str, host: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM prompt_skills WHERE agent = ?1 AND host = ?2",
+        params![agent, host],
+    )
+}
+
+/// Search skills with optional filters.
+pub fn search_skills(conn: &Connection, query: &SkillQuery) -> rusqlite::Result<Vec<Skill>> {
+    let mut sql = String::from(
+        "SELECT id, agent, host, capability, confidence, description, last_used, registered_at
+         FROM prompt_skills WHERE 1=1",
+    );
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
+
+    if let Some(ref cap) = query.capability {
+        sql.push_str(&format!(" AND capability = ?{}", param_values.len() + 1));
+        param_values.push(Box::new(cap.clone()));
+    }
+    if let Some(ref agent) = query.agent {
+        sql.push_str(&format!(" AND agent = ?{}", param_values.len() + 1));
+        param_values.push(Box::new(agent.clone()));
+    }
+    if let Some(min_conf) = query.min_confidence {
+        sql.push_str(&format!(" AND confidence >= ?{}", param_values.len() + 1));
+        param_values.push(Box::new(min_conf));
+    }
+    sql.push_str(" ORDER BY capability, confidence DESC");
+
+    let refs: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|b| b.as_ref()).collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(refs.as_slice(), row_to_skill)?;
+    rows.collect()
+}
+
+/// Find the best agent for a given capability (highest confidence).
+pub fn find_best_agent(
+    conn: &Connection,
+    capability: &str,
+) -> rusqlite::Result<Option<Skill>> {
+    let result = conn.query_row(
+        "SELECT id, agent, host, capability, confidence, description, last_used, registered_at
+         FROM prompt_skills WHERE capability = ?1 ORDER BY confidence DESC LIMIT 1",
+        params![capability],
+        row_to_skill,
+    );
+    match result {
+        Ok(s) => Ok(Some(s)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Update the last_used timestamp for a skill.
+pub fn touch_skill(conn: &Connection, agent: &str, host: &str, capability: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE prompt_skills SET last_used = strftime('%Y-%m-%dT%H:%M:%f','now')
+         WHERE agent = ?1 AND host = ?2 AND capability = ?3",
+        params![agent, host, capability],
+    )?;
+    Ok(())
+}
+
+/// Update confidence via weighted moving average (80% old + 20% rating).
+pub fn update_confidence(
+    conn: &Connection,
+    agent: &str,
+    host: &str,
+    capability: &str,
+    rating: f64,
+) -> rusqlite::Result<()> {
+    let current: f64 = conn
+        .query_row(
+            "SELECT confidence FROM prompt_skills WHERE agent=?1 AND host=?2 AND capability=?3",
+            params![agent, host, capability],
+            |r| r.get(0),
+        )
+        .unwrap_or(0.5);
+    let updated = current * 0.8 + rating * 0.2;
+    conn.execute(
+        "UPDATE prompt_skills SET confidence = ?1 WHERE agent=?2 AND host=?3 AND capability=?4",
+        params![updated, agent, host, capability],
+    )?;
+    Ok(())
+}
+
+fn row_to_skill(row: &rusqlite::Row) -> rusqlite::Result<Skill> {
+    Ok(Skill {
+        id: row.get(0)?,
+        agent: row.get(1)?,
+        host: row.get(2)?,
+        capability: row.get(3)?,
+        confidence: row.get(4)?,
+        description: row.get(5)?,
+        last_used: row.get(6)?,
+        registered_at: row.get(7)?,
+    })
+}
+
+fn uuid_short() -> String {
+    uuid::Uuid::new_v4().to_string()[..8].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
+            .unwrap();
+        conn
+    }
+
+    #[test]
+    fn register_and_search() {
+        let conn = setup();
+        register_skill(&conn, &SkillInput {
+            agent: "elena".into(), host: "m5max".into(),
+            capability: "legal-review".into(), confidence: 0.95,
+            description: "Contract clause analysis".into(),
+        }).unwrap();
+        register_skill(&conn, &SkillInput {
+            agent: "baccio".into(), host: "m1pro".into(),
+            capability: "code-review".into(), confidence: 0.9,
+            description: "Rust code review".into(),
+        }).unwrap();
+        let legal = search_skills(&conn, &SkillQuery {
+            capability: Some("legal-review".into()),
+            ..Default::default()
+        }).unwrap();
+        assert_eq!(legal.len(), 1);
+        assert_eq!(legal[0].agent, "elena");
+    }
+
+    #[test]
+    fn find_best_agent_by_capability() {
+        let conn = setup();
+        register_skill(&conn, &SkillInput {
+            agent: "junior".into(), host: "h1".into(),
+            capability: "testing".into(), confidence: 0.4,
+            description: "Basic testing".into(),
+        }).unwrap();
+        register_skill(&conn, &SkillInput {
+            agent: "senior".into(), host: "h1".into(),
+            capability: "testing".into(), confidence: 0.95,
+            description: "Deep testing".into(),
+        }).unwrap();
+        let best = find_best_agent(&conn, "testing").unwrap().unwrap();
+        assert_eq!(best.agent, "senior");
+    }
+
+    #[test]
+    fn confidence_update_weighted() {
+        let conn = setup();
+        register_skill(&conn, &SkillInput {
+            agent: "worker".into(), host: "h".into(),
+            capability: "deploy".into(), confidence: 0.5,
+            description: "Deployment".into(),
+        }).unwrap();
+        // 0.8 * 0.5 + 0.2 * 1.0 = 0.6
+        update_confidence(&conn, "worker", "h", "deploy", 1.0).unwrap();
+        let skills = search_skills(&conn, &SkillQuery {
+            agent: Some("worker".into()), ..Default::default()
+        }).unwrap();
+        let conf = skills[0].confidence;
+        assert!((conf - 0.6).abs() < 0.01, "expected ~0.6, got {conf}");
+    }
+
+    #[test]
+    fn unregister_removes_all() {
+        let conn = setup();
+        register_skill(&conn, &SkillInput {
+            agent: "temp".into(), host: "h".into(),
+            capability: "s1".into(), confidence: 0.5,
+            description: "Skill 1".into(),
+        }).unwrap();
+        register_skill(&conn, &SkillInput {
+            agent: "temp".into(), host: "h".into(),
+            capability: "s2".into(), confidence: 0.5,
+            description: "Skill 2".into(),
+        }).unwrap();
+        let removed = unregister_agent(&conn, "temp", "h").unwrap();
+        assert_eq!(removed, 2);
+    }
+}

--- a/daemon/crates/convergio-prompts/src/skills.rs
+++ b/daemon/crates/convergio-prompts/src/skills.rs
@@ -14,7 +14,14 @@ pub fn register_skill(conn: &Connection, input: &SkillInput) -> rusqlite::Result
          DO UPDATE SET confidence = excluded.confidence,
                        description = excluded.description,
                        last_used = strftime('%Y-%m-%dT%H:%M:%f','now')",
-        params![id, input.agent, input.host, input.capability, input.confidence, input.description],
+        params![
+            id,
+            input.agent,
+            input.host,
+            input.capability,
+            input.confidence,
+            input.description
+        ],
     )?;
     // Return the actual ID (may be the existing one on conflict).
     let actual_id: String = conn.query_row(
@@ -62,10 +69,7 @@ pub fn search_skills(conn: &Connection, query: &SkillQuery) -> rusqlite::Result<
 }
 
 /// Find the best agent for a given capability (highest confidence).
-pub fn find_best_agent(
-    conn: &Connection,
-    capability: &str,
-) -> rusqlite::Result<Option<Skill>> {
+pub fn find_best_agent(conn: &Connection, capability: &str) -> rusqlite::Result<Option<Skill>> {
     let result = conn.query_row(
         "SELECT id, agent, host, capability, confidence, description, last_used, registered_at
          FROM prompt_skills WHERE capability = ?1 ORDER BY confidence DESC LIMIT 1",
@@ -80,7 +84,12 @@ pub fn find_best_agent(
 }
 
 /// Update the last_used timestamp for a skill.
-pub fn touch_skill(conn: &Connection, agent: &str, host: &str, capability: &str) -> rusqlite::Result<()> {
+pub fn touch_skill(
+    conn: &Connection,
+    agent: &str,
+    host: &str,
+    capability: &str,
+) -> rusqlite::Result<()> {
     conn.execute(
         "UPDATE prompt_skills SET last_used = strftime('%Y-%m-%dT%H:%M:%f','now')
          WHERE agent = ?1 AND host = ?2 AND capability = ?3",
@@ -130,86 +139,5 @@ fn uuid_short() -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn setup() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        convergio_db::migration::ensure_registry(&conn).unwrap();
-        convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
-            .unwrap();
-        conn
-    }
-
-    #[test]
-    fn register_and_search() {
-        let conn = setup();
-        register_skill(&conn, &SkillInput {
-            agent: "elena".into(), host: "m5max".into(),
-            capability: "legal-review".into(), confidence: 0.95,
-            description: "Contract clause analysis".into(),
-        }).unwrap();
-        register_skill(&conn, &SkillInput {
-            agent: "baccio".into(), host: "m1pro".into(),
-            capability: "code-review".into(), confidence: 0.9,
-            description: "Rust code review".into(),
-        }).unwrap();
-        let legal = search_skills(&conn, &SkillQuery {
-            capability: Some("legal-review".into()),
-            ..Default::default()
-        }).unwrap();
-        assert_eq!(legal.len(), 1);
-        assert_eq!(legal[0].agent, "elena");
-    }
-
-    #[test]
-    fn find_best_agent_by_capability() {
-        let conn = setup();
-        register_skill(&conn, &SkillInput {
-            agent: "junior".into(), host: "h1".into(),
-            capability: "testing".into(), confidence: 0.4,
-            description: "Basic testing".into(),
-        }).unwrap();
-        register_skill(&conn, &SkillInput {
-            agent: "senior".into(), host: "h1".into(),
-            capability: "testing".into(), confidence: 0.95,
-            description: "Deep testing".into(),
-        }).unwrap();
-        let best = find_best_agent(&conn, "testing").unwrap().unwrap();
-        assert_eq!(best.agent, "senior");
-    }
-
-    #[test]
-    fn confidence_update_weighted() {
-        let conn = setup();
-        register_skill(&conn, &SkillInput {
-            agent: "worker".into(), host: "h".into(),
-            capability: "deploy".into(), confidence: 0.5,
-            description: "Deployment".into(),
-        }).unwrap();
-        // 0.8 * 0.5 + 0.2 * 1.0 = 0.6
-        update_confidence(&conn, "worker", "h", "deploy", 1.0).unwrap();
-        let skills = search_skills(&conn, &SkillQuery {
-            agent: Some("worker".into()), ..Default::default()
-        }).unwrap();
-        let conf = skills[0].confidence;
-        assert!((conf - 0.6).abs() < 0.01, "expected ~0.6, got {conf}");
-    }
-
-    #[test]
-    fn unregister_removes_all() {
-        let conn = setup();
-        register_skill(&conn, &SkillInput {
-            agent: "temp".into(), host: "h".into(),
-            capability: "s1".into(), confidence: 0.5,
-            description: "Skill 1".into(),
-        }).unwrap();
-        register_skill(&conn, &SkillInput {
-            agent: "temp".into(), host: "h".into(),
-            capability: "s2".into(), confidence: 0.5,
-            description: "Skill 2".into(),
-        }).unwrap();
-        let removed = unregister_agent(&conn, "temp", "h").unwrap();
-        assert_eq!(removed, 2);
-    }
-}
+#[path = "skills_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-prompts/src/skills_tests.rs
+++ b/daemon/crates/convergio-prompts/src/skills_tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+use rusqlite::Connection;
+
+fn setup() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    convergio_db::migration::ensure_registry(&conn).unwrap();
+    convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
+        .unwrap();
+    conn
+}
+
+#[test]
+fn register_and_search() {
+    let conn = setup();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "elena".into(),
+            host: "m5max".into(),
+            capability: "legal-review".into(),
+            confidence: 0.95,
+            description: "Contract clause analysis".into(),
+        },
+    )
+    .unwrap();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "baccio".into(),
+            host: "m1pro".into(),
+            capability: "code-review".into(),
+            confidence: 0.9,
+            description: "Rust code review".into(),
+        },
+    )
+    .unwrap();
+    let legal = search_skills(
+        &conn,
+        &SkillQuery {
+            capability: Some("legal-review".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(legal.len(), 1);
+    assert_eq!(legal[0].agent, "elena");
+}
+
+#[test]
+fn find_best_agent_by_capability() {
+    let conn = setup();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "junior".into(),
+            host: "h1".into(),
+            capability: "testing".into(),
+            confidence: 0.4,
+            description: "Basic testing".into(),
+        },
+    )
+    .unwrap();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "senior".into(),
+            host: "h1".into(),
+            capability: "testing".into(),
+            confidence: 0.95,
+            description: "Deep testing".into(),
+        },
+    )
+    .unwrap();
+    let best = find_best_agent(&conn, "testing").unwrap().unwrap();
+    assert_eq!(best.agent, "senior");
+}
+
+#[test]
+fn confidence_update_weighted() {
+    let conn = setup();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "worker".into(),
+            host: "h".into(),
+            capability: "deploy".into(),
+            confidence: 0.5,
+            description: "Deployment".into(),
+        },
+    )
+    .unwrap();
+    // 0.8 * 0.5 + 0.2 * 1.0 = 0.6
+    update_confidence(&conn, "worker", "h", "deploy", 1.0).unwrap();
+    let skills = search_skills(
+        &conn,
+        &SkillQuery {
+            agent: Some("worker".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let conf = skills[0].confidence;
+    assert!((conf - 0.6).abs() < 0.01, "expected ~0.6, got {conf}");
+}
+
+#[test]
+fn unregister_removes_all() {
+    let conn = setup();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "temp".into(),
+            host: "h".into(),
+            capability: "s1".into(),
+            confidence: 0.5,
+            description: "Skill 1".into(),
+        },
+    )
+    .unwrap();
+    register_skill(
+        &conn,
+        &SkillInput {
+            agent: "temp".into(),
+            host: "h".into(),
+            capability: "s2".into(),
+            confidence: 0.5,
+            description: "Skill 2".into(),
+        },
+    )
+    .unwrap();
+    let removed = unregister_agent(&conn, "temp", "h").unwrap();
+    assert_eq!(removed, 2);
+}

--- a/daemon/crates/convergio-prompts/src/spawn.rs
+++ b/daemon/crates/convergio-prompts/src/spawn.rs
@@ -76,7 +76,10 @@ pub fn get_spawned(conn: &Connection, spawn_id: &str) -> rusqlite::Result<Spawne
 }
 
 /// Get all spawned prompts for a task (useful for audit).
-pub fn get_spawned_for_task(conn: &Connection, task_id: &str) -> rusqlite::Result<Vec<SpawnedPrompt>> {
+pub fn get_spawned_for_task(
+    conn: &Connection,
+    task_id: &str,
+) -> rusqlite::Result<Vec<SpawnedPrompt>> {
     let mut stmt = conn.prepare(
         "SELECT spawn_id, agent, task_id, rendered_body, prompt_template_id, prompt_version, spawned_at
          FROM prompt_spawned WHERE task_id = ?1 ORDER BY spawned_at",
@@ -115,21 +118,29 @@ mod tests {
     #[test]
     fn spawn_freezes_prompt() {
         let conn = setup();
-        store::create_prompt(&conn, &PromptInput {
-            name: "agent-system".into(),
-            body: "You are {{role}}. Rules: {{rules}}".into(),
-            variables: vec![
-                PromptVariable {
-                    name: "role".into(), description: "Agent role".into(),
-                    required: true, default_value: None,
-                },
-                PromptVariable {
-                    name: "rules".into(), description: "Rules".into(),
-                    required: true, default_value: None,
-                },
-            ],
-            category: Some("system".into()),
-        }).unwrap();
+        store::create_prompt(
+            &conn,
+            &PromptInput {
+                name: "agent-system".into(),
+                body: "You are {{role}}. Rules: {{rules}}".into(),
+                variables: vec![
+                    PromptVariable {
+                        name: "role".into(),
+                        description: "Agent role".into(),
+                        required: true,
+                        default_value: None,
+                    },
+                    PromptVariable {
+                        name: "rules".into(),
+                        description: "Rules".into(),
+                        required: true,
+                        default_value: None,
+                    },
+                ],
+                category: Some("system".into()),
+            },
+        )
+        .unwrap();
 
         let mut values = HashMap::new();
         values.insert("role".into(), "legal reviewer".into());
@@ -140,12 +151,16 @@ mod tests {
         assert!(spawned.rendered_body.contains("conventional commits"));
 
         // Updating the template does NOT affect the frozen spawn.
-        store::create_prompt(&conn, &PromptInput {
-            name: "agent-system".into(),
-            body: "CHANGED template".into(),
-            variables: vec![],
-            category: Some("system".into()),
-        }).unwrap();
+        store::create_prompt(
+            &conn,
+            &PromptInput {
+                name: "agent-system".into(),
+                body: "CHANGED template".into(),
+                variables: vec![],
+                category: Some("system".into()),
+            },
+        )
+        .unwrap();
 
         let frozen = get_spawned(&conn, &spawned.spawn_id).unwrap();
         assert!(frozen.rendered_body.contains("legal reviewer"));
@@ -155,15 +170,21 @@ mod tests {
     #[test]
     fn get_spawned_for_task_returns_all() {
         let conn = setup();
-        store::create_prompt(&conn, &PromptInput {
-            name: "simple".into(),
-            body: "Do {{task}}".into(),
-            variables: vec![PromptVariable {
-                name: "task".into(), description: "Task".into(),
-                required: true, default_value: None,
-            }],
-            category: None,
-        }).unwrap();
+        store::create_prompt(
+            &conn,
+            &PromptInput {
+                name: "simple".into(),
+                body: "Do {{task}}".into(),
+                variables: vec![PromptVariable {
+                    name: "task".into(),
+                    description: "Task".into(),
+                    required: true,
+                    default_value: None,
+                }],
+                category: None,
+            },
+        )
+        .unwrap();
 
         let mut v1 = HashMap::new();
         v1.insert("task".into(), "review".into());

--- a/daemon/crates/convergio-prompts/src/spawn.rs
+++ b/daemon/crates/convergio-prompts/src/spawn.rs
@@ -1,0 +1,179 @@
+//! Prompt injection at spawn — frozen, immutable prompts for agent execution.
+//!
+//! When the daemon spawns an agent, the prompt includes current operational rules.
+//! Once spawned, the prompt is immutable for the entire task duration.
+
+use std::collections::HashMap;
+
+use rusqlite::{params, Connection};
+
+use crate::render;
+use crate::store;
+use crate::types::SpawnedPrompt;
+
+/// Build and freeze a prompt for an agent spawn.
+///
+/// Renders the template with the provided variables, persists an immutable
+/// snapshot, and returns it. Changes to the template after this point do
+/// not affect this execution.
+pub fn inject_at_spawn(
+    conn: &Connection,
+    prompt_name: &str,
+    agent: &str,
+    task_id: &str,
+    values: &HashMap<String, String>,
+) -> Result<SpawnedPrompt, String> {
+    let template = store::get_active_prompt(conn, prompt_name)
+        .map_err(|e| format!("prompt not found: {e}"))?;
+
+    let rendered = render::render(&template.body, &template.variables, values)?;
+    let spawn_id = format!("sp-{}", uuid_short());
+
+    conn.execute(
+        "INSERT INTO prompt_spawned (spawn_id, agent, task_id, rendered_body, prompt_template_id, prompt_version)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![spawn_id, agent, task_id, rendered, template.id, template.version],
+    )
+    .map_err(|e| format!("failed to persist spawn: {e}"))?;
+
+    let spawned_at: String = conn
+        .query_row(
+            "SELECT spawned_at FROM prompt_spawned WHERE spawn_id = ?1",
+            params![spawn_id],
+            |r| r.get(0),
+        )
+        .unwrap_or_default();
+
+    Ok(SpawnedPrompt {
+        spawn_id,
+        agent: agent.into(),
+        task_id: task_id.into(),
+        rendered_body: rendered,
+        prompt_template_id: template.id,
+        prompt_version: template.version,
+        spawned_at,
+    })
+}
+
+/// Retrieve the immutable prompt for an active execution.
+pub fn get_spawned(conn: &Connection, spawn_id: &str) -> rusqlite::Result<SpawnedPrompt> {
+    conn.query_row(
+        "SELECT spawn_id, agent, task_id, rendered_body, prompt_template_id, prompt_version, spawned_at
+         FROM prompt_spawned WHERE spawn_id = ?1",
+        params![spawn_id],
+        |row| {
+            Ok(SpawnedPrompt {
+                spawn_id: row.get(0)?,
+                agent: row.get(1)?,
+                task_id: row.get(2)?,
+                rendered_body: row.get(3)?,
+                prompt_template_id: row.get(4)?,
+                prompt_version: row.get(5)?,
+                spawned_at: row.get(6)?,
+            })
+        },
+    )
+}
+
+/// Get all spawned prompts for a task (useful for audit).
+pub fn get_spawned_for_task(conn: &Connection, task_id: &str) -> rusqlite::Result<Vec<SpawnedPrompt>> {
+    let mut stmt = conn.prepare(
+        "SELECT spawn_id, agent, task_id, rendered_body, prompt_template_id, prompt_version, spawned_at
+         FROM prompt_spawned WHERE task_id = ?1 ORDER BY spawned_at",
+    )?;
+    let rows = stmt.query_map(params![task_id], |row| {
+        Ok(SpawnedPrompt {
+            spawn_id: row.get(0)?,
+            agent: row.get(1)?,
+            task_id: row.get(2)?,
+            rendered_body: row.get(3)?,
+            prompt_template_id: row.get(4)?,
+            prompt_version: row.get(5)?,
+            spawned_at: row.get(6)?,
+        })
+    })?;
+    rows.collect()
+}
+
+fn uuid_short() -> String {
+    uuid::Uuid::new_v4().to_string()[..8].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{PromptInput, PromptVariable};
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
+            .unwrap();
+        conn
+    }
+
+    #[test]
+    fn spawn_freezes_prompt() {
+        let conn = setup();
+        store::create_prompt(&conn, &PromptInput {
+            name: "agent-system".into(),
+            body: "You are {{role}}. Rules: {{rules}}".into(),
+            variables: vec![
+                PromptVariable {
+                    name: "role".into(), description: "Agent role".into(),
+                    required: true, default_value: None,
+                },
+                PromptVariable {
+                    name: "rules".into(), description: "Rules".into(),
+                    required: true, default_value: None,
+                },
+            ],
+            category: Some("system".into()),
+        }).unwrap();
+
+        let mut values = HashMap::new();
+        values.insert("role".into(), "legal reviewer".into());
+        values.insert("rules".into(), "max 250 lines, conventional commits".into());
+
+        let spawned = inject_at_spawn(&conn, "agent-system", "elena", "task-7", &values).unwrap();
+        assert!(spawned.rendered_body.contains("legal reviewer"));
+        assert!(spawned.rendered_body.contains("conventional commits"));
+
+        // Updating the template does NOT affect the frozen spawn.
+        store::create_prompt(&conn, &PromptInput {
+            name: "agent-system".into(),
+            body: "CHANGED template".into(),
+            variables: vec![],
+            category: Some("system".into()),
+        }).unwrap();
+
+        let frozen = get_spawned(&conn, &spawned.spawn_id).unwrap();
+        assert!(frozen.rendered_body.contains("legal reviewer"));
+        assert!(!frozen.rendered_body.contains("CHANGED"));
+    }
+
+    #[test]
+    fn get_spawned_for_task_returns_all() {
+        let conn = setup();
+        store::create_prompt(&conn, &PromptInput {
+            name: "simple".into(),
+            body: "Do {{task}}".into(),
+            variables: vec![PromptVariable {
+                name: "task".into(), description: "Task".into(),
+                required: true, default_value: None,
+            }],
+            category: None,
+        }).unwrap();
+
+        let mut v1 = HashMap::new();
+        v1.insert("task".into(), "review".into());
+        inject_at_spawn(&conn, "simple", "agent-a", "task-10", &v1).unwrap();
+
+        let mut v2 = HashMap::new();
+        v2.insert("task".into(), "test".into());
+        inject_at_spawn(&conn, "simple", "agent-b", "task-10", &v2).unwrap();
+
+        let spawns = get_spawned_for_task(&conn, "task-10").unwrap();
+        assert_eq!(spawns.len(), 2);
+    }
+}

--- a/daemon/crates/convergio-prompts/src/store.rs
+++ b/daemon/crates/convergio-prompts/src/store.rs
@@ -19,7 +19,14 @@ pub fn create_prompt(conn: &Connection, input: &PromptInput) -> rusqlite::Result
     conn.execute(
         "INSERT INTO prompt_templates (id, name, version, body, variables, category, active)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
-        params![id, input.name, next_version, input.body, vars_json, input.category],
+        params![
+            id,
+            input.name,
+            next_version,
+            input.body,
+            vars_json,
+            input.category
+        ],
     )?;
     Ok(id)
 }
@@ -69,7 +76,8 @@ pub fn list_prompts(
     }
     sql.push_str(" ORDER BY name, version DESC");
 
-    let params_ref: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
+    let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+        param_values.iter().map(|p| p.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_ref.as_slice(), row_to_prompt)?;
     rows.collect()
@@ -94,8 +102,7 @@ fn next_version_for(conn: &Connection, name: &str) -> rusqlite::Result<u32> {
 
 fn row_to_prompt(row: &rusqlite::Row) -> rusqlite::Result<PromptTemplate> {
     let vars_str: String = row.get(4)?;
-    let variables: Vec<PromptVariable> =
-        serde_json::from_str(&vars_str).unwrap_or_default();
+    let variables: Vec<PromptVariable> = serde_json::from_str(&vars_str).unwrap_or_default();
     Ok(PromptTemplate {
         id: row.get(0)?,
         name: row.get(1)?,

--- a/daemon/crates/convergio-prompts/src/store.rs
+++ b/daemon/crates/convergio-prompts/src/store.rs
@@ -1,0 +1,237 @@
+//! CRUD operations for prompt templates.
+
+use rusqlite::{params, Connection};
+
+use crate::types::{PromptInput, PromptQuery, PromptTemplate, PromptVariable};
+
+/// Create a new prompt template, returning its ID.
+pub fn create_prompt(conn: &Connection, input: &PromptInput) -> rusqlite::Result<String> {
+    let id = format!("pt-{}", &uuid_short());
+    let vars_json = serde_json::to_string(&input.variables).unwrap_or_default();
+    let next_version = next_version_for(conn, &input.name)?;
+
+    // Deactivate previous versions of this prompt name.
+    conn.execute(
+        "UPDATE prompt_templates SET active = 0 WHERE name = ?1",
+        params![input.name],
+    )?;
+
+    conn.execute(
+        "INSERT INTO prompt_templates (id, name, version, body, variables, category, active)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)",
+        params![id, input.name, next_version, input.body, vars_json, input.category],
+    )?;
+    Ok(id)
+}
+
+/// Get a prompt template by ID.
+pub fn get_prompt(conn: &Connection, id: &str) -> rusqlite::Result<PromptTemplate> {
+    conn.query_row(
+        "SELECT id, name, version, body, variables, category, active, created_at, updated_at
+         FROM prompt_templates WHERE id = ?1",
+        params![id],
+        row_to_prompt,
+    )
+}
+
+/// Get the active version of a prompt by name.
+pub fn get_active_prompt(conn: &Connection, name: &str) -> rusqlite::Result<PromptTemplate> {
+    conn.query_row(
+        "SELECT id, name, version, body, variables, category, active, created_at, updated_at
+         FROM prompt_templates WHERE name = ?1 AND active = 1
+         ORDER BY version DESC LIMIT 1",
+        params![name],
+        row_to_prompt,
+    )
+}
+
+/// List prompts with optional filters.
+pub fn list_prompts(
+    conn: &Connection,
+    query: &PromptQuery,
+) -> rusqlite::Result<Vec<PromptTemplate>> {
+    let mut sql = String::from(
+        "SELECT id, name, version, body, variables, category, active, created_at, updated_at
+         FROM prompt_templates WHERE 1=1",
+    );
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
+
+    if let Some(ref name) = query.name {
+        sql.push_str(&format!(" AND name = ?{}", param_values.len() + 1));
+        param_values.push(Box::new(name.clone()));
+    }
+    if let Some(ref cat) = query.category {
+        sql.push_str(&format!(" AND category = ?{}", param_values.len() + 1));
+        param_values.push(Box::new(cat.clone()));
+    }
+    if query.active_only.unwrap_or(false) {
+        sql.push_str(" AND active = 1");
+    }
+    sql.push_str(" ORDER BY name, version DESC");
+
+    let params_ref: Vec<&dyn rusqlite::types::ToSql> = param_values.iter().map(|p| p.as_ref()).collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_ref.as_slice(), row_to_prompt)?;
+    rows.collect()
+}
+
+/// Delete a prompt template by ID.
+pub fn delete_prompt(conn: &Connection, id: &str) -> rusqlite::Result<bool> {
+    let count = conn.execute("DELETE FROM prompt_templates WHERE id = ?1", params![id])?;
+    Ok(count > 0)
+}
+
+fn next_version_for(conn: &Connection, name: &str) -> rusqlite::Result<u32> {
+    let max: Option<u32> = conn
+        .query_row(
+            "SELECT MAX(version) FROM prompt_templates WHERE name = ?1",
+            params![name],
+            |r| r.get(0),
+        )
+        .unwrap_or(None);
+    Ok(max.unwrap_or(0) + 1)
+}
+
+fn row_to_prompt(row: &rusqlite::Row) -> rusqlite::Result<PromptTemplate> {
+    let vars_str: String = row.get(4)?;
+    let variables: Vec<PromptVariable> =
+        serde_json::from_str(&vars_str).unwrap_or_default();
+    Ok(PromptTemplate {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        version: row.get(2)?,
+        body: row.get(3)?,
+        variables,
+        category: row.get(5)?,
+        active: row.get::<_, i32>(6)? != 0,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+fn uuid_short() -> String {
+    uuid::Uuid::new_v4().to_string()[..8].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "prompts", &crate::schema::migrations())
+            .unwrap();
+        conn
+    }
+
+    #[test]
+    fn create_and_get_prompt() {
+        let conn = setup();
+        let input = PromptInput {
+            name: "system-role".into(),
+            body: "You are {{role}} for {{org}}.".into(),
+            variables: vec![
+                PromptVariable {
+                    name: "role".into(),
+                    description: "Agent role".into(),
+                    required: true,
+                    default_value: None,
+                },
+                PromptVariable {
+                    name: "org".into(),
+                    description: "Organization".into(),
+                    required: false,
+                    default_value: Some("Convergio".into()),
+                },
+            ],
+            category: Some("system".into()),
+        };
+        let id = create_prompt(&conn, &input).unwrap();
+        let prompt = get_prompt(&conn, &id).unwrap();
+        assert_eq!(prompt.name, "system-role");
+        assert_eq!(prompt.version, 1);
+        assert!(prompt.active);
+        assert_eq!(prompt.variables.len(), 2);
+    }
+
+    #[test]
+    fn versioning_deactivates_old() {
+        let conn = setup();
+        let input = PromptInput {
+            name: "greeting".into(),
+            body: "Hello v1".into(),
+            variables: vec![],
+            category: None,
+        };
+        let id1 = create_prompt(&conn, &input).unwrap();
+        let input2 = PromptInput {
+            name: "greeting".into(),
+            body: "Hello v2".into(),
+            variables: vec![],
+            category: None,
+        };
+        let id2 = create_prompt(&conn, &input2).unwrap();
+        let p1 = get_prompt(&conn, &id1).unwrap();
+        let p2 = get_prompt(&conn, &id2).unwrap();
+        assert!(!p1.active);
+        assert!(p2.active);
+        assert_eq!(p2.version, 2);
+    }
+
+    #[test]
+    fn get_active_prompt_returns_latest() {
+        let conn = setup();
+        for i in 1..=3 {
+            let input = PromptInput {
+                name: "evolving".into(),
+                body: format!("Version {i}"),
+                variables: vec![],
+                category: None,
+            };
+            create_prompt(&conn, &input).unwrap();
+        }
+        let active = get_active_prompt(&conn, "evolving").unwrap();
+        assert_eq!(active.version, 3);
+        assert_eq!(active.body, "Version 3");
+    }
+
+    #[test]
+    fn delete_prompt_works() {
+        let conn = setup();
+        let input = PromptInput {
+            name: "disposable".into(),
+            body: "bye".into(),
+            variables: vec![],
+            category: None,
+        };
+        let id = create_prompt(&conn, &input).unwrap();
+        assert!(delete_prompt(&conn, &id).unwrap());
+        assert!(get_prompt(&conn, &id).is_err());
+    }
+
+    #[test]
+    fn list_prompts_with_filters() {
+        let conn = setup();
+        for name in ["alpha", "beta"] {
+            let input = PromptInput {
+                name: name.into(),
+                body: "test".into(),
+                variables: vec![],
+                category: Some("system".into()),
+            };
+            create_prompt(&conn, &input).unwrap();
+        }
+        let all = list_prompts(&conn, &PromptQuery::default()).unwrap();
+        assert_eq!(all.len(), 2);
+        let filtered = list_prompts(
+            &conn,
+            &PromptQuery {
+                name: Some("alpha".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(filtered.len(), 1);
+    }
+}

--- a/daemon/crates/convergio-prompts/src/types.rs
+++ b/daemon/crates/convergio-prompts/src/types.rs
@@ -1,0 +1,115 @@
+//! Core types for prompt management and skill registry.
+
+use serde::{Deserialize, Serialize};
+
+/// A versioned prompt template with variable placeholders.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptTemplate {
+    pub id: String,
+    pub name: String,
+    pub version: u32,
+    /// Template body with `{{variable}}` placeholders.
+    pub body: String,
+    /// Variable declarations: name -> description.
+    pub variables: Vec<PromptVariable>,
+    /// Optional category (e.g. "agent-role", "system", "task").
+    pub category: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    /// Whether this is the active version for its name.
+    pub active: bool,
+}
+
+/// A variable declared in a prompt template.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptVariable {
+    pub name: String,
+    pub description: String,
+    pub required: bool,
+    pub default_value: Option<String>,
+}
+
+/// Request to create or update a prompt template.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PromptInput {
+    pub name: String,
+    pub body: String,
+    pub variables: Vec<PromptVariable>,
+    pub category: Option<String>,
+}
+
+/// A skill registered by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Skill {
+    pub id: String,
+    pub agent: String,
+    pub host: String,
+    pub capability: String,
+    pub confidence: f64,
+    pub description: String,
+    pub last_used: Option<String>,
+    pub registered_at: String,
+}
+
+/// Request to register a skill.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkillInput {
+    pub agent: String,
+    pub host: String,
+    pub capability: String,
+    pub confidence: f64,
+    pub description: String,
+}
+
+/// Result of an A/B test comparison.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AbTestResult {
+    pub test_id: String,
+    pub prompt_a_id: String,
+    pub prompt_b_id: String,
+    pub task_ref: String,
+    pub winner: Option<String>,
+    pub tokens_a: u64,
+    pub tokens_b: u64,
+    pub score_a: f64,
+    pub score_b: f64,
+    pub created_at: String,
+}
+
+/// Token usage stats for a prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenStats {
+    pub prompt_id: String,
+    pub total_tokens: u64,
+    pub usage_count: u64,
+    pub avg_tokens: f64,
+}
+
+/// An immutable snapshot of a prompt bound to an agent execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpawnedPrompt {
+    pub spawn_id: String,
+    pub agent: String,
+    pub task_id: String,
+    /// The fully rendered prompt, frozen at spawn time.
+    pub rendered_body: String,
+    pub prompt_template_id: String,
+    pub prompt_version: u32,
+    pub spawned_at: String,
+}
+
+/// Prompt search query parameters.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PromptQuery {
+    pub name: Option<String>,
+    pub category: Option<String>,
+    pub active_only: Option<bool>,
+}
+
+/// Skill search query parameters.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SkillQuery {
+    pub capability: Option<String>,
+    pub agent: Option<String>,
+    pub min_confidence: Option<f64>,
+}


### PR DESCRIPTION
## Summary

- New crate `convergio-prompts` implementing Phase 12: prompt management + skill registry
- **Versioned prompt templates** with `{{variable}}` substitution, auto-versioning, and active/inactive tracking
- **Skill registry** with agent capability declaration, confidence scoring (weighted moving average), and discovery by capability
- **Token optimization** tracking per-prompt token usage with aggregated stats and compression suggestions
- **A/B testing** infrastructure for comparing prompt variants on the same task
- **Immutable spawn snapshots** — when the daemon spawns an agent, the fully rendered prompt is frozen in `prompt_spawned` and never changes during execution
- **HTTP API** routes: CRUD `/api/prompts`, `/api/skills`, `/api/skills/search?capability=X`
- Implements the `Extension` trait with 3 DB migrations, health checks, and metrics
- Dependencies: convergio-types, convergio-db, convergio-telemetry

## Modules

| File | Purpose | Tests |
|------|---------|-------|
| `types.rs` | Core types (PromptTemplate, Skill, AbTestResult, SpawnedPrompt) | - |
| `schema.rs` | 3 DB migrations (templates+skills, AB+tokens, spawned) | 2 |
| `store.rs` | Prompt CRUD with auto-versioning | 5 |
| `render.rs` | Template engine + token estimation | 5 |
| `skills.rs` | Skill registry, discovery, confidence | 4 |
| `optimizer.rs` | Token tracking + optimization suggestions | 3 |
| `ab_test.rs` | A/B test lifecycle | 2 |
| `spawn.rs` | Immutable prompt injection at agent spawn | 2 |
| `routes.rs` | Axum HTTP routes for prompts and skills | - |
| `ext.rs` | Extension trait + HealthCheck + MetricSource | - |

## Test plan

- [x] `cargo check --workspace` — full workspace compiles with zero warnings
- [x] `cargo test -p convergio-prompts` — 23 tests pass
- [x] `cargo test --workspace` — 363 tests pass, zero regressions
- [ ] Manual verification: routes compile with correct path patterns
- [ ] Review: no file exceeds 250 lines

Generated with [Claude Code](https://claude.com/claude-code)