### PR TITLE
feat: fase 11 — convergio-inference

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -437,6 +437,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-inference"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "convergio-db",
+ "convergio-ipc",
+ "convergio-telemetry",
+ "convergio-types",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "convergio-ipc"
 version = "0.1.0"
 dependencies = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/convergio-org",
     "crates/convergio-voice",
     "crates/convergio-prompts",
+    "crates/convergio-inference",
 ]
 
 [package]

--- a/daemon/crates/convergio-inference/Cargo.toml
+++ b/daemon/crates/convergio-inference/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "convergio-inference"
+description = "Inference routing, model selection, budget tracking, token optimization"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
+convergio-ipc = { path = "../convergio-ipc" }
+convergio-telemetry = { path = "../convergio-telemetry" }
+tracing = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+rusqlite = { workspace = true }
+axum = { workspace = true }

--- a/daemon/crates/convergio-inference/src/budget.rs
+++ b/daemon/crates/convergio-inference/src/budget.rs
@@ -1,0 +1,146 @@
+//! Budget-aware token tracking per agent/org/plan.
+//!
+//! Persists cost records in SQLite and provides real-time aggregation.
+//! Supports budget limits per agent and per org, with automatic tier downgrade
+//! when budget is nearly exhausted.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{CostRecord, CostSummary, InferenceTier};
+
+/// Budget configuration for an entity (agent or org).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetConfig {
+    /// Daily token budget.
+    pub daily_token_limit: u64,
+    /// Daily cost budget in USD.
+    pub daily_cost_limit_usd: f64,
+    /// Threshold (0.0-1.0) at which to start downgrading tiers.
+    pub downgrade_threshold: f64,
+}
+
+impl Default for BudgetConfig {
+    fn default() -> Self {
+        Self {
+            daily_token_limit: 10_000_000,
+            daily_cost_limit_usd: 50.0,
+            downgrade_threshold: 0.8,
+        }
+    }
+}
+
+/// Record a cost entry in the database.
+pub fn record_cost(conn: &Connection, record: &CostRecord) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO inference_costs (agent_id, org_id, plan_id, model,
+         tokens_input, tokens_output, cost_usd, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        rusqlite::params![
+            record.agent_id,
+            record.org_id,
+            record.plan_id,
+            record.model,
+            record.tokens_input,
+            record.tokens_output,
+            record.cost_usd,
+            record.timestamp,
+        ],
+    )
+    .map_err(|e| format!("failed to record cost: {e}"))?;
+    Ok(())
+}
+
+/// Get cost summary for an agent (today).
+pub fn agent_costs_today(conn: &Connection, agent_id: &str) -> Result<CostSummary, String> {
+    costs_by_scope(conn, "agent_id", agent_id)
+}
+
+/// Get cost summary for an org (today).
+pub fn org_costs_today(conn: &Connection, org_id: &str) -> Result<CostSummary, String> {
+    costs_by_scope(conn, "org_id", org_id)
+}
+
+/// Get cost summary for a plan (lifetime).
+pub fn plan_costs(conn: &Connection, plan_id: i64) -> Result<CostSummary, String> {
+    let sql = "SELECT COALESCE(SUM(tokens_input + tokens_output), 0),
+                      COALESCE(SUM(cost_usd), 0.0),
+                      COUNT(*)
+               FROM inference_costs WHERE plan_id = ?1";
+
+    let (total_tokens, total_cost, count): (u64, f64, u64) = conn
+        .query_row(sql, [plan_id], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .map_err(|e| format!("query error: {e}"))?;
+
+    let models = distinct_models_for_plan(conn, plan_id)?;
+
+    Ok(CostSummary {
+        scope: "plan".into(),
+        scope_id: plan_id.to_string(),
+        total_tokens,
+        total_cost_usd: total_cost,
+        request_count: count,
+        models_used: models,
+    })
+}
+
+/// Check if an agent should be downgraded based on budget usage.
+pub fn should_downgrade(
+    conn: &Connection,
+    agent_id: &str,
+    config: &BudgetConfig,
+) -> Result<bool, String> {
+    let summary = agent_costs_today(conn, agent_id)?;
+    let cost_ratio = summary.total_cost_usd / config.daily_cost_limit_usd;
+    let token_ratio = summary.total_tokens as f64 / config.daily_token_limit as f64;
+    Ok(cost_ratio >= config.downgrade_threshold || token_ratio >= config.downgrade_threshold)
+}
+
+/// Downgrade a tier by one step; floor is T1Trivial.
+pub fn downgrade_tier(tier: InferenceTier) -> InferenceTier {
+    match tier {
+        InferenceTier::T1Trivial => InferenceTier::T1Trivial,
+        InferenceTier::T2Standard => InferenceTier::T1Trivial,
+        InferenceTier::T3Complex => InferenceTier::T2Standard,
+        InferenceTier::T4Critical => InferenceTier::T3Complex,
+    }
+}
+
+// --- internal helpers ---
+
+fn costs_by_scope(conn: &Connection, col: &str, val: &str) -> Result<CostSummary, String> {
+    let sql = format!(
+        "SELECT COALESCE(SUM(tokens_input + tokens_output), 0),
+                COALESCE(SUM(cost_usd), 0.0),
+                COUNT(*)
+         FROM inference_costs
+         WHERE {col} = ?1 AND date(created_at) = date('now')"
+    );
+
+    let (total_tokens, total_cost, count): (u64, f64, u64) = conn
+        .query_row(&sql, [val], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .map_err(|e| format!("query error: {e}"))?;
+
+    Ok(CostSummary {
+        scope: col.replace("_id", "").to_string(),
+        scope_id: val.to_string(),
+        total_tokens,
+        total_cost_usd: total_cost,
+        request_count: count,
+        models_used: vec![],
+    })
+}
+
+fn distinct_models_for_plan(conn: &Connection, plan_id: i64) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare("SELECT DISTINCT model FROM inference_costs WHERE plan_id = ?1")
+        .map_err(|e| format!("prepare error: {e}"))?;
+    let rows = stmt
+        .query_map([plan_id], |r| r.get(0))
+        .map_err(|e| format!("query error: {e}"))?;
+    let mut models = Vec::new();
+    for row in rows {
+        models.push(row.map_err(|e| format!("row error: {e}"))?);
+    }
+    Ok(models)
+}

--- a/daemon/crates/convergio-inference/src/classifier.rs
+++ b/daemon/crates/convergio-inference/src/classifier.rs
@@ -1,0 +1,131 @@
+//! Task complexity classifier — semantic tier assignment.
+//!
+//! Replaces the static t1/t2/t3/t4 mapping with keyword-based routing.
+//! Priority: tier_hint > keyword analysis > prompt length heuristic.
+
+use crate::types::{InferenceRequest, InferenceTier};
+
+/// Classify an inference request into a tier.
+///
+/// WHY: semantic routing beats static chains — a short prompt asking for
+/// "architecture review" should use a capable model, not the cheapest one.
+pub fn classify(request: &InferenceRequest) -> InferenceTier {
+    if let Some(hint) = &request.tier_hint {
+        return hint.clone();
+    }
+
+    let prompt_lower = request.prompt.to_lowercase();
+    let len = request.prompt.len();
+
+    let base = base_tier_from_length(len);
+    let delta = keyword_delta(&prompt_lower);
+    apply_delta(base, delta)
+}
+
+/// Base tier from prompt length.
+fn base_tier_from_length(len: usize) -> InferenceTier {
+    if len < 100 {
+        InferenceTier::T1Trivial
+    } else if len < 500 {
+        InferenceTier::T2Standard
+    } else if len < 2000 {
+        InferenceTier::T3Complex
+    } else {
+        InferenceTier::T4Critical
+    }
+}
+
+/// Count keyword-based tier adjustments.
+fn keyword_delta(prompt: &str) -> i32 {
+    const BOOSTERS: &[&str] = &[
+        "architecture",
+        "security",
+        "review",
+        "refactor",
+        "design",
+        "critical",
+    ];
+    const REDUCERS: &[&str] = &["format", "list", "simple", "rename", "typo"];
+
+    let boost = BOOSTERS.iter().filter(|&&kw| prompt.contains(kw)).count() as i32;
+    let reduce = REDUCERS.iter().filter(|&&kw| prompt.contains(kw)).count() as i32;
+    boost - reduce
+}
+
+/// Apply delta to tier, clamping to valid range.
+fn apply_delta(tier: InferenceTier, delta: i32) -> InferenceTier {
+    let idx = tier_to_index(&tier);
+    let clamped = (idx + delta).clamp(0, 3);
+    index_to_tier(clamped)
+}
+
+fn tier_to_index(tier: &InferenceTier) -> i32 {
+    match tier {
+        InferenceTier::T1Trivial => 0,
+        InferenceTier::T2Standard => 1,
+        InferenceTier::T3Complex => 2,
+        InferenceTier::T4Critical => 3,
+    }
+}
+
+fn index_to_tier(idx: i32) -> InferenceTier {
+    match idx {
+        0 => InferenceTier::T1Trivial,
+        1 => InferenceTier::T2Standard,
+        2 => InferenceTier::T3Complex,
+        _ => InferenceTier::T4Critical,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::InferenceConstraints;
+
+    fn make_request(prompt: &str, hint: Option<InferenceTier>) -> InferenceRequest {
+        InferenceRequest {
+            prompt: prompt.to_string(),
+            max_tokens: 256,
+            tier_hint: hint,
+            agent_id: "test-agent".into(),
+            org_id: None,
+            plan_id: None,
+            constraints: InferenceConstraints {
+                max_latency_ms: None,
+                max_cost: None,
+            },
+        }
+    }
+
+    #[test]
+    fn hint_overrides_classification() {
+        let req = make_request("hello", Some(InferenceTier::T4Critical));
+        assert_eq!(classify(&req), InferenceTier::T4Critical);
+    }
+
+    #[test]
+    fn short_prompt_is_trivial() {
+        let req = make_request("fix typo", None);
+        // "typo" reducer brings T1 down, but floor is T1
+        assert_eq!(classify(&req), InferenceTier::T1Trivial);
+    }
+
+    #[test]
+    fn security_keyword_boosts_tier() {
+        let req = make_request("check security of the auth module", None);
+        // len < 100 → T1, "security" +1 → T2
+        assert_eq!(classify(&req), InferenceTier::T2Standard);
+    }
+
+    #[test]
+    fn long_prompt_is_complex() {
+        let req = make_request(&"x".repeat(1500), None);
+        assert_eq!(classify(&req), InferenceTier::T3Complex);
+    }
+
+    #[test]
+    fn very_long_prompt_is_critical() {
+        let req = make_request(&"x".repeat(3000), None);
+        assert_eq!(classify(&req), InferenceTier::T4Critical);
+    }
+}

--- a/daemon/crates/convergio-inference/src/ext.rs
+++ b/daemon/crates/convergio-inference/src/ext.rs
@@ -1,0 +1,157 @@
+//! InferenceExtension — impl Extension for the inference module.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use convergio_db::pool::ConnPool;
+use convergio_types::extension::{
+    AppContext, ExtResult, Extension, Health, Metric, Migration,
+};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+use crate::metrics::MetricsCollector;
+use crate::router::ModelRouter;
+use crate::routes::InferenceState;
+
+/// The inference extension — model routing, budget tracking, token optimization.
+pub struct InferenceExtension {
+    pool: ConnPool,
+    router: Arc<RwLock<ModelRouter>>,
+    metrics: Arc<RwLock<MetricsCollector>>,
+}
+
+impl InferenceExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self {
+            pool,
+            router: Arc::new(RwLock::new(ModelRouter::new())),
+            metrics: Arc::new(RwLock::new(MetricsCollector::new())),
+        }
+    }
+
+    pub fn pool(&self) -> &ConnPool {
+        &self.pool
+    }
+
+    pub fn router(&self) -> &Arc<RwLock<ModelRouter>> {
+        &self.router
+    }
+
+    pub fn metrics(&self) -> &Arc<RwLock<MetricsCollector>> {
+        &self.metrics
+    }
+
+    /// Build the shared state for API routes.
+    pub fn state(&self) -> Arc<InferenceState> {
+        Arc::new(InferenceState {
+            pool: self.pool.clone(),
+            router: self.router.clone(),
+            metrics: self.metrics.clone(),
+        })
+    }
+}
+
+impl Extension for InferenceExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-inference".to_string(),
+            description: "Model routing, budget tracking, token optimization".into(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![
+                Capability {
+                    name: "model-routing".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Semantic model selection by tier, budget, health"
+                        .to_string(),
+                },
+                Capability {
+                    name: "token-tracking".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Per-agent/org/plan cost aggregation".to_string(),
+                },
+                Capability {
+                    name: "budget-enforcement".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Automatic tier downgrade on budget pressure"
+                        .to_string(),
+                },
+            ],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::routes::inference_routes(self.state()))
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("inference: extension started");
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match self.pool.get() {
+            Ok(conn) => {
+                let ok = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM inference_costs",
+                        [],
+                        |r| r.get::<_, i64>(0),
+                    )
+                    .is_ok();
+                if ok {
+                    Health::Ok
+                } else {
+                    Health::Degraded {
+                        reason: "inference_costs table inaccessible".into(),
+                    }
+                }
+            }
+            Err(e) => Health::Down {
+                reason: format!("pool error: {e}"),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(_) => return vec![],
+        };
+        let mut out = Vec::new();
+
+        if let Ok(n) = conn.query_row(
+            "SELECT COUNT(*) FROM inference_costs",
+            [],
+            |r| r.get::<_, f64>(0),
+        ) {
+            out.push(Metric {
+                name: "inference.requests.total".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+
+        if let Ok(cost) = conn.query_row(
+            "SELECT COALESCE(SUM(cost_usd), 0.0) FROM inference_costs
+             WHERE date(created_at) = date('now')",
+            [],
+            |r| r.get::<_, f64>(0),
+        ) {
+            out.push(Metric {
+                name: "inference.cost.today_usd".into(),
+                value: cost,
+                labels: vec![],
+            });
+        }
+
+        out
+    }
+}

--- a/daemon/crates/convergio-inference/src/ext.rs
+++ b/daemon/crates/convergio-inference/src/ext.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use convergio_db::pool::ConnPool;
-use convergio_types::extension::{
-    AppContext, ExtResult, Extension, Health, Metric, Migration,
-};
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric, Migration};
 use convergio_types::manifest::{Capability, Manifest, ModuleKind};
 
 use crate::metrics::MetricsCollector;
@@ -63,8 +61,7 @@ impl Extension for InferenceExtension {
                 Capability {
                     name: "model-routing".to_string(),
                     version: "1.0".to_string(),
-                    description: "Semantic model selection by tier, budget, health"
-                        .to_string(),
+                    description: "Semantic model selection by tier, budget, health".to_string(),
                 },
                 Capability {
                     name: "token-tracking".to_string(),
@@ -74,8 +71,7 @@ impl Extension for InferenceExtension {
                 Capability {
                     name: "budget-enforcement".to_string(),
                     version: "1.0".to_string(),
-                    description: "Automatic tier downgrade on budget pressure"
-                        .to_string(),
+                    description: "Automatic tier downgrade on budget pressure".to_string(),
                 },
             ],
             requires: vec![],
@@ -100,11 +96,9 @@ impl Extension for InferenceExtension {
         match self.pool.get() {
             Ok(conn) => {
                 let ok = conn
-                    .query_row(
-                        "SELECT COUNT(*) FROM inference_costs",
-                        [],
-                        |r| r.get::<_, i64>(0),
-                    )
+                    .query_row("SELECT COUNT(*) FROM inference_costs", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
                     .is_ok();
                 if ok {
                     Health::Ok
@@ -127,11 +121,9 @@ impl Extension for InferenceExtension {
         };
         let mut out = Vec::new();
 
-        if let Ok(n) = conn.query_row(
-            "SELECT COUNT(*) FROM inference_costs",
-            [],
-            |r| r.get::<_, f64>(0),
-        ) {
+        if let Ok(n) = conn.query_row("SELECT COUNT(*) FROM inference_costs", [], |r| {
+            r.get::<_, f64>(0)
+        }) {
             out.push(Metric {
                 name: "inference.requests.total".into(),
                 value: n,

--- a/daemon/crates/convergio-inference/src/lib.rs
+++ b/daemon/crates/convergio-inference/src/lib.rs
@@ -1,0 +1,15 @@
+//! convergio-inference — Model routing, budget tracking, token optimization.
+//!
+//! Implements Extension: provides semantic model routing that replaces
+//! static fallback chains with intelligent, budget-aware selection.
+
+pub mod budget;
+pub mod classifier;
+pub mod ext;
+pub mod metrics;
+pub mod router;
+pub mod routes;
+pub mod schema;
+pub mod types;
+
+pub use ext::InferenceExtension;

--- a/daemon/crates/convergio-inference/src/metrics.rs
+++ b/daemon/crates/convergio-inference/src/metrics.rs
@@ -1,0 +1,194 @@
+//! Inference metrics — rolling windows with per-model stats.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Single observation recorded after an inference call.
+#[derive(Debug, Clone)]
+pub struct MetricsEntry {
+    pub model: String,
+    pub latency_ms: u64,
+    pub tokens_used: u32,
+    pub cost: f64,
+    pub success: bool,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Time window for metric queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeWindow {
+    OneHour,
+    TwentyFourHours,
+    SevenDays,
+}
+
+impl TimeWindow {
+    fn duration(self) -> chrono::Duration {
+        match self {
+            Self::OneHour => chrono::Duration::hours(1),
+            Self::TwentyFourHours => chrono::Duration::hours(24),
+            Self::SevenDays => chrono::Duration::days(7),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::OneHour => "1h",
+            Self::TwentyFourHours => "24h",
+            Self::SevenDays => "7d",
+        }
+    }
+}
+
+/// Computed statistics for one model over a time window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelMetrics {
+    pub model: String,
+    pub request_count: usize,
+    pub error_rate: f64,
+    pub latency_p50: u64,
+    pub latency_p95: u64,
+    pub avg_cost: f64,
+    pub window_label: String,
+}
+
+/// Bounded in-memory store of inference observations.
+pub struct MetricsCollector {
+    entries: Vec<MetricsEntry>,
+}
+
+impl MetricsCollector {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Append one observation and evict entries beyond 7-day retention.
+    pub fn record(&mut self, entry: MetricsEntry) {
+        self.entries.push(entry);
+        let cutoff = Utc::now() - TimeWindow::SevenDays.duration();
+        self.entries.retain(|e| e.timestamp >= cutoff);
+    }
+
+    /// Compute stats for `model` within `window`.
+    pub fn metrics_for(&self, model: &str, window: TimeWindow) -> ModelMetrics {
+        let cutoff = Utc::now() - window.duration();
+        let relevant: Vec<&MetricsEntry> = self
+            .entries
+            .iter()
+            .filter(|e| e.model == model && e.timestamp >= cutoff)
+            .collect();
+
+        compute_metrics(model.to_string(), &relevant, window)
+    }
+
+    /// Compute stats for every known model within `window`.
+    pub fn all_metrics(&self, window: TimeWindow) -> Vec<ModelMetrics> {
+        let cutoff = Utc::now() - window.duration();
+        let mut models: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|e| e.timestamp >= cutoff)
+            .map(|e| e.model.clone())
+            .collect();
+        models.sort();
+        models.dedup();
+        models.into_iter().map(|m| self.metrics_for(&m, window)).collect()
+    }
+}
+
+impl Default for MetricsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn compute_metrics(model: String, entries: &[&MetricsEntry], window: TimeWindow) -> ModelMetrics {
+    if entries.is_empty() {
+        return ModelMetrics {
+            model,
+            request_count: 0,
+            error_rate: 0.0,
+            latency_p50: 0,
+            latency_p95: 0,
+            avg_cost: 0.0,
+            window_label: window.label().to_string(),
+        };
+    }
+
+    let count = entries.len();
+    let errors = entries.iter().filter(|e| !e.success).count();
+    let error_rate = errors as f64 / count as f64;
+
+    let mut latencies: Vec<u64> = entries.iter().map(|e| e.latency_ms).collect();
+    latencies.sort_unstable();
+
+    let avg_cost = entries.iter().map(|e| e.cost).sum::<f64>() / count as f64;
+
+    ModelMetrics {
+        model,
+        request_count: count,
+        error_rate,
+        latency_p50: percentile(&latencies, 50),
+        latency_p95: percentile(&latencies, 95),
+        avg_cost,
+        window_label: window.label().to_string(),
+    }
+}
+
+/// Nearest-rank percentile.
+fn percentile(sorted: &[u64], p: usize) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((p as f64 / 100.0) * sorted.len() as f64).ceil() as usize;
+    sorted[idx.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(model: &str, latency: u64, cost: f64, success: bool) -> MetricsEntry {
+        MetricsEntry {
+            model: model.into(),
+            latency_ms: latency,
+            tokens_used: 100,
+            cost,
+            success,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn empty_collector_returns_zero_metrics() {
+        let collector = MetricsCollector::new();
+        let m = collector.metrics_for("haiku", TimeWindow::OneHour);
+        assert_eq!(m.request_count, 0);
+        assert_eq!(m.error_rate, 0.0);
+    }
+
+    #[test]
+    fn records_and_computes_metrics() {
+        let mut collector = MetricsCollector::new();
+        collector.record(entry("opus", 200, 0.5, true));
+        collector.record(entry("opus", 300, 0.6, true));
+        collector.record(entry("opus", 500, 0.4, false));
+
+        let m = collector.metrics_for("opus", TimeWindow::OneHour);
+        assert_eq!(m.request_count, 3);
+        assert!((m.error_rate - 1.0 / 3.0).abs() < 0.01);
+        assert_eq!(m.latency_p50, 300);
+    }
+
+    #[test]
+    fn all_metrics_returns_per_model() {
+        let mut collector = MetricsCollector::new();
+        collector.record(entry("haiku", 50, 0.01, true));
+        collector.record(entry("opus", 200, 0.5, true));
+
+        let all = collector.all_metrics(TimeWindow::OneHour);
+        assert_eq!(all.len(), 2);
+    }
+}

--- a/daemon/crates/convergio-inference/src/metrics.rs
+++ b/daemon/crates/convergio-inference/src/metrics.rs
@@ -94,7 +94,10 @@ impl MetricsCollector {
             .collect();
         models.sort();
         models.dedup();
-        models.into_iter().map(|m| self.metrics_for(&m, window)).collect()
+        models
+            .into_iter()
+            .map(|m| self.metrics_for(&m, window))
+            .collect()
     }
 }
 

--- a/daemon/crates/convergio-inference/src/router.rs
+++ b/daemon/crates/convergio-inference/src/router.rs
@@ -67,7 +67,10 @@ impl ModelRouter {
         let decision = self.select(&effective_tier, &request.constraints, budget_downgrade)?;
 
         let response = InferenceResponse {
-            content: format!("[routed to {}] {}", decision.selected_model, &request.prompt),
+            content: format!(
+                "[routed to {}] {}",
+                decision.selected_model, &request.prompt
+            ),
             model_used: decision.selected_model.clone(),
             latency_ms: 0,
             tokens_used: request.max_tokens,
@@ -96,11 +99,21 @@ impl ModelRouter {
 
         // Sort: local first, then by input cost ascending
         candidates.sort_by(|a, b| {
-            let local_a = if a.provider == ModelProvider::Local { 0 } else { 1 };
-            let local_b = if b.provider == ModelProvider::Local { 0 } else { 1 };
-            local_a
-                .cmp(&local_b)
-                .then(a.cost_per_1k_input.partial_cmp(&b.cost_per_1k_input).unwrap())
+            let local_a = if a.provider == ModelProvider::Local {
+                0
+            } else {
+                1
+            };
+            let local_b = if b.provider == ModelProvider::Local {
+                0
+            } else {
+                1
+            };
+            local_a.cmp(&local_b).then(
+                a.cost_per_1k_input
+                    .partial_cmp(&b.cost_per_1k_input)
+                    .unwrap(),
+            )
         });
 
         // Apply max_cost constraint if set
@@ -112,8 +125,7 @@ impl ModelRouter {
         }
 
         let selected = candidates[0];
-        let fallback_chain: Vec<String> =
-            candidates[1..].iter().map(|e| e.name.clone()).collect();
+        let fallback_chain: Vec<String> = candidates[1..].iter().map(|e| e.name.clone()).collect();
 
         let reason = if budget_downgrade {
             format!("tier {:?} (downgraded from budget pressure)", tier)

--- a/daemon/crates/convergio-inference/src/router.rs
+++ b/daemon/crates/convergio-inference/src/router.rs
@@ -1,0 +1,142 @@
+//! Model router — semantic routing with budget awareness.
+//!
+//! Selects the best model based on: classified tier, health status,
+//! budget constraints, and cost optimization. Replaces the static
+//! fallback chain (t1/t2/t3/t4) with intelligent routing.
+
+use std::collections::HashMap;
+
+use crate::budget;
+use crate::classifier;
+use crate::types::{
+    InferenceConstraints, InferenceRequest, InferenceResponse, InferenceTier, ModelEndpoint,
+    ModelProvider, RoutingDecision,
+};
+
+/// Routes inference requests to the best available model.
+///
+/// Selection pipeline:
+/// 1. Classify request tier (semantic, not static)
+/// 2. Apply budget constraints (downgrade if near limit)
+/// 3. Filter by health and tier coverage
+/// 4. Sort by preference: local first, then by cost
+/// 5. Build fallback chain from remaining candidates
+pub struct ModelRouter {
+    models: HashMap<String, ModelEndpoint>,
+}
+
+impl ModelRouter {
+    pub fn new() -> Self {
+        Self {
+            models: HashMap::new(),
+        }
+    }
+
+    /// Register a model endpoint. Replaces existing entry with same name.
+    pub fn register_model(&mut self, endpoint: ModelEndpoint) {
+        self.models.insert(endpoint.name.clone(), endpoint);
+    }
+
+    /// Update health status for a named model.
+    pub fn set_health(&mut self, name: &str, healthy: bool) {
+        if let Some(ep) = self.models.get_mut(name) {
+            ep.healthy = healthy;
+        }
+    }
+
+    /// Return all registered model names.
+    pub fn model_names(&self) -> Vec<String> {
+        self.models.keys().cloned().collect()
+    }
+
+    /// Route a request, applying semantic classification and budget awareness.
+    /// Returns Err when no healthy model covers the effective tier.
+    pub fn route(
+        &self,
+        request: &InferenceRequest,
+        budget_downgrade: bool,
+    ) -> Result<(InferenceResponse, RoutingDecision), String> {
+        let classified_tier = classifier::classify(request);
+
+        let effective_tier = if budget_downgrade {
+            budget::downgrade_tier(classified_tier.clone())
+        } else {
+            classified_tier.clone()
+        };
+
+        let decision = self.select(&effective_tier, &request.constraints, budget_downgrade)?;
+
+        let response = InferenceResponse {
+            content: format!("[routed to {}] {}", decision.selected_model, &request.prompt),
+            model_used: decision.selected_model.clone(),
+            latency_ms: 0,
+            tokens_used: request.max_tokens,
+            cost: 0.0,
+        };
+
+        Ok((response, decision))
+    }
+
+    /// Build a routing decision for the given tier and constraints.
+    fn select(
+        &self,
+        tier: &InferenceTier,
+        constraints: &InferenceConstraints,
+        budget_downgrade: bool,
+    ) -> Result<RoutingDecision, String> {
+        let mut candidates: Vec<&ModelEndpoint> = self
+            .models
+            .values()
+            .filter(|ep| ep.healthy && ep.tier_range.0 <= *tier && ep.tier_range.1 >= *tier)
+            .collect();
+
+        if candidates.is_empty() {
+            return Err(format!("no healthy model for tier {:?}", tier));
+        }
+
+        // Sort: local first, then by input cost ascending
+        candidates.sort_by(|a, b| {
+            let local_a = if a.provider == ModelProvider::Local { 0 } else { 1 };
+            let local_b = if b.provider == ModelProvider::Local { 0 } else { 1 };
+            local_a
+                .cmp(&local_b)
+                .then(a.cost_per_1k_input.partial_cmp(&b.cost_per_1k_input).unwrap())
+        });
+
+        // Apply max_cost constraint if set
+        if let Some(max_cost) = constraints.max_cost {
+            candidates.retain(|ep| ep.cost_per_1k_input <= max_cost);
+            if candidates.is_empty() {
+                return Err("no model within cost constraint".to_string());
+            }
+        }
+
+        let selected = candidates[0];
+        let fallback_chain: Vec<String> =
+            candidates[1..].iter().map(|e| e.name.clone()).collect();
+
+        let reason = if budget_downgrade {
+            format!("tier {:?} (downgraded from budget pressure)", tier)
+        } else {
+            format!("tier {:?} → best candidate by cost/locality", tier)
+        };
+
+        Ok(RoutingDecision {
+            selected_model: selected.name.clone(),
+            reason,
+            effective_tier: tier.label().to_string(),
+            fallback_chain,
+            budget_remaining: None,
+        })
+    }
+}
+
+impl Default for ModelRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[path = "router_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-inference/src/router_tests.rs
+++ b/daemon/crates/convergio-inference/src/router_tests.rs
@@ -37,15 +37,23 @@ fn req(tier: Option<InferenceTier>) -> InferenceRequest {
 fn routes_to_cheapest_local_model() {
     let mut router = ModelRouter::new();
     router.register_model(ep(
-        "haiku", ModelProvider::Cloud,
-        InferenceTier::T1Trivial, InferenceTier::T2Standard, 0.25,
+        "haiku",
+        ModelProvider::Cloud,
+        InferenceTier::T1Trivial,
+        InferenceTier::T2Standard,
+        0.25,
     ));
     router.register_model(ep(
-        "gemma", ModelProvider::Local,
-        InferenceTier::T1Trivial, InferenceTier::T2Standard, 0.0,
+        "gemma",
+        ModelProvider::Local,
+        InferenceTier::T1Trivial,
+        InferenceTier::T2Standard,
+        0.0,
     ));
 
-    let (resp, decision) = router.route(&req(Some(InferenceTier::T1Trivial)), false).unwrap();
+    let (resp, decision) = router
+        .route(&req(Some(InferenceTier::T1Trivial)), false)
+        .unwrap();
     assert_eq!(resp.model_used, "gemma");
     assert!(decision.fallback_chain.contains(&"haiku".to_string()));
 }
@@ -54,17 +62,25 @@ fn routes_to_cheapest_local_model() {
 fn skips_unhealthy_models() {
     let mut router = ModelRouter::new();
     let mut broken = ep(
-        "broken", ModelProvider::Local,
-        InferenceTier::T1Trivial, InferenceTier::T4Critical, 0.0,
+        "broken",
+        ModelProvider::Local,
+        InferenceTier::T1Trivial,
+        InferenceTier::T4Critical,
+        0.0,
     );
     broken.healthy = false;
     router.register_model(broken);
     router.register_model(ep(
-        "healthy", ModelProvider::Cloud,
-        InferenceTier::T1Trivial, InferenceTier::T4Critical, 1.0,
+        "healthy",
+        ModelProvider::Cloud,
+        InferenceTier::T1Trivial,
+        InferenceTier::T4Critical,
+        1.0,
     ));
 
-    let (resp, _) = router.route(&req(Some(InferenceTier::T2Standard)), false).unwrap();
+    let (resp, _) = router
+        .route(&req(Some(InferenceTier::T2Standard)), false)
+        .unwrap();
     assert_eq!(resp.model_used, "healthy");
 }
 
@@ -72,8 +88,11 @@ fn skips_unhealthy_models() {
 fn error_when_no_model_for_tier() {
     let mut router = ModelRouter::new();
     router.register_model(ep(
-        "tiny", ModelProvider::Local,
-        InferenceTier::T1Trivial, InferenceTier::T1Trivial, 0.0,
+        "tiny",
+        ModelProvider::Local,
+        InferenceTier::T1Trivial,
+        InferenceTier::T1Trivial,
+        0.0,
     ));
 
     let result = router.route(&req(Some(InferenceTier::T4Critical)), false);
@@ -84,12 +103,18 @@ fn error_when_no_model_for_tier() {
 fn budget_downgrade_changes_tier() {
     let mut router = ModelRouter::new();
     router.register_model(ep(
-        "haiku", ModelProvider::Cloud,
-        InferenceTier::T1Trivial, InferenceTier::T2Standard, 0.25,
+        "haiku",
+        ModelProvider::Cloud,
+        InferenceTier::T1Trivial,
+        InferenceTier::T2Standard,
+        0.25,
     ));
     router.register_model(ep(
-        "opus", ModelProvider::Cloud,
-        InferenceTier::T3Complex, InferenceTier::T4Critical, 15.0,
+        "opus",
+        ModelProvider::Cloud,
+        InferenceTier::T3Complex,
+        InferenceTier::T4Critical,
+        15.0,
     ));
 
     // T3 with downgrade -> T2, should use haiku not opus
@@ -104,13 +129,20 @@ fn budget_downgrade_changes_tier() {
 fn health_update_toggles_availability() {
     let mut router = ModelRouter::new();
     router.register_model(ep(
-        "model-a", ModelProvider::Local,
-        InferenceTier::T1Trivial, InferenceTier::T4Critical, 0.0,
+        "model-a",
+        ModelProvider::Local,
+        InferenceTier::T1Trivial,
+        InferenceTier::T4Critical,
+        0.0,
     ));
     router.set_health("model-a", false);
-    assert!(router.route(&req(Some(InferenceTier::T2Standard)), false).is_err());
+    assert!(router
+        .route(&req(Some(InferenceTier::T2Standard)), false)
+        .is_err());
 
     router.set_health("model-a", true);
-    let (resp, _) = router.route(&req(Some(InferenceTier::T2Standard)), false).unwrap();
+    let (resp, _) = router
+        .route(&req(Some(InferenceTier::T2Standard)), false)
+        .unwrap();
     assert_eq!(resp.model_used, "model-a");
 }

--- a/daemon/crates/convergio-inference/src/router_tests.rs
+++ b/daemon/crates/convergio-inference/src/router_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+fn ep(
+    name: &str,
+    provider: ModelProvider,
+    low: InferenceTier,
+    high: InferenceTier,
+    cost: f64,
+) -> ModelEndpoint {
+    ModelEndpoint {
+        name: name.into(),
+        provider,
+        url: format!("http://localhost/{name}"),
+        cost_per_1k_input: cost,
+        cost_per_1k_output: cost * 3.0,
+        tier_range: (low, high),
+        healthy: true,
+    }
+}
+
+fn req(tier: Option<InferenceTier>) -> InferenceRequest {
+    InferenceRequest {
+        prompt: "test prompt".into(),
+        max_tokens: 256,
+        tier_hint: tier,
+        agent_id: "elena".into(),
+        org_id: Some("legal-corp".into()),
+        plan_id: Some(42),
+        constraints: InferenceConstraints {
+            max_latency_ms: None,
+            max_cost: None,
+        },
+    }
+}
+
+#[test]
+fn routes_to_cheapest_local_model() {
+    let mut router = ModelRouter::new();
+    router.register_model(ep(
+        "haiku", ModelProvider::Cloud,
+        InferenceTier::T1Trivial, InferenceTier::T2Standard, 0.25,
+    ));
+    router.register_model(ep(
+        "gemma", ModelProvider::Local,
+        InferenceTier::T1Trivial, InferenceTier::T2Standard, 0.0,
+    ));
+
+    let (resp, decision) = router.route(&req(Some(InferenceTier::T1Trivial)), false).unwrap();
+    assert_eq!(resp.model_used, "gemma");
+    assert!(decision.fallback_chain.contains(&"haiku".to_string()));
+}
+
+#[test]
+fn skips_unhealthy_models() {
+    let mut router = ModelRouter::new();
+    let mut broken = ep(
+        "broken", ModelProvider::Local,
+        InferenceTier::T1Trivial, InferenceTier::T4Critical, 0.0,
+    );
+    broken.healthy = false;
+    router.register_model(broken);
+    router.register_model(ep(
+        "healthy", ModelProvider::Cloud,
+        InferenceTier::T1Trivial, InferenceTier::T4Critical, 1.0,
+    ));
+
+    let (resp, _) = router.route(&req(Some(InferenceTier::T2Standard)), false).unwrap();
+    assert_eq!(resp.model_used, "healthy");
+}
+
+#[test]
+fn error_when_no_model_for_tier() {
+    let mut router = ModelRouter::new();
+    router.register_model(ep(
+        "tiny", ModelProvider::Local,
+        InferenceTier::T1Trivial, InferenceTier::T1Trivial, 0.0,
+    ));
+
+    let result = router.route(&req(Some(InferenceTier::T4Critical)), false);
+    assert!(result.is_err());
+}
+
+#[test]
+fn budget_downgrade_changes_tier() {
+    let mut router = ModelRouter::new();
+    router.register_model(ep(
+        "haiku", ModelProvider::Cloud,
+        InferenceTier::T1Trivial, InferenceTier::T2Standard, 0.25,
+    ));
+    router.register_model(ep(
+        "opus", ModelProvider::Cloud,
+        InferenceTier::T3Complex, InferenceTier::T4Critical, 15.0,
+    ));
+
+    // T3 with downgrade -> T2, should use haiku not opus
+    let (resp, decision) = router
+        .route(&req(Some(InferenceTier::T3Complex)), true)
+        .unwrap();
+    assert_eq!(resp.model_used, "haiku");
+    assert_eq!(decision.effective_tier, "t2");
+}
+
+#[test]
+fn health_update_toggles_availability() {
+    let mut router = ModelRouter::new();
+    router.register_model(ep(
+        "model-a", ModelProvider::Local,
+        InferenceTier::T1Trivial, InferenceTier::T4Critical, 0.0,
+    ));
+    router.set_health("model-a", false);
+    assert!(router.route(&req(Some(InferenceTier::T2Standard)), false).is_err());
+
+    router.set_health("model-a", true);
+    let (resp, _) = router.route(&req(Some(InferenceTier::T2Standard)), false).unwrap();
+    assert_eq!(resp.model_used, "model-a");
+}

--- a/daemon/crates/convergio-inference/src/routes.rs
+++ b/daemon/crates/convergio-inference/src/routes.rs
@@ -1,0 +1,140 @@
+//! API routes: GET /api/inference/costs, GET /api/inference/routing-decision.
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::response::Json;
+use axum::routing::get;
+use axum::Router;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::budget;
+use crate::metrics::{MetricsCollector, TimeWindow};
+use crate::router::ModelRouter;
+use crate::types::{
+    CostSummary, InferenceConstraints, InferenceRequest, InferenceTier, RoutingDecision,
+};
+use convergio_db::pool::ConnPool;
+
+/// Shared state for inference routes.
+pub struct InferenceState {
+    pub pool: ConnPool,
+    pub router: Arc<RwLock<ModelRouter>>,
+    pub metrics: Arc<RwLock<MetricsCollector>>,
+}
+
+/// Query params for GET /costs.
+#[derive(Debug, Deserialize)]
+pub struct CostsQuery {
+    pub agent_id: Option<String>,
+    pub org_id: Option<String>,
+    pub plan_id: Option<i64>,
+}
+
+/// Response for GET /costs.
+#[derive(Debug, Serialize)]
+pub struct CostsResponse {
+    pub summaries: Vec<CostSummary>,
+}
+
+/// Query params for GET /routing-decision.
+#[derive(Debug, Deserialize)]
+pub struct RoutingQuery {
+    pub prompt: Option<String>,
+    pub tier: Option<String>,
+    pub agent_id: Option<String>,
+    pub max_cost: Option<f64>,
+}
+
+/// Response for GET /routing-decision.
+#[derive(Debug, Serialize)]
+pub struct RoutingResponse {
+    pub decision: RoutingDecision,
+    pub model_metrics: Vec<crate::metrics::ModelMetrics>,
+}
+
+/// Build the inference API router.
+pub fn inference_routes(state: Arc<InferenceState>) -> Router {
+    Router::new()
+        .route("/api/inference/costs", get(handle_costs))
+        .route("/api/inference/routing-decision", get(handle_routing))
+        .with_state(state)
+}
+
+async fn handle_costs(
+    State(state): State<Arc<InferenceState>>,
+    Query(params): Query<CostsQuery>,
+) -> Json<CostsResponse> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(_) => return Json(CostsResponse { summaries: vec![] }),
+    };
+
+    let mut summaries = Vec::new();
+
+    if let Some(agent_id) = &params.agent_id {
+        if let Ok(s) = budget::agent_costs_today(&conn, agent_id) {
+            summaries.push(s);
+        }
+    }
+    if let Some(org_id) = &params.org_id {
+        if let Ok(s) = budget::org_costs_today(&conn, org_id) {
+            summaries.push(s);
+        }
+    }
+    if let Some(plan_id) = params.plan_id {
+        if let Ok(s) = budget::plan_costs(&conn, plan_id) {
+            summaries.push(s);
+        }
+    }
+
+    Json(CostsResponse { summaries })
+}
+
+async fn handle_routing(
+    State(state): State<Arc<InferenceState>>,
+    Query(params): Query<RoutingQuery>,
+) -> Json<serde_json::Value> {
+    let tier_hint = params.tier.as_deref().and_then(InferenceTier::from_label);
+
+    let request = InferenceRequest {
+        prompt: params.prompt.unwrap_or_default(),
+        max_tokens: 256,
+        tier_hint,
+        agent_id: params.agent_id.clone().unwrap_or_else(|| "anonymous".into()),
+        org_id: None,
+        plan_id: None,
+        constraints: InferenceConstraints {
+            max_latency_ms: None,
+            max_cost: params.max_cost,
+        },
+    };
+
+    // Check budget for downgrade
+    let should_downgrade = if let Some(agent_id) = &params.agent_id {
+        let conn = state.pool.get().ok();
+        conn.map(|c| {
+            budget::should_downgrade(&c, agent_id, &budget::BudgetConfig::default())
+                .unwrap_or(false)
+        })
+        .unwrap_or(false)
+    } else {
+        false
+    };
+
+    let router = state.router.read().await;
+    match router.route(&request, should_downgrade) {
+        Ok((_resp, decision)) => {
+            let metrics_lock = state.metrics.read().await;
+            let model_metrics = metrics_lock.all_metrics(TimeWindow::OneHour);
+            Json(serde_json::json!({
+                "decision": decision,
+                "model_metrics": model_metrics,
+            }))
+        }
+        Err(e) => Json(serde_json::json!({
+            "error": { "code": "NO_MODEL", "message": e }
+        })),
+    }
+}

--- a/daemon/crates/convergio-inference/src/routes.rs
+++ b/daemon/crates/convergio-inference/src/routes.rs
@@ -102,7 +102,10 @@ async fn handle_routing(
         prompt: params.prompt.unwrap_or_default(),
         max_tokens: 256,
         tier_hint,
-        agent_id: params.agent_id.clone().unwrap_or_else(|| "anonymous".into()),
+        agent_id: params
+            .agent_id
+            .clone()
+            .unwrap_or_else(|| "anonymous".into()),
         org_id: None,
         plan_id: None,
         constraints: InferenceConstraints {

--- a/daemon/crates/convergio-inference/src/schema.rs
+++ b/daemon/crates/convergio-inference/src/schema.rs
@@ -1,0 +1,65 @@
+//! DB migrations for inference token tracking tables.
+
+use convergio_types::extension::Migration;
+
+pub fn migrations() -> Vec<Migration> {
+    vec![Migration {
+        version: 1,
+        description: "inference cost tracking tables",
+        up: "
+            CREATE TABLE IF NOT EXISTS inference_costs (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id      TEXT    NOT NULL,
+                org_id        TEXT,
+                plan_id       INTEGER,
+                model         TEXT    NOT NULL,
+                tokens_input  INTEGER NOT NULL DEFAULT 0,
+                tokens_output INTEGER NOT NULL DEFAULT 0,
+                cost_usd      REAL    NOT NULL DEFAULT 0.0,
+                created_at    TEXT    NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_costs_agent
+                ON inference_costs(agent_id, created_at);
+            CREATE INDEX IF NOT EXISTS idx_costs_org
+                ON inference_costs(org_id, created_at);
+            CREATE INDEX IF NOT EXISTS idx_costs_plan
+                ON inference_costs(plan_id);
+
+            CREATE TABLE IF NOT EXISTS inference_budgets (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type         TEXT    NOT NULL,
+                entity_id           TEXT    NOT NULL,
+                daily_token_limit   INTEGER NOT NULL DEFAULT 10000000,
+                daily_cost_limit    REAL    NOT NULL DEFAULT 50.0,
+                downgrade_threshold REAL    NOT NULL DEFAULT 0.8,
+                created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
+                UNIQUE (entity_type, entity_id)
+            );
+        ",
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_are_ordered() {
+        let m = migrations();
+        for (i, mig) in m.iter().enumerate() {
+            assert_eq!(mig.version, (i + 1) as u32);
+        }
+    }
+
+    #[test]
+    fn migrations_apply_cleanly() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        let applied =
+            convergio_db::migration::apply_migrations(&conn, "inference", &migrations())
+                .unwrap();
+        assert_eq!(applied, 1);
+    }
+}

--- a/daemon/crates/convergio-inference/src/schema.rs
+++ b/daemon/crates/convergio-inference/src/schema.rs
@@ -58,8 +58,7 @@ mod tests {
         let conn = pool.get().unwrap();
         convergio_db::migration::ensure_registry(&conn).unwrap();
         let applied =
-            convergio_db::migration::apply_migrations(&conn, "inference", &migrations())
-                .unwrap();
+            convergio_db::migration::apply_migrations(&conn, "inference", &migrations()).unwrap();
         assert_eq!(applied, 1);
     }
 }

--- a/daemon/crates/convergio-inference/src/types.rs
+++ b/daemon/crates/convergio-inference/src/types.rs
@@ -1,0 +1,121 @@
+//! Inference types — tiers, requests, responses, routing decisions.
+
+use serde::{Deserialize, Serialize};
+
+/// Model tier classification — maps to capability requirements.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum InferenceTier {
+    T1Trivial,
+    T2Standard,
+    T3Complex,
+    T4Critical,
+}
+
+impl InferenceTier {
+    /// Short label for serialization and DB storage.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::T1Trivial => "t1",
+            Self::T2Standard => "t2",
+            Self::T3Complex => "t3",
+            Self::T4Critical => "t4",
+        }
+    }
+
+    /// Parse from short label.
+    pub fn from_label(s: &str) -> Option<Self> {
+        match s {
+            "t1" => Some(Self::T1Trivial),
+            "t2" => Some(Self::T2Standard),
+            "t3" => Some(Self::T3Complex),
+            "t4" => Some(Self::T4Critical),
+            _ => None,
+        }
+    }
+}
+
+/// Routing constraints from the caller.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InferenceConstraints {
+    pub max_latency_ms: Option<u64>,
+    pub max_cost: Option<f64>,
+}
+
+/// Incoming inference request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InferenceRequest {
+    pub prompt: String,
+    pub max_tokens: u32,
+    /// Caller hint — router may override based on health/budget.
+    pub tier_hint: Option<InferenceTier>,
+    pub agent_id: String,
+    pub org_id: Option<String>,
+    pub plan_id: Option<i64>,
+    pub constraints: InferenceConstraints,
+}
+
+/// Result returned after routing and inference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InferenceResponse {
+    pub content: String,
+    pub model_used: String,
+    pub latency_ms: u64,
+    pub tokens_used: u32,
+    pub cost: f64,
+}
+
+/// Provider classification.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ModelProvider {
+    Local,
+    Cloud,
+}
+
+/// A registered model endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelEndpoint {
+    pub name: String,
+    pub provider: ModelProvider,
+    pub url: String,
+    /// Cost per 1K input tokens (USD).
+    pub cost_per_1k_input: f64,
+    /// Cost per 1K output tokens (USD).
+    pub cost_per_1k_output: f64,
+    /// Inclusive tier range this model serves.
+    pub tier_range: (InferenceTier, InferenceTier),
+    pub healthy: bool,
+}
+
+/// The router's routing decision (for logging, API, and fallback chains).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutingDecision {
+    pub selected_model: String,
+    pub reason: String,
+    pub effective_tier: String,
+    pub fallback_chain: Vec<String>,
+    pub budget_remaining: Option<f64>,
+}
+
+/// Cost record for tracking spend per agent/org/plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostRecord {
+    pub agent_id: String,
+    pub org_id: Option<String>,
+    pub plan_id: Option<i64>,
+    pub model: String,
+    pub tokens_input: u32,
+    pub tokens_output: u32,
+    pub cost_usd: f64,
+    pub timestamp: String,
+}
+
+/// Aggregated costs for a given scope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostSummary {
+    pub scope: String,
+    pub scope_id: String,
+    pub total_tokens: u64,
+    pub total_cost_usd: f64,
+    pub request_count: u64,
+    pub models_used: Vec<String>,
+}


### PR DESCRIPTION
## Summary

- New `convergio-inference` crate: semantic model routing, budget-aware tier selection, and token cost tracking
- **Model router**: selects best model based on classified task complexity, health status, cost, and locality (local models preferred over cloud)
- **Budget tracking**: per-agent/org/plan cost records in SQLite with real-time aggregation and automatic tier downgrade when budget threshold exceeded
- **Task classifier**: keyword-based semantic tier assignment replaces static t1/t2/t3/t4 fallback chains
- **API routes**: `GET /api/inference/costs` (cost summaries by agent/org/plan) and `GET /api/inference/routing-decision` (dry-run routing with metrics)
- **Extension trait**: full implementation with migrations, routes, health, and metrics
- 15 tests covering router, classifier, metrics, and schema

## Modules

| File | Lines | Purpose |
|------|-------|---------|
| types.rs | 121 | Tiers, requests, responses, cost records |
| router.rs | 142 | Semantic model selection pipeline |
| classifier.rs | 131 | Keyword-based tier classification |
| budget.rs | 146 | DB-backed cost tracking + downgrade logic |
| metrics.rs | 194 | Rolling-window per-model statistics |
| routes.rs | 140 | Axum API handlers |
| schema.rs | 65 | DB migrations (inference_costs, inference_budgets) |
| ext.rs | 157 | Extension trait implementation |

## Deps

`convergio-types`, `convergio-db`, `convergio-ipc`, `convergio-telemetry`

## Test plan

- [x] `cargo check --workspace` — clean, no warnings
- [x] `cargo test -p convergio-inference` — 15/15 pass
- [x] `cargo test --workspace` — 355 tests pass, no regressions
- [x] All files under 250 lines
- [ ] Manual: verify API routes respond correctly when server is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)