### PR TITLE
feat: fase 16 — dependency graph validation + OpenAPI

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -437,6 +437,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-depgraph"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "convergio-types",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "convergio-http-bridge"
 version = "0.1.0"
 dependencies = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/convergio-inference",
     "crates/convergio-org-package",
     "crates/convergio-http-bridge",
+    "crates/convergio-depgraph",
 ]
 
 [package]

--- a/daemon/crates/convergio-depgraph/Cargo.toml
+++ b/daemon/crates/convergio-depgraph/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "convergio-depgraph"
+description = "Dependency graph validation, OpenAPI generation, capability listing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+semver = "1"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/daemon/crates/convergio-depgraph/src/ext.rs
+++ b/daemon/crates/convergio-depgraph/src/ext.rs
@@ -1,0 +1,166 @@
+//! DepgraphExtension — impl Extension for the depgraph module.
+
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric};
+use convergio_types::manifest::{Capability, Dependency, Manifest, ModuleKind};
+
+use crate::graph::DepGraph;
+use crate::routes::{self, DepgraphState};
+
+/// Extension that validates the dependency graph and serves graph/OpenAPI routes.
+pub struct DepgraphExtension {
+    manifests: Vec<Manifest>,
+}
+
+impl Default for DepgraphExtension {
+    fn default() -> Self {
+        Self::new(vec![])
+    }
+}
+
+impl DepgraphExtension {
+    pub fn new(manifests: Vec<Manifest>) -> Self {
+        Self { manifests }
+    }
+
+    /// Run startup validation — call this before serving traffic.
+    /// Returns Ok(()) if graph is valid, Err with details otherwise.
+    pub fn validate_at_startup(&self) -> Result<(), String> {
+        match DepGraph::validate(&self.manifests) {
+            Ok(()) => {
+                tracing::info!(
+                    modules = self.manifests.len(),
+                    "dependency graph validated successfully"
+                );
+                Ok(())
+            }
+            Err(errors) => {
+                for e in &errors {
+                    tracing::error!(?e, "dependency graph validation error");
+                }
+                Err(format!("dependency graph has {} error(s)", errors.len()))
+            }
+        }
+    }
+}
+
+impl Extension for DepgraphExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-depgraph".into(),
+            description: "Dependency graph validation, OpenAPI generation, \
+                          capability listing"
+                .into(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![
+                Capability {
+                    name: "dep-graph".into(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    description: "Dependency graph validation and \
+                                  visualization"
+                        .into(),
+                },
+                Capability {
+                    name: "openapi-gen".into(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    description: "Auto-generated OpenAPI spec from \
+                                  Extension manifests"
+                        .into(),
+                },
+                Capability {
+                    name: "capability-list".into(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    description: "Full system capability listing".into(),
+                },
+            ],
+            requires: vec![Dependency {
+                capability: "types-core".into(),
+                version_req: ">=0.1.0".into(),
+                required: false,
+            }],
+            agent_tools: vec![],
+        }
+    }
+
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        let state = DepgraphState::new(self.manifests.clone());
+        Some(routes::router(state))
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        self.validate_at_startup()
+            .map_err(|e| Box::new(std::io::Error::other(e)) as Box<_>)?;
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match DepGraph::validate(&self.manifests) {
+            Ok(()) => Health::Ok,
+            Err(errors) => Health::Degraded {
+                reason: format!("{} validation error(s)", errors.len()),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let graph = DepGraph::from_manifests(&self.manifests);
+        vec![
+            Metric {
+                name: "depgraph_modules".into(),
+                value: graph.nodes.len() as f64,
+                labels: vec![],
+            },
+            Metric {
+                name: "depgraph_edges".into(),
+                value: graph.edges.len() as f64,
+                labels: vec![],
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_has_correct_id() {
+        let ext = DepgraphExtension::default();
+        let m = ext.manifest();
+        assert_eq!(m.id, "convergio-depgraph");
+    }
+
+    #[test]
+    fn provides_three_capabilities() {
+        let ext = DepgraphExtension::default();
+        let m = ext.manifest();
+        assert_eq!(m.provides.len(), 3);
+    }
+
+    #[test]
+    fn health_ok_with_empty_graph() {
+        let ext = DepgraphExtension::default();
+        assert!(matches!(ext.health(), Health::Ok));
+    }
+
+    #[test]
+    fn metrics_report_counts() {
+        let ext = DepgraphExtension::default();
+        let metrics = ext.metrics();
+        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics[0].name, "depgraph_modules");
+    }
+
+    #[test]
+    fn startup_validation_passes_empty() {
+        let ext = DepgraphExtension::default();
+        assert!(ext.validate_at_startup().is_ok());
+    }
+
+    #[test]
+    fn routes_are_provided() {
+        let ext = DepgraphExtension::default();
+        let ctx = AppContext::new();
+        assert!(ext.routes(&ctx).is_some());
+    }
+}

--- a/daemon/crates/convergio-depgraph/src/graph.rs
+++ b/daemon/crates/convergio-depgraph/src/graph.rs
@@ -1,0 +1,241 @@
+//! Core dependency graph: build from manifests, detect cycles, validate deps.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use convergio_types::manifest::{Capability, Dependency, Manifest};
+use serde::{Deserialize, Serialize};
+
+/// Validation error kinds produced during graph analysis.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GraphError {
+    /// A required dependency is not provided by any loaded module.
+    MissingDependency {
+        module: String,
+        capability: String,
+        version_req: String,
+    },
+    /// Two or more modules form a dependency cycle.
+    CircularDependency { cycle: Vec<String> },
+    /// A capability version does not satisfy a consumer's version_req.
+    SemVerMismatch {
+        module: String,
+        capability: String,
+        required: String,
+        provided: String,
+    },
+}
+
+/// A node in the serializable dependency graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphNode {
+    pub id: String,
+    pub version: String,
+    pub kind: String,
+    pub provides: Vec<Capability>,
+    pub requires: Vec<Dependency>,
+}
+
+/// An edge in the serializable dependency graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphEdge {
+    pub from: String,
+    pub to: String,
+    pub capability: String,
+}
+
+/// The full dependency graph — serializable to JSON for UI consumption.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DepGraph {
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
+
+impl Default for DepGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DepGraph {
+    pub fn new() -> Self {
+        Self {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    /// Build graph from a set of manifests.
+    pub fn from_manifests(manifests: &[Manifest]) -> Self {
+        let cap_providers = build_capability_map(manifests);
+        let mut nodes = Vec::new();
+        let mut edges = Vec::new();
+
+        for m in manifests {
+            nodes.push(GraphNode {
+                id: m.id.clone(),
+                version: m.version.clone(),
+                kind: format!("{:?}", m.kind),
+                provides: m.provides.clone(),
+                requires: m.requires.clone(),
+            });
+            for dep in &m.requires {
+                if let Some(provider) = cap_providers.get(&dep.capability) {
+                    edges.push(GraphEdge {
+                        from: m.id.clone(),
+                        to: provider.clone(),
+                        capability: dep.capability.clone(),
+                    });
+                }
+            }
+        }
+
+        Self { nodes, edges }
+    }
+
+    /// Validate the graph: check missing deps, semver, cycles.
+    /// Returns Ok(()) if valid, Err with all errors found.
+    pub fn validate(manifests: &[Manifest]) -> Result<(), Vec<GraphError>> {
+        let mut errors = Vec::new();
+
+        let cap_map = build_capability_map(manifests);
+        let cap_versions = build_capability_version_map(manifests);
+
+        // Check missing + semver
+        for m in manifests {
+            for dep in &m.requires {
+                match cap_map.get(&dep.capability) {
+                    None if dep.required => {
+                        errors.push(GraphError::MissingDependency {
+                            module: m.id.clone(),
+                            capability: dep.capability.clone(),
+                            version_req: dep.version_req.clone(),
+                        });
+                    }
+                    Some(_provider) => {
+                        if let Some(provided_ver) = cap_versions.get(&dep.capability) {
+                            if let Err(e) =
+                                crate::semver_check::check(provided_ver, &dep.version_req)
+                            {
+                                errors.push(GraphError::SemVerMismatch {
+                                    module: m.id.clone(),
+                                    capability: dep.capability.clone(),
+                                    required: dep.version_req.clone(),
+                                    provided: e.provided,
+                                });
+                            }
+                        }
+                    }
+                    _ => {} // optional dep missing — ok
+                }
+            }
+        }
+
+        // Cycle detection
+        if let Some(cycle) = detect_cycle(manifests, &cap_map) {
+            errors.push(GraphError::CircularDependency { cycle });
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// Map capability name -> provider module id.
+fn build_capability_map(manifests: &[Manifest]) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for m in manifests {
+        for cap in &m.provides {
+            map.insert(cap.name.clone(), m.id.clone());
+        }
+    }
+    map
+}
+
+/// Map capability name -> provided version string.
+fn build_capability_version_map(manifests: &[Manifest]) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for m in manifests {
+        for cap in &m.provides {
+            map.insert(cap.name.clone(), cap.version.clone());
+        }
+    }
+    map
+}
+
+/// Detect cycles using BFS-based topological sort (Kahn's algorithm).
+/// Returns the first cycle found, or None.
+fn detect_cycle(manifests: &[Manifest], cap_map: &HashMap<String, String>) -> Option<Vec<String>> {
+    let ids: Vec<&str> = manifests.iter().map(|m| m.id.as_str()).collect();
+    let id_set: HashSet<&str> = ids.iter().copied().collect();
+
+    // Build adjacency: module -> set of modules it depends on
+    let mut deps: HashMap<&str, HashSet<&str>> = HashMap::new();
+    let mut rdeps: HashMap<&str, HashSet<&str>> = HashMap::new();
+    for id in &ids {
+        deps.insert(id, HashSet::new());
+        rdeps.insert(id, HashSet::new());
+    }
+
+    for m in manifests {
+        for dep in &m.requires {
+            if let Some(provider) = cap_map.get(&dep.capability) {
+                if id_set.contains(provider.as_str()) && provider.as_str() != m.id.as_str() {
+                    deps.get_mut(m.id.as_str())
+                        .unwrap()
+                        .insert(provider.as_str());
+                    rdeps
+                        .get_mut(provider.as_str())
+                        .unwrap()
+                        .insert(m.id.as_str());
+                }
+            }
+        }
+    }
+
+    // Kahn's: start with nodes that have zero in-degree
+    let mut in_degree: HashMap<&str, usize> = HashMap::new();
+    for id in &ids {
+        in_degree.insert(id, deps[id].len());
+    }
+
+    let mut queue: VecDeque<&str> = VecDeque::new();
+    for (&id, &deg) in &in_degree {
+        if deg == 0 {
+            queue.push_back(id);
+        }
+    }
+
+    let mut sorted_count = 0usize;
+    while let Some(node) = queue.pop_front() {
+        sorted_count += 1;
+        if let Some(dependents) = rdeps.get(node) {
+            for &dep in dependents {
+                let d = in_degree.get_mut(dep).unwrap();
+                *d -= 1;
+                if *d == 0 {
+                    queue.push_back(dep);
+                }
+            }
+        }
+    }
+
+    if sorted_count == ids.len() {
+        return None; // no cycle
+    }
+
+    // Extract cycle participants
+    let cycle: Vec<String> = in_degree
+        .iter()
+        .filter(|(_, &deg)| deg > 0)
+        .map(|(&id, _)| id.to_string())
+        .collect();
+
+    Some(cycle)
+}
+
+#[cfg(test)]
+#[path = "graph_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-depgraph/src/graph_tests.rs
+++ b/daemon/crates/convergio-depgraph/src/graph_tests.rs
@@ -1,0 +1,166 @@
+//! Tests for dependency graph validation.
+
+use super::*;
+use convergio_types::manifest::{Capability, Dependency, Manifest, ModuleKind};
+
+fn cap(name: &str, ver: &str) -> Capability {
+    Capability {
+        name: name.into(),
+        version: ver.into(),
+        description: format!("{name} capability"),
+    }
+}
+
+fn dep(cap_name: &str, ver_req: &str, required: bool) -> Dependency {
+    Dependency {
+        capability: cap_name.into(),
+        version_req: ver_req.into(),
+        required,
+    }
+}
+
+fn manifest(id: &str, provides: Vec<Capability>, requires: Vec<Dependency>) -> Manifest {
+    Manifest {
+        id: id.into(),
+        description: format!("{id} module"),
+        version: "0.1.0".into(),
+        kind: ModuleKind::Core,
+        provides,
+        requires,
+        agent_tools: vec![],
+    }
+}
+
+#[test]
+fn valid_graph_passes() {
+    let manifests = vec![
+        manifest("types", vec![cap("types-core", "0.1.0")], vec![]),
+        manifest(
+            "db",
+            vec![cap("db-pool", "0.1.0")],
+            vec![dep("types-core", ">=0.1.0", true)],
+        ),
+    ];
+    assert!(DepGraph::validate(&manifests).is_ok());
+}
+
+#[test]
+fn missing_required_dep_fails() {
+    let manifests = vec![manifest(
+        "mesh",
+        vec![],
+        vec![dep("nonexistent", ">=1.0.0", true)],
+    )];
+    let errors = DepGraph::validate(&manifests).unwrap_err();
+    assert!(errors.iter().any(|e| matches!(
+        e,
+        GraphError::MissingDependency { capability, .. }
+        if capability == "nonexistent"
+    )));
+}
+
+#[test]
+fn missing_optional_dep_ok() {
+    let manifests = vec![manifest(
+        "mesh",
+        vec![],
+        vec![dep("optional-cap", ">=1.0.0", false)],
+    )];
+    assert!(DepGraph::validate(&manifests).is_ok());
+}
+
+#[test]
+fn circular_dep_detected() {
+    let manifests = vec![
+        manifest(
+            "alpha",
+            vec![cap("cap-a", "1.0.0")],
+            vec![dep("cap-b", ">=1.0.0", true)],
+        ),
+        manifest(
+            "beta",
+            vec![cap("cap-b", "1.0.0")],
+            vec![dep("cap-a", ">=1.0.0", true)],
+        ),
+    ];
+    let errors = DepGraph::validate(&manifests).unwrap_err();
+    assert!(errors
+        .iter()
+        .any(|e| matches!(e, GraphError::CircularDependency { .. })));
+}
+
+#[test]
+fn semver_mismatch_detected() {
+    let manifests = vec![
+        manifest("types", vec![cap("core", "0.1.0")], vec![]),
+        manifest("consumer", vec![], vec![dep("core", ">=2.0.0", true)]),
+    ];
+    let errors = DepGraph::validate(&manifests).unwrap_err();
+    assert!(errors.iter().any(|e| matches!(
+        e,
+        GraphError::SemVerMismatch { capability, .. }
+        if capability == "core"
+    )));
+}
+
+#[test]
+fn graph_serializes_to_json() {
+    let manifests = vec![
+        manifest("types", vec![cap("core", "0.1.0")], vec![]),
+        manifest(
+            "db",
+            vec![cap("pool", "0.1.0")],
+            vec![dep("core", ">=0.1.0", true)],
+        ),
+    ];
+    let graph = DepGraph::from_manifests(&manifests);
+    let json = serde_json::to_string(&graph).unwrap();
+    assert!(json.contains("\"nodes\""));
+    assert!(json.contains("\"edges\""));
+    assert!(json.contains("types"));
+    assert!(json.contains("db"));
+}
+
+#[test]
+fn no_self_cycle_false_positive() {
+    // A module providing cap-a and requiring cap-a should not self-cycle
+    // because we skip self-edges in detect_cycle.
+    let manifests = vec![manifest(
+        "self-ref",
+        vec![cap("cap-x", "1.0.0")],
+        vec![dep("cap-x", ">=1.0.0", true)],
+    )];
+    assert!(DepGraph::validate(&manifests).is_ok());
+}
+
+#[test]
+fn three_node_cycle() {
+    let manifests = vec![
+        manifest(
+            "a",
+            vec![cap("cap-a", "1.0.0")],
+            vec![dep("cap-c", ">=1.0.0", true)],
+        ),
+        manifest(
+            "b",
+            vec![cap("cap-b", "1.0.0")],
+            vec![dep("cap-a", ">=1.0.0", true)],
+        ),
+        manifest(
+            "c",
+            vec![cap("cap-c", "1.0.0")],
+            vec![dep("cap-b", ">=1.0.0", true)],
+        ),
+    ];
+    let errors = DepGraph::validate(&manifests).unwrap_err();
+    assert!(errors
+        .iter()
+        .any(|e| matches!(e, GraphError::CircularDependency { .. })));
+}
+
+#[test]
+fn default_depgraph_is_empty() {
+    let g = DepGraph::default();
+    assert!(g.nodes.is_empty());
+    assert!(g.edges.is_empty());
+}

--- a/daemon/crates/convergio-depgraph/src/lib.rs
+++ b/daemon/crates/convergio-depgraph/src/lib.rs
@@ -1,0 +1,15 @@
+//! convergio-depgraph — Dependency graph validation, OpenAPI, capability listing.
+//!
+//! Validates the extension dependency graph at startup (fail-fast on cycles or
+//! missing deps), blocks unsafe module removal, checks SemVer compatibility,
+//! generates OpenAPI specs from Extension::routes(), and lists all capabilities.
+
+pub mod ext;
+pub mod graph;
+pub mod openapi;
+pub mod removal;
+pub mod routes;
+pub mod semver_check;
+
+pub use ext::DepgraphExtension;
+pub use graph::DepGraph;

--- a/daemon/crates/convergio-depgraph/src/openapi.rs
+++ b/daemon/crates/convergio-depgraph/src/openapi.rs
@@ -1,0 +1,133 @@
+//! OpenAPI spec generation from Extension manifests and route metadata.
+//!
+//! Generates a minimal OpenAPI 3.0 document describing the system's
+//! capabilities, modules, and tools. Full route introspection requires
+//! extensions to declare route metadata (future enhancement).
+
+use convergio_types::manifest::Manifest;
+use serde_json::{json, Value};
+
+/// Generate an OpenAPI 3.0 spec from a set of manifests.
+///
+/// Each module's capabilities become tagged paths, and agent tools
+/// become operation descriptions under `/api/tools/{tool_name}`.
+pub fn generate(manifests: &[Manifest]) -> Value {
+    let mut paths = serde_json::Map::new();
+    let mut tags: Vec<Value> = Vec::new();
+
+    for m in manifests {
+        tags.push(json!({
+            "name": m.id,
+            "description": m.description,
+        }));
+
+        // Capability endpoints
+        for cap in &m.provides {
+            let path = format!("/api/capabilities/{}", cap.name);
+            paths.insert(
+                path,
+                json!({
+                    "get": {
+                        "tags": [&m.id],
+                        "summary": &cap.description,
+                        "operationId": format!("get_{}", cap.name.replace('-', "_")),
+                        "responses": {
+                            "200": {
+                                "description": "Capability info",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "type": "object" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+            );
+        }
+
+        // Agent tool endpoints
+        for tool in &m.agent_tools {
+            let path = format!("/api/tools/{}", tool.name);
+            paths.insert(
+                path,
+                json!({
+                    "post": {
+                        "tags": [&m.id],
+                        "summary": &tool.description,
+                        "operationId": format!("invoke_{}", tool.name.replace('-', "_")),
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": &tool.parameters_schema
+                                }
+                            }
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Tool result",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "type": "object" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+            );
+        }
+    }
+
+    json!({
+        "openapi": "3.0.3",
+        "info": {
+            "title": "Convergio Daemon API",
+            "version": "0.1.0",
+            "description": "Auto-generated from Extension manifests"
+        },
+        "tags": tags,
+        "paths": paths
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use convergio_types::manifest::{Capability, ModuleKind, ToolSpec};
+
+    #[test]
+    fn generates_valid_openapi_structure() {
+        let manifests = vec![Manifest {
+            id: "test-module".into(),
+            description: "A test module".into(),
+            version: "1.0.0".into(),
+            kind: ModuleKind::Extension,
+            provides: vec![Capability {
+                name: "test-cap".into(),
+                version: "1.0.0".into(),
+                description: "Test capability".into(),
+            }],
+            requires: vec![],
+            agent_tools: vec![ToolSpec {
+                name: "test-tool".into(),
+                description: "A test tool".into(),
+                parameters_schema: json!({"type": "object"}),
+            }],
+        }];
+
+        let spec = generate(&manifests);
+        assert_eq!(spec["openapi"], "3.0.3");
+        assert!(spec["info"]["title"].is_string());
+        assert!(spec["paths"]["/api/capabilities/test-cap"].is_object());
+        assert!(spec["paths"]["/api/tools/test-tool"].is_object());
+        assert_eq!(spec["tags"][0]["name"], "test-module");
+    }
+
+    #[test]
+    fn empty_manifests_produces_empty_paths() {
+        let spec = generate(&[]);
+        assert!(spec["paths"].as_object().unwrap().is_empty());
+        assert!(spec["tags"].as_array().unwrap().is_empty());
+    }
+}

--- a/daemon/crates/convergio-depgraph/src/removal.rs
+++ b/daemon/crates/convergio-depgraph/src/removal.rs
@@ -1,0 +1,170 @@
+//! Module removal safety check — blocks removal if it breaks dependents.
+
+use convergio_types::manifest::Manifest;
+use std::collections::HashMap;
+
+/// Result of checking whether a module can be safely removed.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RemovalCheck {
+    /// Module being considered for removal.
+    pub module_id: String,
+    /// Whether removal is safe (no required dependents broken).
+    pub safe: bool,
+    /// Modules that would break if this module is removed.
+    pub would_break: Vec<BrokenDependent>,
+}
+
+/// A module that depends on a capability that would be lost.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BrokenDependent {
+    pub module_id: String,
+    pub capability: String,
+    pub required: bool,
+}
+
+/// Check if removing `target_id` would break any other module's
+/// required dependencies.
+pub fn check_removal(target_id: &str, manifests: &[Manifest]) -> RemovalCheck {
+    // Find capabilities provided by target module.
+    let target = manifests.iter().find(|m| m.id == target_id);
+    let provided_caps: Vec<String> = match target {
+        Some(m) => m.provides.iter().map(|c| c.name.clone()).collect(),
+        None => {
+            return RemovalCheck {
+                module_id: target_id.to_string(),
+                safe: true,
+                would_break: vec![],
+            };
+        }
+    };
+
+    // Check which other providers exist for each capability.
+    let mut cap_providers: HashMap<String, Vec<String>> = HashMap::new();
+    for m in manifests {
+        for cap in &m.provides {
+            cap_providers
+                .entry(cap.name.clone())
+                .or_default()
+                .push(m.id.clone());
+        }
+    }
+
+    // Find dependents that would break.
+    let mut would_break = Vec::new();
+    for m in manifests {
+        if m.id == target_id {
+            continue;
+        }
+        for dep in &m.requires {
+            if provided_caps.contains(&dep.capability) {
+                // Check if another module also provides this.
+                let providers = cap_providers
+                    .get(&dep.capability)
+                    .cloned()
+                    .unwrap_or_default();
+                let alt_exists = providers.iter().any(|p| p != target_id);
+                if !alt_exists {
+                    would_break.push(BrokenDependent {
+                        module_id: m.id.clone(),
+                        capability: dep.capability.clone(),
+                        required: dep.required,
+                    });
+                }
+            }
+        }
+    }
+
+    let safe = !would_break.iter().any(|b| b.required);
+
+    RemovalCheck {
+        module_id: target_id.to_string(),
+        safe,
+        would_break,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use convergio_types::manifest::{Capability, Dependency, ModuleKind};
+
+    fn cap(name: &str) -> Capability {
+        Capability {
+            name: name.into(),
+            version: "0.1.0".into(),
+            description: String::new(),
+        }
+    }
+
+    fn dep(name: &str, required: bool) -> Dependency {
+        Dependency {
+            capability: name.into(),
+            version_req: ">=0.1.0".into(),
+            required,
+        }
+    }
+
+    fn manifest(id: &str, provides: Vec<Capability>, requires: Vec<Dependency>) -> Manifest {
+        Manifest {
+            id: id.into(),
+            description: String::new(),
+            version: "0.1.0".into(),
+            kind: ModuleKind::Core,
+            provides,
+            requires,
+            agent_tools: vec![],
+        }
+    }
+
+    #[test]
+    fn removal_safe_when_no_dependents() {
+        let manifests = vec![
+            manifest("types", vec![cap("core")], vec![]),
+            manifest("unused", vec![cap("nothing")], vec![]),
+        ];
+        let result = check_removal("unused", &manifests);
+        assert!(result.safe);
+        assert!(result.would_break.is_empty());
+    }
+
+    #[test]
+    fn removal_blocked_with_required_dependent() {
+        let manifests = vec![
+            manifest("types", vec![cap("core")], vec![]),
+            manifest("db", vec![], vec![dep("core", true)]),
+        ];
+        let result = check_removal("types", &manifests);
+        assert!(!result.safe);
+        assert_eq!(result.would_break.len(), 1);
+        assert_eq!(result.would_break[0].module_id, "db");
+    }
+
+    #[test]
+    fn removal_ok_with_optional_dependent() {
+        let manifests = vec![
+            manifest("types", vec![cap("core")], vec![]),
+            manifest("ext", vec![], vec![dep("core", false)]),
+        ];
+        let result = check_removal("types", &manifests);
+        assert!(result.safe);
+        assert_eq!(result.would_break.len(), 1);
+    }
+
+    #[test]
+    fn removal_of_nonexistent_module() {
+        let manifests = vec![manifest("types", vec![cap("core")], vec![])];
+        let result = check_removal("ghost", &manifests);
+        assert!(result.safe);
+    }
+
+    #[test]
+    fn removal_ok_when_alt_provider_exists() {
+        let manifests = vec![
+            manifest("provider-a", vec![cap("shared")], vec![]),
+            manifest("provider-b", vec![cap("shared")], vec![]),
+            manifest("consumer", vec![], vec![dep("shared", true)]),
+        ];
+        let result = check_removal("provider-a", &manifests);
+        assert!(result.safe);
+    }
+}

--- a/daemon/crates/convergio-depgraph/src/routes.rs
+++ b/daemon/crates/convergio-depgraph/src/routes.rs
@@ -1,0 +1,113 @@
+//! HTTP routes for depgraph: graph JSON, capabilities, OpenAPI, removal check.
+
+use axum::extract::Path;
+use axum::routing::get;
+use axum::{Json, Router};
+use convergio_types::manifest::Manifest;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use crate::graph::DepGraph;
+use crate::openapi;
+use crate::removal;
+
+/// Shared state for depgraph routes — holds all manifests.
+#[derive(Clone)]
+pub struct DepgraphState {
+    manifests: Arc<Vec<Manifest>>,
+}
+
+impl DepgraphState {
+    pub fn new(manifests: Vec<Manifest>) -> Self {
+        Self {
+            manifests: Arc::new(manifests),
+        }
+    }
+}
+
+/// Build the depgraph router. All routes are `Router<()>`.
+pub fn router(state: DepgraphState) -> Router {
+    Router::new()
+        .route("/api/depgraph", get(graph_handler))
+        .route("/api/depgraph/validate", get(validate_handler))
+        .route("/api/capabilities", get(capabilities_handler))
+        .route("/api/openapi", get(openapi_handler))
+        .route(
+            "/api/depgraph/removal-check/{module_id}",
+            get(removal_check_handler),
+        )
+        .layer(axum::Extension(state))
+}
+
+async fn graph_handler(axum::Extension(state): axum::Extension<DepgraphState>) -> Json<Value> {
+    let graph = DepGraph::from_manifests(&state.manifests);
+    Json(json!({
+        "ok": true,
+        "graph": graph,
+    }))
+}
+
+async fn validate_handler(axum::Extension(state): axum::Extension<DepgraphState>) -> Json<Value> {
+    match DepGraph::validate(&state.manifests) {
+        Ok(()) => Json(json!({ "ok": true, "valid": true, "errors": [] })),
+        Err(errors) => Json(json!({
+            "ok": true,
+            "valid": false,
+            "errors": errors,
+        })),
+    }
+}
+
+async fn capabilities_handler(
+    axum::Extension(state): axum::Extension<DepgraphState>,
+) -> Json<Value> {
+    let mut caps = Vec::new();
+    for m in state.manifests.iter() {
+        for cap in &m.provides {
+            caps.push(json!({
+                "module": &m.id,
+                "name": &cap.name,
+                "version": &cap.version,
+                "description": &cap.description,
+            }));
+        }
+    }
+    let tools: Vec<Value> = state
+        .manifests
+        .iter()
+        .flat_map(|m| {
+            m.agent_tools.iter().map(move |t| {
+                json!({
+                    "module": &m.id,
+                    "name": &t.name,
+                    "description": &t.description,
+                })
+            })
+        })
+        .collect();
+
+    Json(json!({
+        "ok": true,
+        "capabilities": caps,
+        "tools": tools,
+        "module_count": state.manifests.len(),
+        "capability_count": caps.len(),
+        "tool_count": tools.len(),
+    }))
+}
+
+async fn openapi_handler(axum::Extension(state): axum::Extension<DepgraphState>) -> Json<Value> {
+    let spec = openapi::generate(&state.manifests);
+    Json(spec)
+}
+
+async fn removal_check_handler(
+    axum::Extension(state): axum::Extension<DepgraphState>,
+    Path(module_id): Path<String>,
+) -> Json<Value> {
+    let result = removal::check_removal(&module_id, &state.manifests);
+    Json(json!({
+        "ok": true,
+        "removal_check": result,
+    }))
+}

--- a/daemon/crates/convergio-depgraph/src/semver_check.rs
+++ b/daemon/crates/convergio-depgraph/src/semver_check.rs
@@ -1,0 +1,80 @@
+//! SemVer compatibility checking between provided and required versions.
+
+use semver::{Version, VersionReq};
+
+/// Error returned when a version does not satisfy a requirement.
+#[derive(Debug)]
+pub struct SemVerError {
+    pub provided: String,
+    pub required: String,
+}
+
+/// Check that `provided_version` satisfies `version_req_str`.
+///
+/// Both strings are parsed as semver; returns Ok(()) on match,
+/// Err with details on mismatch or parse failure.
+pub fn check(provided_version: &str, version_req_str: &str) -> Result<(), SemVerError> {
+    let provided = Version::parse(provided_version).map_err(|_| SemVerError {
+        provided: provided_version.to_string(),
+        required: version_req_str.to_string(),
+    })?;
+
+    let req = VersionReq::parse(version_req_str).map_err(|_| SemVerError {
+        provided: provided_version.to_string(),
+        required: version_req_str.to_string(),
+    })?;
+
+    if req.matches(&provided) {
+        Ok(())
+    } else {
+        Err(SemVerError {
+            provided: provided_version.to_string(),
+            required: version_req_str.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match() {
+        assert!(check("1.0.0", "=1.0.0").is_ok());
+    }
+
+    #[test]
+    fn range_match() {
+        assert!(check("1.2.3", ">=1.0.0, <2.0.0").is_ok());
+    }
+
+    #[test]
+    fn range_mismatch() {
+        assert!(check("0.9.0", ">=1.0.0").is_err());
+    }
+
+    #[test]
+    fn caret_match() {
+        assert!(check("0.1.5", "^0.1.0").is_ok());
+    }
+
+    #[test]
+    fn caret_mismatch() {
+        assert!(check("0.2.0", "^0.1.0").is_err());
+    }
+
+    #[test]
+    fn wildcard_match() {
+        assert!(check("3.7.1", ">=0.1.0").is_ok());
+    }
+
+    #[test]
+    fn invalid_version_errors() {
+        assert!(check("not-a-version", ">=1.0.0").is_err());
+    }
+
+    #[test]
+    fn invalid_req_errors() {
+        assert!(check("1.0.0", "not-a-req!!!").is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- New `convergio-depgraph` crate implementing dependency graph validation, OpenAPI generation, and capability listing
- `validate_dependency_graph()` runs at startup via `on_start()` — fail-fast if the graph has missing deps, SemVer mismatches, or cycles
- Circular dependency detection using Kahn's topological sort algorithm
- Module removal safety check — blocks removal if required dependents would break, allows if alternative providers exist
- SemVer compatibility: each capability's version is checked against consumers' `version_req` using the `semver` crate
- JSON-serializable `DepGraph` (nodes + edges) for UI visualization
- OpenAPI 3.0 spec auto-generated from Extension manifests (capabilities become GET paths, agent tools become POST paths)
- Full capability listing endpoint with module/capability/tool counts

### Routes
| Endpoint | Method | Description |
|---|---|---|
| `/api/depgraph` | GET | Full graph as JSON (nodes + edges) |
| `/api/depgraph/validate` | GET | Run validation, return errors |
| `/api/capabilities` | GET | List all capabilities and tools |
| `/api/openapi` | GET | Auto-generated OpenAPI 3.0 spec |
| `/api/depgraph/removal-check/{module_id}` | GET | Check if module can be safely removed |

### Files (all under 250 lines)
- `graph.rs` (241) — core graph building, validation, cycle detection
- `graph_tests.rs` (166) — 9 tests for graph validation
- `ext.rs` (166) — Extension trait implementation
- `removal.rs` (170) — module removal safety check + 5 tests
- `openapi.rs` (133) — OpenAPI 3.0 generation + 2 tests
- `routes.rs` (113) — Axum HTTP handlers
- `semver_check.rs` (80) — SemVer compatibility + 8 tests
- `lib.rs` (15) — module declarations

## Test plan
- [x] `cargo test -p convergio-depgraph` — 30 tests pass
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — formatted
- [x] All files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)