### PR TITLE
feat: fase 15 — long-running execution protocol

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -529,6 +529,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-longrunning"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "convergio-db",
+ "convergio-ipc",
+ "convergio-telemetry",
+ "convergio-types",
+ "r2d2",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "convergio-mesh"
 version = "0.1.0"
 dependencies = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/convergio-org-package",
     "crates/convergio-http-bridge",
     "crates/convergio-depgraph",
+    "crates/convergio-longrunning",
 ]
 
 [package]

--- a/daemon/crates/convergio-longrunning/Cargo.toml
+++ b/daemon/crates/convergio-longrunning/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "convergio-longrunning"
+description = "Long-running execution protocol: heartbeat, checkpoint, resume, budget guard, delegation chain"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
+convergio-ipc = { path = "../convergio-ipc" }
+convergio-telemetry = { path = "../convergio-telemetry" }
+tracing = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+rusqlite = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+r2d2 = { workspace = true }

--- a/daemon/crates/convergio-longrunning/src/budget.rs
+++ b/daemon/crates/convergio-longrunning/src/budget.rs
@@ -1,0 +1,171 @@
+//! Budget guard — stops execution when budget is exhausted.
+//!
+//! Tracks cost per execution and enforces limits. When spent >= limit,
+//! the execution is paused and a BudgetExceeded error is returned.
+
+use rusqlite::{params, Connection};
+
+use crate::types::{LongRunError, LongRunResult};
+
+/// Record cost for an execution and check budget.
+///
+/// Returns Ok(remaining) if within budget, or BudgetExceeded error if over.
+pub fn record_cost(conn: &Connection, execution_id: &str, cost_usd: f64) -> LongRunResult<f64> {
+    // Atomically update spent
+    conn.execute(
+        "UPDATE lr_executions SET spent_usd = spent_usd + ?1, \
+         updated_at = datetime('now') WHERE id = ?2",
+        params![cost_usd, execution_id],
+    )?;
+
+    // Check budget
+    let (spent, budget): (f64, f64) = conn.query_row(
+        "SELECT spent_usd, budget_usd FROM lr_executions WHERE id = ?1",
+        params![execution_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+
+    // budget_usd == 0 means unlimited
+    if budget > 0.0 && spent >= budget {
+        // Pause the execution
+        conn.execute(
+            "UPDATE lr_executions SET stage = 'paused', \
+             updated_at = datetime('now') WHERE id = ?1",
+            params![execution_id],
+        )?;
+        tracing::warn!(
+            execution_id,
+            spent,
+            budget,
+            "budget exhausted, execution paused"
+        );
+        return Err(LongRunError::BudgetExceeded {
+            spent,
+            limit: budget,
+        });
+    }
+
+    let remaining = if budget > 0.0 {
+        budget - spent
+    } else {
+        f64::INFINITY
+    };
+    Ok(remaining)
+}
+
+/// Get current budget status for an execution.
+pub fn status(conn: &Connection, execution_id: &str) -> LongRunResult<(f64, f64)> {
+    let result = conn.query_row(
+        "SELECT spent_usd, budget_usd FROM lr_executions WHERE id = ?1",
+        params![execution_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    );
+    match result {
+        Ok(pair) => Ok(pair),
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            Err(LongRunError::NotFound(execution_id.to_string()))
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Propagate budget from parent to child execution.
+/// Child gets a fraction of the remaining parent budget.
+pub fn propagate(
+    conn: &Connection,
+    parent_id: &str,
+    child_id: &str,
+    fraction: f64,
+) -> LongRunResult<f64> {
+    let (parent_spent, parent_budget) = status(conn, parent_id)?;
+    let remaining = if parent_budget > 0.0 {
+        (parent_budget - parent_spent).max(0.0)
+    } else {
+        0.0 // unlimited parent => child gets 0 (unlimited)
+    };
+    let child_budget = remaining * fraction.clamp(0.0, 1.0);
+    conn.execute(
+        "UPDATE lr_executions SET budget_usd = ?1, \
+         updated_at = datetime('now') WHERE id = ?2",
+        params![child_budget, child_id],
+    )?;
+    Ok(child_budget)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn record_cost_within_budget() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node, budget_usd) \
+             VALUES ('e1', 'a', 'n', 1.0)",
+            [],
+        )
+        .unwrap();
+        let remaining = record_cost(&conn, "e1", 0.3).unwrap();
+        assert!((remaining - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn record_cost_exceeds_budget() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node, budget_usd) \
+             VALUES ('e2', 'a', 'n', 0.5)",
+            [],
+        )
+        .unwrap();
+        let err = record_cost(&conn, "e2", 0.6).unwrap_err();
+        assert!(err.to_string().contains("budget exceeded"));
+    }
+
+    #[test]
+    fn unlimited_budget_always_ok() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node, budget_usd) \
+             VALUES ('e3', 'a', 'n', 0.0)",
+            [],
+        )
+        .unwrap();
+        let remaining = record_cost(&conn, "e3", 100.0).unwrap();
+        assert!(remaining.is_infinite());
+    }
+
+    #[test]
+    fn propagate_budget_to_child() {
+        let conn = setup();
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node, budget_usd) \
+             VALUES ('parent', 'a', 'n', 10.0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node, parent_id) \
+             VALUES ('child', 'b', 'n', 'parent')",
+            [],
+        )
+        .unwrap();
+        let child_budget = propagate(&conn, "parent", "child", 0.5).unwrap();
+        assert!((child_budget - 5.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn status_not_found() {
+        let conn = setup();
+        let err = status(&conn, "nope").unwrap_err();
+        assert!(err.to_string().contains("nope"));
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/checkpoint.rs
+++ b/daemon/crates/convergio-longrunning/src/checkpoint.rs
@@ -1,0 +1,110 @@
+//! Checkpoint persistence — save and restore execution state.
+//!
+//! Each execution can save arbitrary JSON state. On resume, the last
+//! checkpoint is loaded and passed back to the LongRunnable.
+
+use rusqlite::{params, Connection};
+use serde_json::Value;
+
+use crate::types::LongRunResult;
+
+/// Save a checkpoint for an execution. Replaces previous checkpoint.
+pub fn save(conn: &Connection, execution_id: &str, state: &Value) -> LongRunResult<()> {
+    let state_json = serde_json::to_string(state)?;
+    // Remove old checkpoint, insert fresh
+    conn.execute(
+        "DELETE FROM lr_checkpoints WHERE execution_id = ?1",
+        params![execution_id],
+    )?;
+    conn.execute(
+        "INSERT INTO lr_checkpoints (execution_id, state) VALUES (?1, ?2)",
+        params![execution_id, state_json],
+    )?;
+    // Update execution stage
+    conn.execute(
+        "UPDATE lr_executions SET stage = 'checkpointing', \
+         updated_at = datetime('now') WHERE id = ?1",
+        params![execution_id],
+    )?;
+    tracing::debug!(execution_id, "checkpoint saved");
+    Ok(())
+}
+
+/// Load the most recent checkpoint for an execution.
+pub fn load(conn: &Connection, execution_id: &str) -> LongRunResult<Option<Value>> {
+    let mut stmt = conn.prepare(
+        "SELECT state FROM lr_checkpoints \
+         WHERE execution_id = ?1 ORDER BY id DESC LIMIT 1",
+    )?;
+    let result = stmt.query_row(params![execution_id], |row| row.get::<_, String>(0));
+    match result {
+        Ok(json_str) => {
+            let val: Value = serde_json::from_str(&json_str)?;
+            Ok(Some(val))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Remove all checkpoints for an execution (after completion).
+pub fn clear(conn: &Connection, execution_id: &str) -> LongRunResult<usize> {
+    let n = conn.execute(
+        "DELETE FROM lr_checkpoints WHERE execution_id = ?1",
+        params![execution_id],
+    )?;
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node) VALUES ('e1', 'a', 'n')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let conn = setup();
+        let state = json!({"wave": 2, "tasks_done": 5});
+        save(&conn, "e1", &state).unwrap();
+        let loaded = load(&conn, "e1").unwrap().unwrap();
+        assert_eq!(loaded["wave"], 2);
+        assert_eq!(loaded["tasks_done"], 5);
+    }
+
+    #[test]
+    fn load_missing_returns_none() {
+        let conn = setup();
+        assert!(load(&conn, "nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn save_replaces_previous() {
+        let conn = setup();
+        save(&conn, "e1", &json!({"v": 1})).unwrap();
+        save(&conn, "e1", &json!({"v": 2})).unwrap();
+        let loaded = load(&conn, "e1").unwrap().unwrap();
+        assert_eq!(loaded["v"], 2);
+    }
+
+    #[test]
+    fn clear_removes_all() {
+        let conn = setup();
+        save(&conn, "e1", &json!({})).unwrap();
+        let n = clear(&conn, "e1").unwrap();
+        assert_eq!(n, 1);
+        assert!(load(&conn, "e1").unwrap().is_none());
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/delegation.rs
+++ b/daemon/crates/convergio-longrunning/src/delegation.rs
@@ -1,0 +1,118 @@
+//! Delegation chain — tree of parent-child execution relationships.
+//!
+//! Tracks the complete delegation tree with budget/deadline propagation
+//! and death cascade (parent reaped => children reaped).
+
+use rusqlite::{params, Connection};
+
+use crate::types::{DelegationNode, ExecutionStage, LongRunResult};
+
+/// Register a child execution under a parent.
+pub fn create_child(
+    conn: &Connection,
+    child_id: &str,
+    parent_id: &str,
+    agent: &str,
+    node: &str,
+    budget_usd: f64,
+    deadline: Option<&str>,
+) -> LongRunResult<()> {
+    conn.execute(
+        "INSERT INTO lr_executions \
+         (id, agent, node, parent_id, budget_usd, deadline, stage) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'starting')",
+        params![child_id, agent, node, parent_id, budget_usd, deadline],
+    )?;
+    tracing::info!(child_id, parent_id, agent, "delegation child created");
+    Ok(())
+}
+
+/// Build the full delegation tree rooted at `root_id`.
+pub fn build_tree(conn: &Connection, root_id: &str) -> LongRunResult<Option<DelegationNode>> {
+    let root = load_node(conn, root_id)?;
+    match root {
+        Some(mut node) => {
+            populate_children(conn, &mut node)?;
+            Ok(Some(node))
+        }
+        None => Ok(None),
+    }
+}
+
+/// List direct children of an execution.
+pub fn list_children(conn: &Connection, parent_id: &str) -> LongRunResult<Vec<DelegationNode>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, parent_id, agent, node, budget_usd, deadline, stage \
+         FROM lr_executions WHERE parent_id = ?1 ORDER BY created_at",
+    )?;
+    let rows = stmt.query_map(params![parent_id], map_row)?;
+    let mut children = Vec::new();
+    for row in rows {
+        children.push(row?);
+    }
+    Ok(children)
+}
+
+/// Cascade death: mark all descendants of a reaped execution as reaped.
+pub fn cascade_death(conn: &Connection, parent_id: &str) -> LongRunResult<usize> {
+    // Recursive CTE to find all descendants
+    let n = conn.execute(
+        "WITH RECURSIVE descendants(id) AS ( \
+             SELECT id FROM lr_executions WHERE parent_id = ?1 \
+             UNION ALL \
+             SELECT e.id FROM lr_executions e \
+             JOIN descendants d ON e.parent_id = d.id \
+         ) \
+         UPDATE lr_executions SET stage = 'reaped', \
+         updated_at = datetime('now') \
+         WHERE id IN (SELECT id FROM descendants) \
+         AND stage NOT IN ('completing', 'failed', 'reaped')",
+        params![parent_id],
+    )?;
+    if n > 0 {
+        tracing::warn!(parent_id, descendants_reaped = n, "death cascaded");
+    }
+    Ok(n)
+}
+
+fn load_node(conn: &Connection, id: &str) -> LongRunResult<Option<DelegationNode>> {
+    let result = conn.query_row(
+        "SELECT id, parent_id, agent, node, budget_usd, deadline, stage \
+         FROM lr_executions WHERE id = ?1",
+        params![id],
+        map_row,
+    );
+    match result {
+        Ok(node) => Ok(Some(node)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn populate_children(conn: &Connection, node: &mut DelegationNode) -> LongRunResult<()> {
+    let children = list_children(conn, &node.execution_id)?;
+    for mut child in children {
+        populate_children(conn, &mut child)?;
+        node.children.push(child);
+    }
+    Ok(())
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DelegationNode> {
+    let stage_str: String = row.get(6)?;
+    let stage = ExecutionStage::parse(&stage_str).unwrap_or(ExecutionStage::Running);
+    Ok(DelegationNode {
+        execution_id: row.get(0)?,
+        parent_id: row.get(1)?,
+        agent: row.get(2)?,
+        node: row.get(3)?,
+        budget_usd: row.get(4)?,
+        deadline: row.get(5)?,
+        stage,
+        children: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+#[path = "delegation_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-longrunning/src/delegation_tests.rs
+++ b/daemon/crates/convergio-longrunning/src/delegation_tests.rs
@@ -1,0 +1,97 @@
+//! Tests for delegation chain module.
+
+use super::*;
+use rusqlite::Connection;
+
+fn setup() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    for m in crate::schema::migrations() {
+        conn.execute_batch(m.up).unwrap();
+    }
+    // Insert root execution
+    conn.execute(
+        "INSERT INTO lr_executions (id, agent, node, budget_usd, stage) \
+         VALUES ('root', 'elena', 'M5Max', 10.0, 'running')",
+        [],
+    )
+    .unwrap();
+    conn
+}
+
+#[test]
+fn create_and_list_children() {
+    let conn = setup();
+    create_child(&conn, "child-1", "root", "baccio", "M1Pro", 3.0, None).unwrap();
+    create_child(
+        &conn,
+        "child-2",
+        "root",
+        "marco",
+        "M5Max",
+        2.0,
+        Some("2026-04-10T00:00:00Z"),
+    )
+    .unwrap();
+    let children = list_children(&conn, "root").unwrap();
+    assert_eq!(children.len(), 2);
+    assert_eq!(children[0].agent, "baccio");
+    assert_eq!(
+        children[1].deadline.as_deref(),
+        Some("2026-04-10T00:00:00Z")
+    );
+}
+
+#[test]
+fn build_tree_nested() {
+    let conn = setup();
+    create_child(&conn, "mid", "root", "baccio", "M1Pro", 5.0, None).unwrap();
+    create_child(&conn, "leaf", "mid", "marco", "M5Max", 2.0, None).unwrap();
+    let tree = build_tree(&conn, "root").unwrap().unwrap();
+    assert_eq!(tree.execution_id, "root");
+    assert_eq!(tree.children.len(), 1);
+    assert_eq!(tree.children[0].execution_id, "mid");
+    assert_eq!(tree.children[0].children.len(), 1);
+    assert_eq!(tree.children[0].children[0].execution_id, "leaf");
+}
+
+#[test]
+fn build_tree_missing_returns_none() {
+    let conn = setup();
+    assert!(build_tree(&conn, "nonexistent").unwrap().is_none());
+}
+
+#[test]
+fn cascade_death_kills_descendants() {
+    let conn = setup();
+    create_child(&conn, "mid", "root", "b", "n", 0.0, None).unwrap();
+    create_child(&conn, "leaf", "mid", "c", "n", 0.0, None).unwrap();
+    // Mark both as running
+    conn.execute(
+        "UPDATE lr_executions SET stage = 'running' WHERE id IN ('mid', 'leaf')",
+        [],
+    )
+    .unwrap();
+    let reaped = cascade_death(&conn, "root").unwrap();
+    assert_eq!(reaped, 2);
+    let stage: String = conn
+        .query_row(
+            "SELECT stage FROM lr_executions WHERE id = 'leaf'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stage, "reaped");
+}
+
+#[test]
+fn cascade_death_skips_terminal() {
+    let conn = setup();
+    create_child(&conn, "done-child", "root", "b", "n", 0.0, None).unwrap();
+    conn.execute(
+        "UPDATE lr_executions SET stage = 'completing' WHERE id = 'done-child'",
+        [],
+    )
+    .unwrap();
+    let reaped = cascade_death(&conn, "root").unwrap();
+    assert_eq!(reaped, 0);
+}

--- a/daemon/crates/convergio-longrunning/src/ext.rs
+++ b/daemon/crates/convergio-longrunning/src/ext.rs
@@ -1,0 +1,171 @@
+//! LongRunningExtension — impl Extension for the long-running protocol.
+
+use std::time::Duration;
+
+use convergio_db::pool::ConnPool;
+use convergio_types::extension::{
+    AppContext, ExtResult, Extension, Health, Metric, Migration, ScheduledTask,
+};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+/// The Extension entry point for the long-running execution protocol.
+pub struct LongRunningExtension {
+    pool: ConnPool,
+}
+
+impl LongRunningExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &ConnPool {
+        &self.pool
+    }
+}
+
+impl Default for LongRunningExtension {
+    fn default() -> Self {
+        let pool = convergio_db::pool::create_memory_pool().expect("in-memory pool for default");
+        Self { pool }
+    }
+}
+
+impl Extension for LongRunningExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-longrunning".to_string(),
+            description: "Long-running execution protocol: heartbeat, \
+                          checkpoint, resume, budget guard, delegation chain"
+                .to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![
+                Capability {
+                    name: "heartbeat-monitor".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Liveness tracking for long-running executions".to_string(),
+                },
+                Capability {
+                    name: "checkpoint-resume".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Persist and restore execution state".to_string(),
+                },
+                Capability {
+                    name: "budget-guard".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Stop execution when budget exhausted".to_string(),
+                },
+                Capability {
+                    name: "delegation-chain".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Tree of delegated executions with cascade".to_string(),
+                },
+            ],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("longrunning: starting heartbeat reaper");
+        let reaper_interval = Duration::from_secs(60);
+        crate::reaper::spawn_reaper(self.pool.clone(), reaper_interval);
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match self.pool.get() {
+            Ok(conn) => {
+                let ok = conn
+                    .query_row("SELECT COUNT(*) FROM lr_executions", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
+                    .is_ok();
+                if ok {
+                    Health::Ok
+                } else {
+                    Health::Degraded {
+                        reason: "lr_executions table inaccessible".into(),
+                    }
+                }
+            }
+            Err(e) => Health::Down {
+                reason: format!("pool error: {e}"),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(_) => return vec![],
+        };
+        let mut metrics = Vec::new();
+        if let Ok(n) = conn.query_row(
+            "SELECT COUNT(*) FROM lr_executions WHERE stage = 'running'",
+            [],
+            |r| r.get::<_, f64>(0),
+        ) {
+            metrics.push(Metric {
+                name: "longrunning.executions.active".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        if let Ok(n) = conn.query_row(
+            "SELECT COUNT(*) FROM lr_executions WHERE stage = 'reaped'",
+            [],
+            |r| r.get::<_, f64>(0),
+        ) {
+            metrics.push(Metric {
+                name: "longrunning.executions.reaped".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        metrics
+    }
+
+    fn scheduled_tasks(&self) -> Vec<ScheduledTask> {
+        vec![ScheduledTask {
+            name: "heartbeat-reaper",
+            cron: "* * * * *",
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_has_correct_id() {
+        let ext = LongRunningExtension::default();
+        let m = ext.manifest();
+        assert_eq!(m.id, "convergio-longrunning");
+        assert_eq!(m.provides.len(), 4);
+    }
+
+    #[test]
+    fn migrations_are_returned() {
+        let ext = LongRunningExtension::default();
+        let migs = ext.migrations();
+        assert_eq!(migs.len(), 3);
+    }
+
+    #[test]
+    fn health_ok_with_memory_pool() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+        let ext = LongRunningExtension::new(pool);
+        assert!(matches!(ext.health(), Health::Ok));
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/heartbeat.rs
+++ b/daemon/crates/convergio-longrunning/src/heartbeat.rs
@@ -1,0 +1,118 @@
+//! Heartbeat monitor — tracks liveness of long-running executions.
+//!
+//! Each execution registers its expected heartbeat interval. The monitor
+//! updates `lr_heartbeats` on each beat. The reaper checks for stale entries.
+
+use rusqlite::{params, Connection};
+
+use crate::types::LongRunResult;
+
+/// Register a new execution for heartbeat monitoring.
+pub fn register(conn: &Connection, execution_id: &str, interval_secs: u64) -> LongRunResult<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO lr_heartbeats (execution_id, last_seen, interval_s) \
+         VALUES (?1, datetime('now'), ?2)",
+        params![execution_id, interval_secs as i64],
+    )?;
+    tracing::debug!(execution_id, interval_secs, "heartbeat registered");
+    Ok(())
+}
+
+/// Record a heartbeat for an execution.
+pub fn beat(conn: &Connection, execution_id: &str) -> LongRunResult<()> {
+    let updated = conn.execute(
+        "UPDATE lr_heartbeats SET last_seen = datetime('now') \
+         WHERE execution_id = ?1",
+        params![execution_id],
+    )?;
+    if updated == 0 {
+        return Err(crate::types::LongRunError::NotFound(format!(
+            "no heartbeat registration for {execution_id}"
+        )));
+    }
+    Ok(())
+}
+
+/// Remove heartbeat tracking for a completed execution.
+pub fn unregister(conn: &Connection, execution_id: &str) -> LongRunResult<()> {
+    conn.execute(
+        "DELETE FROM lr_heartbeats WHERE execution_id = ?1",
+        params![execution_id],
+    )?;
+    Ok(())
+}
+
+/// Find executions whose heartbeat is stale (last_seen older than 3x interval).
+/// Returns list of (execution_id, elapsed_secs, max_secs).
+pub fn find_stale(conn: &Connection) -> LongRunResult<Vec<(String, u64, u64)>> {
+    let mut stmt = conn.prepare(
+        "SELECT execution_id, interval_s, \
+         CAST((julianday('now') - julianday(last_seen)) * 86400 AS INTEGER) \
+         AS elapsed_s \
+         FROM lr_heartbeats \
+         WHERE elapsed_s > (interval_s * 3)",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    let mut stale = Vec::new();
+    for row in rows {
+        let (id, interval, elapsed) = row?;
+        let max = (interval * 3) as u64;
+        stale.push((id, elapsed as u64, max));
+    }
+    Ok(stale)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node) VALUES ('e1', 'a', 'n')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn register_and_beat() {
+        let conn = setup();
+        register(&conn, "e1", 30).unwrap();
+        beat(&conn, "e1").unwrap();
+    }
+
+    #[test]
+    fn beat_unknown_errors() {
+        let conn = setup();
+        let err = beat(&conn, "nonexistent").unwrap_err();
+        assert!(err.to_string().contains("no heartbeat registration"));
+    }
+
+    #[test]
+    fn unregister_removes_entry() {
+        let conn = setup();
+        register(&conn, "e1", 30).unwrap();
+        unregister(&conn, "e1").unwrap();
+        let err = beat(&conn, "e1").unwrap_err();
+        assert!(err.to_string().contains("no heartbeat"));
+    }
+
+    #[test]
+    fn find_stale_empty_when_fresh() {
+        let conn = setup();
+        register(&conn, "e1", 30).unwrap();
+        let stale = find_stale(&conn).unwrap();
+        assert!(stale.is_empty(), "fresh heartbeat should not be stale");
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/lib.rs
+++ b/daemon/crates/convergio-longrunning/src/lib.rs
@@ -1,0 +1,21 @@
+//! convergio-longrunning — Long-running execution protocol.
+//!
+//! Provides heartbeat monitoring, checkpoint persistence, budget guards,
+//! progress streaming via SSE, and delegation chain tracking.
+//!
+//! Deps: types, db, ipc (SSE), orchestrator (via types only).
+
+pub mod budget;
+pub mod checkpoint;
+pub mod delegation;
+pub mod ext;
+pub mod heartbeat;
+pub mod progress;
+pub mod reaper;
+pub mod schema;
+pub mod traits;
+pub mod types;
+
+pub use ext::LongRunningExtension;
+pub use traits::LongRunnable;
+pub use types::{LongRunError, LongRunResult};

--- a/daemon/crates/convergio-longrunning/src/progress.rs
+++ b/daemon/crates/convergio-longrunning/src/progress.rs
@@ -1,0 +1,137 @@
+//! Progress tracking and SSE streaming for long-running executions.
+//!
+//! Updates are stored in lr_executions and published to the IPC event bus
+//! so SSE clients can stream percentage, stage, cost, and ETA in real time.
+
+use std::sync::Arc;
+
+use convergio_ipc::sse::{EventBus, IpcEvent};
+use rusqlite::{params, Connection};
+
+use crate::types::{ExecutionStage, LongRunResult, ProgressSnapshot};
+
+/// Update progress for an execution and publish via SSE.
+pub fn update(
+    conn: &Connection,
+    bus: Option<&Arc<EventBus>>,
+    snap: &ProgressSnapshot,
+) -> LongRunResult<()> {
+    conn.execute(
+        "UPDATE lr_executions SET percent = ?1, stage = ?2, \
+         message = ?3, updated_at = datetime('now') WHERE id = ?4",
+        params![
+            snap.percent,
+            snap.stage.as_str(),
+            snap.message,
+            snap.execution_id,
+        ],
+    )?;
+
+    // Publish to SSE bus if available
+    if let Some(bus) = bus {
+        let data = serde_json::to_string(snap).unwrap_or_default();
+        bus.publish(IpcEvent {
+            from: "longrunning".into(),
+            to: None,
+            content: data,
+            event_type: "progress".into(),
+            ts: chrono::Utc::now().to_rfc3339(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Load current progress for an execution.
+pub fn load(conn: &Connection, execution_id: &str) -> LongRunResult<Option<ProgressSnapshot>> {
+    let result = conn.query_row(
+        "SELECT percent, stage, spent_usd, message FROM lr_executions \
+         WHERE id = ?1",
+        params![execution_id],
+        |row| {
+            Ok((
+                row.get::<_, f64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, f64>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        },
+    );
+    match result {
+        Ok((percent, stage_str, cost, message)) => {
+            let stage = ExecutionStage::parse(&stage_str).unwrap_or(ExecutionStage::Running);
+            Ok(Some(ProgressSnapshot {
+                execution_id: execution_id.to_string(),
+                percent,
+                stage,
+                cost_usd: cost,
+                eta_secs: None,
+                message,
+            }))
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO lr_executions (id, agent, node) \
+             VALUES ('e1', 'agent-a', 'node-1')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn update_and_load_progress() {
+        let conn = setup();
+        let snap = ProgressSnapshot {
+            execution_id: "e1".into(),
+            percent: 55.0,
+            stage: ExecutionStage::Running,
+            cost_usd: 0.12,
+            eta_secs: Some(60),
+            message: Some("wave 3 of 5".into()),
+        };
+        update(&conn, None, &snap).unwrap();
+        let loaded = load(&conn, "e1").unwrap().unwrap();
+        assert!((loaded.percent - 55.0).abs() < 0.001);
+        assert_eq!(loaded.stage, ExecutionStage::Running);
+        assert_eq!(loaded.message.as_deref(), Some("wave 3 of 5"));
+    }
+
+    #[test]
+    fn load_missing_returns_none() {
+        let conn = setup();
+        assert!(load(&conn, "nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn update_with_event_bus() {
+        let bus = Arc::new(EventBus::new(16));
+        let mut rx = bus.subscribe();
+        let conn = setup();
+        let snap = ProgressSnapshot {
+            execution_id: "e1".into(),
+            percent: 75.0,
+            stage: ExecutionStage::Checkpointing,
+            cost_usd: 0.0,
+            eta_secs: None,
+            message: None,
+        };
+        update(&conn, Some(&bus), &snap).unwrap();
+        let event = rx.try_recv().unwrap();
+        assert_eq!(event.event_type, "progress");
+        assert!(event.content.contains("75.0"));
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/reaper.rs
+++ b/daemon/crates/convergio-longrunning/src/reaper.rs
@@ -1,0 +1,136 @@
+//! Heartbeat reaper — kills stale long-running executions.
+//!
+//! Runs periodically, finds executions with no heartbeat beyond 3x interval,
+//! marks them as reaped, and propagates death to delegation children.
+
+use std::time::Duration;
+
+use convergio_db::pool::ConnPool;
+use rusqlite::params;
+
+use crate::types::LongRunResult;
+
+/// Reap result for a single execution.
+#[derive(Debug, Clone)]
+pub struct ReapedExecution {
+    pub execution_id: String,
+    pub elapsed_secs: u64,
+    pub max_secs: u64,
+}
+
+/// Run one reaper cycle: find stale heartbeats, mark as reaped, kill children.
+pub fn reap_cycle(pool: &ConnPool) -> LongRunResult<Vec<ReapedExecution>> {
+    let conn = pool.get()?;
+    let stale = crate::heartbeat::find_stale(&conn)?;
+    let mut reaped = Vec::new();
+
+    for (exec_id, elapsed, max) in &stale {
+        tracing::warn!(
+            execution_id = exec_id.as_str(),
+            elapsed_secs = elapsed,
+            max_secs = max,
+            "reaping stale execution"
+        );
+        // Mark execution as reaped
+        conn.execute(
+            "UPDATE lr_executions SET stage = 'reaped', \
+             updated_at = datetime('now') WHERE id = ?1",
+            params![exec_id],
+        )?;
+        // Propagate death to children
+        conn.execute(
+            "UPDATE lr_executions SET stage = 'reaped', \
+             updated_at = datetime('now') \
+             WHERE parent_id = ?1 AND stage NOT IN ('completing', 'failed', 'reaped')",
+            params![exec_id],
+        )?;
+        // Clean up heartbeat
+        crate::heartbeat::unregister(&conn, exec_id)?;
+
+        reaped.push(ReapedExecution {
+            execution_id: exec_id.clone(),
+            elapsed_secs: *elapsed,
+            max_secs: *max,
+        });
+    }
+
+    if !reaped.is_empty() {
+        tracing::info!(count = reaped.len(), "reaper cycle: reaped executions");
+    }
+    Ok(reaped)
+}
+
+/// Spawn the reaper as a background tokio task.
+pub fn spawn_reaper(pool: ConnPool, interval: Duration) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // skip immediate first tick
+        loop {
+            ticker.tick().await;
+            match reap_cycle(&pool) {
+                Ok(reaped) => {
+                    if !reaped.is_empty() {
+                        tracing::info!(count = reaped.len(), "longrunning reaper: cycle complete");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("longrunning reaper: cycle failed: {e}");
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reap_cycle_empty_when_no_stale() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        {
+            let conn = pool.get().unwrap();
+            for m in crate::schema::migrations() {
+                conn.execute_batch(m.up).unwrap();
+            }
+        }
+        let reaped = reap_cycle(&pool).unwrap();
+        assert!(reaped.is_empty());
+    }
+
+    #[test]
+    fn reap_cycle_marks_stale_as_reaped() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        {
+            let conn = pool.get().unwrap();
+            for m in crate::schema::migrations() {
+                conn.execute_batch(m.up).unwrap();
+            }
+            conn.execute(
+                "INSERT INTO lr_executions (id, agent, node, stage) \
+                 VALUES ('stale-1', 'agent-a', 'node-1', 'running')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO lr_heartbeats (execution_id, last_seen, interval_s) \
+                 VALUES ('stale-1', datetime('now', '-300 seconds'), 10)",
+                [],
+            )
+            .unwrap();
+        }
+        let reaped = reap_cycle(&pool).unwrap();
+        assert_eq!(reaped.len(), 1);
+        assert_eq!(reaped[0].execution_id, "stale-1");
+
+        let conn = pool.get().unwrap();
+        let stage: String = conn
+            .query_row(
+                "SELECT stage FROM lr_executions WHERE id = 'stale-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stage, "reaped");
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/schema.rs
+++ b/daemon/crates/convergio-longrunning/src/schema.rs
@@ -1,0 +1,87 @@
+//! DB migrations for the long-running execution protocol.
+//!
+//! Tables: lr_executions, lr_checkpoints, lr_heartbeats, lr_delegations.
+
+use convergio_types::extension::Migration;
+
+pub fn migrations() -> Vec<Migration> {
+    vec![
+        Migration {
+            version: 1,
+            description: "long-running executions table",
+            up: "\
+CREATE TABLE IF NOT EXISTS lr_executions (
+    id          TEXT PRIMARY KEY,
+    agent       TEXT NOT NULL,
+    node        TEXT NOT NULL,
+    parent_id   TEXT,
+    stage       TEXT NOT NULL DEFAULT 'starting',
+    budget_usd  REAL NOT NULL DEFAULT 0.0,
+    spent_usd   REAL NOT NULL DEFAULT 0.0,
+    deadline    TEXT,
+    percent     REAL NOT NULL DEFAULT 0.0,
+    message     TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_lr_exec_stage ON lr_executions(stage);
+CREATE INDEX IF NOT EXISTS idx_lr_exec_parent ON lr_executions(parent_id);",
+        },
+        Migration {
+            version: 2,
+            description: "checkpoint persistence table",
+            up: "\
+CREATE TABLE IF NOT EXISTS lr_checkpoints (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id TEXT NOT NULL,
+    state        TEXT NOT NULL DEFAULT '{}',
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (execution_id) REFERENCES lr_executions(id)
+);
+CREATE INDEX IF NOT EXISTS idx_lr_ckpt_exec ON lr_checkpoints(execution_id);",
+        },
+        Migration {
+            version: 3,
+            description: "heartbeat tracking table",
+            up: "\
+CREATE TABLE IF NOT EXISTS lr_heartbeats (
+    execution_id TEXT PRIMARY KEY,
+    last_seen    TEXT NOT NULL DEFAULT (datetime('now')),
+    interval_s   INTEGER NOT NULL DEFAULT 30,
+    FOREIGN KEY (execution_id) REFERENCES lr_executions(id)
+);",
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_have_sequential_versions() {
+        let migs = migrations();
+        assert!(!migs.is_empty());
+        for (i, m) in migs.iter().enumerate() {
+            assert_eq!(m.version, (i + 1) as u32);
+        }
+    }
+
+    #[test]
+    fn migrations_apply_to_sqlite() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        for m in migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        // Verify tables exist
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' \
+                 AND name LIKE 'lr_%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/traits.rs
+++ b/daemon/crates/convergio-longrunning/src/traits.rs
@@ -1,0 +1,116 @@
+//! LongRunnable trait — the contract for long-running executions.
+//!
+//! Any execution that can last hours/days implements this trait
+//! to participate in heartbeat monitoring, checkpointing, and budget tracking.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::types::{ExecutionStage, ProgressSnapshot};
+
+/// The contract for long-running executions in Convergio.
+///
+/// Implementors get automatic heartbeat monitoring, checkpoint persistence,
+/// budget enforcement, and progress streaming via SSE.
+pub trait LongRunnable: Send + Sync {
+    /// Unique identifier for this execution.
+    fn execution_id(&self) -> &str;
+
+    /// How often the monitor should expect a heartbeat.
+    /// If no heartbeat arrives within 3x this interval, the reaper kills it.
+    fn heartbeat_interval(&self) -> Duration {
+        Duration::from_secs(30)
+    }
+
+    /// Save current state for later resume. Called periodically and before pause.
+    fn checkpoint(&self) -> Value {
+        Value::Null
+    }
+
+    /// Resume from a previously saved checkpoint.
+    fn resume(&mut self, _state: Value) {
+        // Default: no-op (stateless execution)
+    }
+
+    /// Current progress snapshot for SSE streaming.
+    fn progress(&self) -> ProgressSnapshot {
+        ProgressSnapshot {
+            execution_id: self.execution_id().to_string(),
+            percent: 0.0,
+            stage: ExecutionStage::Running,
+            cost_usd: 0.0,
+            eta_secs: None,
+            message: None,
+        }
+    }
+
+    /// Budget limit in USD. None = unlimited.
+    fn budget_limit_usd(&self) -> Option<f64> {
+        None
+    }
+
+    /// Deadline (ISO 8601). None = no deadline.
+    fn deadline(&self) -> Option<String> {
+        None
+    }
+
+    /// Parent execution ID for delegation chains.
+    fn parent_execution_id(&self) -> Option<&str> {
+        None
+    }
+
+    /// Agent name running this execution.
+    fn agent_name(&self) -> &str;
+
+    /// Node where this execution is running.
+    fn node_name(&self) -> &str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestExec {
+        id: String,
+    }
+
+    impl LongRunnable for TestExec {
+        fn execution_id(&self) -> &str {
+            &self.id
+        }
+        fn agent_name(&self) -> &str {
+            "test-agent"
+        }
+        fn node_name(&self) -> &str {
+            "test-node"
+        }
+    }
+
+    #[test]
+    fn default_heartbeat_interval() {
+        let exec = TestExec { id: "e1".into() };
+        assert_eq!(exec.heartbeat_interval(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn default_checkpoint_is_null() {
+        let exec = TestExec { id: "e2".into() };
+        assert_eq!(exec.checkpoint(), Value::Null);
+    }
+
+    #[test]
+    fn default_budget_is_none() {
+        let exec = TestExec { id: "e3".into() };
+        assert!(exec.budget_limit_usd().is_none());
+    }
+
+    #[test]
+    fn default_progress() {
+        let exec = TestExec { id: "e4".into() };
+        let p = exec.progress();
+        assert_eq!(p.execution_id, "e4");
+        assert_eq!(p.percent, 0.0);
+        assert_eq!(p.stage, ExecutionStage::Running);
+    }
+}

--- a/daemon/crates/convergio-longrunning/src/types.rs
+++ b/daemon/crates/convergio-longrunning/src/types.rs
@@ -1,0 +1,154 @@
+//! Shared types for the long-running execution protocol.
+
+use serde::{Deserialize, Serialize};
+
+/// Errors specific to long-running executions.
+#[derive(Debug, thiserror::Error)]
+pub enum LongRunError {
+    #[error("database: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("pool: {0}")]
+    Pool(#[from] r2d2::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("budget exceeded: spent {spent:.4} of {limit:.4} USD")]
+    BudgetExceeded { spent: f64, limit: f64 },
+    #[error("execution stale: no heartbeat for {elapsed_secs}s (max {max_secs}s)")]
+    Stale { elapsed_secs: u64, max_secs: u64 },
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("{0}")]
+    Internal(String),
+}
+
+pub type LongRunResult<T> = Result<T, LongRunError>;
+
+/// Current stage of a long-running execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutionStage {
+    Starting,
+    Running,
+    Checkpointing,
+    Paused,
+    Resuming,
+    Completing,
+    Failed,
+    Reaped,
+}
+
+impl ExecutionStage {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Checkpointing => "checkpointing",
+            Self::Paused => "paused",
+            Self::Resuming => "resuming",
+            Self::Completing => "completing",
+            Self::Failed => "failed",
+            Self::Reaped => "reaped",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "starting" => Some(Self::Starting),
+            "running" => Some(Self::Running),
+            "checkpointing" => Some(Self::Checkpointing),
+            "paused" => Some(Self::Paused),
+            "resuming" => Some(Self::Resuming),
+            "completing" => Some(Self::Completing),
+            "failed" => Some(Self::Failed),
+            "reaped" => Some(Self::Reaped),
+            _ => None,
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completing | Self::Failed | Self::Reaped)
+    }
+}
+
+impl std::fmt::Display for ExecutionStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Progress snapshot for a long-running execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgressSnapshot {
+    pub execution_id: String,
+    pub percent: f64,
+    pub stage: ExecutionStage,
+    pub cost_usd: f64,
+    pub eta_secs: Option<u64>,
+    pub message: Option<String>,
+}
+
+/// A node in the delegation chain tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationNode {
+    pub execution_id: String,
+    pub parent_id: Option<String>,
+    pub agent: String,
+    pub node: String,
+    pub budget_usd: f64,
+    pub deadline: Option<String>,
+    pub stage: ExecutionStage,
+    pub children: Vec<DelegationNode>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_stage_roundtrip() {
+        let stages = [
+            ExecutionStage::Starting,
+            ExecutionStage::Running,
+            ExecutionStage::Checkpointing,
+            ExecutionStage::Paused,
+            ExecutionStage::Resuming,
+            ExecutionStage::Completing,
+            ExecutionStage::Failed,
+            ExecutionStage::Reaped,
+        ];
+        for stage in &stages {
+            let s = stage.as_str();
+            let parsed = ExecutionStage::parse(s).unwrap();
+            assert_eq!(&parsed, stage);
+            assert_eq!(stage.to_string(), s);
+        }
+    }
+
+    #[test]
+    fn execution_stage_parse_invalid() {
+        assert!(ExecutionStage::parse("bogus").is_none());
+    }
+
+    #[test]
+    fn terminal_stages() {
+        assert!(!ExecutionStage::Running.is_terminal());
+        assert!(ExecutionStage::Completing.is_terminal());
+        assert!(ExecutionStage::Failed.is_terminal());
+        assert!(ExecutionStage::Reaped.is_terminal());
+    }
+
+    #[test]
+    fn progress_snapshot_serializes() {
+        let snap = ProgressSnapshot {
+            execution_id: "exec-1".into(),
+            percent: 42.5,
+            stage: ExecutionStage::Running,
+            cost_usd: 0.03,
+            eta_secs: Some(120),
+            message: Some("processing wave 2".into()),
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        assert!(json.contains("42.5"));
+        assert!(json.contains("running"));
+    }
+}


### PR DESCRIPTION
## Summary

- New crate `convergio-longrunning` implementing the long-running execution protocol
- **LongRunnable trait**: `heartbeat_interval`, `checkpoint`, `resume`, `progress`, `budget_limit_usd`, `deadline`, delegation chain support
- **Heartbeat monitor**: register/beat/unregister with `lr_heartbeats` table; `find_stale` detects executions missing 3x their interval
- **Reaper**: background tokio task kills stale executions, propagates death to delegation children
- **Checkpoint persistence**: save/load/clear execution state as JSON in `lr_checkpoints`
- **Budget guard**: `record_cost` enforces limits, pauses execution on overrun, `propagate` shares parent budget with children
- **Progress via SSE**: updates stored in `lr_executions` and published to IPC EventBus for real-time streaming
- **Delegation chain**: parent-child tree with `build_tree` (recursive), `cascade_death` (recursive CTE), budget/deadline propagation
- **Extension impl**: manifest with 4 capabilities, 3 DB migrations, health check, metrics, scheduled reaper task
- Deps: types, db, ipc, telemetry

## Test plan

- [x] `cargo fmt --all` — clean
- [x] All files under 250 lines (max: 171)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo check --workspace` — compiles
- [x] `cargo test -p convergio-longrunning` — 36 tests passing
- [x] `cargo test --workspace` — all workspace tests passing
- [x] Checkpoint: save/load roundtrip, replace, clear, missing returns None
- [x] Heartbeat: register/beat, beat-unknown errors, unregister, fresh not stale
- [x] Reaper: empty cycle, marks stale as reaped with stage verification
- [x] Budget: within budget, exceeds budget (pauses), unlimited always OK, propagate to child, not-found error
- [x] Progress: update/load, missing returns None, SSE event bus integration
- [x] Delegation: create/list children, build nested tree, missing returns None, cascade death kills descendants, skips terminal
- [x] Extension: manifest ID, migrations count, health with memory pool
- [x] Types: stage roundtrip, parse invalid, terminal detection, progress serialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)