### PR TITLE
feat: fase 18 — MCP server

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -548,6 +548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-mcp"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "convergio-mesh"
 version = "0.1.0"
 dependencies = [

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/convergio-http-bridge",
     "crates/convergio-depgraph",
     "crates/convergio-longrunning",
+    "crates/convergio-mcp",
 ]
 
 [package]

--- a/daemon/crates/convergio-mcp/Cargo.toml
+++ b/daemon/crates/convergio-mcp/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "convergio-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "convergio-mcp-server"
+path = "src/main.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+
+[dev-dependencies]

--- a/daemon/crates/convergio-mcp/src/handlers.rs
+++ b/daemon/crates/convergio-mcp/src/handlers.rs
@@ -1,0 +1,212 @@
+//! Tool call dispatch: routes each MCP tool name to the daemon HTTP API.
+
+use serde_json::{json, Value};
+
+use crate::http::{http_get, http_post};
+use crate::ring::McpError;
+
+/// Dispatch a tool call by name. Returns JSON result or McpError.
+pub fn handle_tool_call(
+    name: &str,
+    args: &Value,
+    daemon_url: &str,
+    token: Option<&str>,
+) -> Result<Value, McpError> {
+    match name {
+        "cvg_list_plans" => list_plans(daemon_url, token, args),
+        "cvg_get_plan" => get_plan(daemon_url, token, args),
+        "cvg_update_task" => update_task(daemon_url, token, args),
+        "cvg_checkpoint_save" => checkpoint_save(daemon_url, token, args),
+        "cvg_list_agents" => list_agents(daemon_url, token),
+        "cvg_agent_start" => agent_start(daemon_url, token, args),
+        "cvg_agent_complete" => agent_complete(daemon_url, token, args),
+        "cvg_mesh_status" => mesh_status(daemon_url, token),
+        "cvg_node_readiness" => node_readiness(daemon_url, token),
+        "cvg_cost_summary" => cost_summary(daemon_url, token),
+        "cvg_kernel_status" => kernel_status(daemon_url, token),
+        "cvg_kernel_ask" => kernel_ask(daemon_url, token, args),
+        "cvg_notify" => notify(daemon_url, token, args),
+        "cvg_restart_node" => restart_node(daemon_url, token, args),
+        "cvg_interrupt_agent" => interrupt_agent(daemon_url, token, args),
+        _ => Err(McpError::InvalidParams("unknown tool")),
+    }
+}
+
+// ── Plan handlers ────────────────────────────────────────────────────────────
+
+fn list_plans(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let url = format!("{daemon_url}/api/plan-db/list");
+    let body = http_get(&url, token)?;
+    let plans = body.get("plans").cloned().unwrap_or(json!([]));
+    if let Some(filter) = args.get("status_filter").and_then(|v| v.as_str()) {
+        let filtered: Vec<Value> = plans
+            .as_array()
+            .unwrap_or(&vec![])
+            .iter()
+            .filter(|p| p.get("status").and_then(|s| s.as_str()) == Some(filter))
+            .cloned()
+            .collect();
+        return Ok(json!(filtered));
+    }
+    Ok(plans)
+}
+
+fn get_plan(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let plan_id = args
+        .get("plan_id")
+        .and_then(|v| v.as_i64())
+        .ok_or(McpError::InvalidParams("plan_id is required"))?;
+    http_get(&format!("{daemon_url}/api/plan-db/json/{plan_id}"), token)
+}
+
+fn update_task(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let task_id = args
+        .get("task_id")
+        .and_then(|v| v.as_i64())
+        .ok_or(McpError::InvalidParams("task_id is required"))?;
+    let status = args
+        .get("status")
+        .and_then(|v| v.as_str())
+        .ok_or(McpError::InvalidParams("status is required"))?;
+    let payload = json!({
+        "task_id": task_id,
+        "status": status,
+        "summary": args.get("summary").and_then(|v| v.as_str()).unwrap_or("")
+    });
+    http_post(
+        &format!("{daemon_url}/api/plan-db/task/update"),
+        token,
+        &payload,
+    )
+}
+
+fn checkpoint_save(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let plan_id = args
+        .get("plan_id")
+        .and_then(|v| v.as_i64())
+        .ok_or(McpError::InvalidParams("plan_id is required"))?;
+    http_post(
+        &format!("{daemon_url}/api/plan-db/checkpoint/save"),
+        token,
+        &json!({"plan_id": plan_id}),
+    )
+}
+
+// ── Agent handlers ───────────────────────────────────────────────────────────
+
+fn list_agents(daemon_url: &str, token: Option<&str>) -> Result<Value, McpError> {
+    http_get(&format!("{daemon_url}/api/ipc/agents"), token)
+}
+
+fn agent_start(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let name = args
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or(McpError::InvalidParams("name is required"))?;
+    let mut payload = json!({"agent_id": name});
+    if let Some(task_id) = args.get("task_id").and_then(|v| v.as_i64()) {
+        payload["task_id"] = json!(task_id);
+    }
+    http_post(
+        &format!("{daemon_url}/api/plan-db/agent/start"),
+        token,
+        &payload,
+    )
+}
+
+fn agent_complete(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let name = args
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or(McpError::InvalidParams("name is required"))?;
+    let mut payload = json!({"agent_id": name});
+    if let Some(reason) = args.get("exit_reason").and_then(|v| v.as_str()) {
+        payload["exit_reason"] = json!(reason);
+    }
+    http_post(
+        &format!("{daemon_url}/api/plan-db/agent/complete"),
+        token,
+        &payload,
+    )
+}
+
+// ── Mesh/metrics handlers ────────────────────────────────────────────────────
+
+fn mesh_status(daemon_url: &str, token: Option<&str>) -> Result<Value, McpError> {
+    http_get(&format!("{daemon_url}/api/mesh"), token)
+}
+
+fn node_readiness(daemon_url: &str, token: Option<&str>) -> Result<Value, McpError> {
+    http_get(&format!("{daemon_url}/api/node/readiness"), token)
+}
+
+fn cost_summary(daemon_url: &str, token: Option<&str>) -> Result<Value, McpError> {
+    let body = http_get(&format!("{daemon_url}/api/plan-db/list"), token)?;
+    let plans = body
+        .get("plans")
+        .and_then(|p| p.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let total_cost: f64 = plans
+        .iter()
+        .filter_map(|p| p.get("total_cost").and_then(|v| v.as_f64()))
+        .sum();
+    let active = plans
+        .iter()
+        .filter(|p| p.get("status").and_then(|s| s.as_str()) == Some("doing"))
+        .count();
+    Ok(json!({
+        "total_cost": total_cost,
+        "active_plans": active,
+        "total_plans": plans.len(),
+    }))
+}
+
+// ── Kernel handlers ──────────────────────────────────────────────────────────
+
+fn kernel_status(daemon_url: &str, token: Option<&str>) -> Result<Value, McpError> {
+    http_get(&format!("{daemon_url}/api/kernel/status"), token)
+}
+
+fn kernel_ask(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let prompt = args
+        .get("prompt")
+        .and_then(|v| v.as_str())
+        .ok_or(McpError::InvalidParams("prompt is required"))?;
+    http_post(
+        &format!("{daemon_url}/api/kernel/ask"),
+        token,
+        &json!({"prompt": prompt}),
+    )
+}
+
+// ── Action handlers ──────────────────────────────────────────────────────────
+
+fn notify(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let message = args
+        .get("message")
+        .and_then(|v| v.as_str())
+        .ok_or(McpError::InvalidParams("message is required"))?;
+    let payload = json!({
+        "message": message,
+        "title": args.get("title").and_then(|v| v.as_str()).unwrap_or("Convergio"),
+        "severity": args.get("severity").and_then(|v| v.as_str()).unwrap_or("info"),
+    });
+    http_post(&format!("{daemon_url}/api/notify"), token, &payload)
+}
+
+fn restart_node(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    let target = args
+        .get("target")
+        .and_then(|v| v.as_str())
+        .ok_or(McpError::InvalidParams("target is required"))?;
+    http_post(
+        &format!("{daemon_url}/api/node/recover"),
+        token,
+        &json!({"target": target}),
+    )
+}
+
+fn interrupt_agent(daemon_url: &str, token: Option<&str>, args: &Value) -> Result<Value, McpError> {
+    http_post(&format!("{daemon_url}/api/agent/interrupt"), token, args)
+}

--- a/daemon/crates/convergio-mcp/src/http.rs
+++ b/daemon/crates/convergio-mcp/src/http.rs
@@ -1,0 +1,54 @@
+//! HTTP bridge to the Convergio daemon API.
+//!
+//! Each MCP tool handler calls the daemon over HTTP.
+//! Uses reqwest::blocking with a 5-second timeout.
+
+use serde_json::Value;
+use std::time::Duration;
+
+use crate::ring::McpError;
+
+// ── Client ───────────────────────────────────────────────────────────────────
+
+fn make_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_else(|_| reqwest::blocking::Client::new())
+}
+
+/// GET request to daemon, returning parsed JSON.
+pub fn http_get(url: &str, token: Option<&str>) -> Result<Value, McpError> {
+    let client = make_client();
+    let mut req = client.get(url);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().map_err(|_| McpError::DaemonUnreachable)?;
+    if !resp.status().is_success() {
+        return Err(McpError::DaemonError(format!(
+            "HTTP {}",
+            resp.status().as_u16()
+        )));
+    }
+    resp.json::<Value>()
+        .map_err(|e| McpError::DaemonError(e.to_string()))
+}
+
+/// POST request to daemon with JSON body, returning parsed JSON.
+pub fn http_post(url: &str, token: Option<&str>, body: &Value) -> Result<Value, McpError> {
+    let client = make_client();
+    let mut req = client.post(url).json(body);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().map_err(|_| McpError::DaemonUnreachable)?;
+    if !resp.status().is_success() {
+        return Err(McpError::DaemonError(format!(
+            "HTTP {}",
+            resp.status().as_u16()
+        )));
+    }
+    resp.json::<Value>()
+        .map_err(|e| McpError::DaemonError(e.to_string()))
+}

--- a/daemon/crates/convergio-mcp/src/lib.rs
+++ b/daemon/crates/convergio-mcp/src/lib.rs
@@ -1,0 +1,20 @@
+//! convergio-mcp: MCP server binary for Convergio.
+//!
+//! Exposes daemon capabilities as MCP tools over JSON-RPC stdio transport.
+//! This is a standalone binary that bridges Claude Code/Copilot to the
+//! Convergio daemon API via HTTP.
+
+pub mod handlers;
+pub mod http;
+pub mod protocol;
+pub mod ring;
+pub mod server;
+pub mod tools;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+#[cfg(test)]
+#[path = "server_tests.rs"]
+mod server_tests;

--- a/daemon/crates/convergio-mcp/src/main.rs
+++ b/daemon/crates/convergio-mcp/src/main.rs
@@ -1,0 +1,35 @@
+//! convergio-mcp-server binary entry point.
+//!
+//! Exposes the Convergio daemon as an MCP server over stdio transport.
+//! CRITICAL: stdout is JSON-RPC protocol only. All logs must go to stderr.
+
+use convergio_mcp::server::McpServer;
+
+fn main() {
+    // Route tracing to stderr — stdout is reserved for JSON-RPC.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    // Ring level: 0=Core, 1=Trusted, 2=Community, 3=Sandboxed (default).
+    let ring: u8 = std::env::var("CONVERGIO_MCP_RING")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3);
+
+    // Daemon URL — defaults to local daemon.
+    let daemon_url = std::env::var("CONVERGIO_DAEMON_URL")
+        .unwrap_or_else(|_| "http://localhost:8420".to_string());
+
+    // Optional bearer token for daemon auth middleware.
+    let token = std::env::var("CONVERGIO_API_TOKEN").ok();
+
+    tracing::info!(ring, daemon_url = %daemon_url, "starting");
+
+    let server = McpServer::new(ring, &daemon_url, token.as_deref());
+    server.run_stdio();
+}

--- a/daemon/crates/convergio-mcp/src/protocol.rs
+++ b/daemon/crates/convergio-mcp/src/protocol.rs
@@ -1,0 +1,77 @@
+//! JSON-RPC 2.0 types for the MCP protocol.
+//!
+//! stdout is reserved for protocol messages — all logs go to stderr.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ── Request ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    /// Absent for notifications.
+    pub id: Option<Value>,
+    pub method: String,
+    pub params: Option<Value>,
+}
+
+// ── Response ─────────────────────────────────────────────────────────────────
+
+/// Serialised to stdout. Only one of result/error is non-null per spec.
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+}
+
+// ── Error ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+/// Standard and custom JSON-RPC error codes.
+pub mod error_codes {
+    /// Ring access violation — caller ring cannot use this tool.
+    pub const RING_VIOLATION: i32 = -32001;
+    /// Daemon at configured URL is unreachable.
+    pub const DAEMON_UNREACHABLE: i32 = -32002;
+    /// Daemon returned a non-2xx status or error body.
+    pub const DAEMON_ERROR: i32 = -32003;
+    /// Malformed JSON-RPC envelope.
+    pub const INVALID_REQUEST: i32 = -32600;
+    /// Method name not recognised.
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    /// Required parameter missing or wrong type.
+    pub const INVALID_PARAMS: i32 = -32602;
+}

--- a/daemon/crates/convergio-mcp/src/ring.rs
+++ b/daemon/crates/convergio-mcp/src/ring.rs
@@ -1,0 +1,101 @@
+//! Ring-based access control for MCP tool calls.
+//!
+//! Lower ring number = more privilege.
+//! 0 = Core, 1 = Trusted, 2 = Community, 3 = Sandboxed.
+
+use crate::protocol::error_codes;
+
+// ── Ring ─────────────────────────────────────────────────────────────────────
+
+/// Security ring level. Core is most privileged.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Ring {
+    Core = 0,
+    Trusted = 1,
+    Community = 2,
+    #[default]
+    Sandboxed = 3,
+}
+
+impl Ring {
+    /// Parse from u8. Values > 3 become Sandboxed.
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Core,
+            1 => Self::Trusted,
+            2 => Self::Community,
+            _ => Self::Sandboxed,
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Returns true if this ring can access a tool at `required` ring level.
+    /// Core(0) can access everything; Sandboxed(3) only Sandboxed tools.
+    pub fn can_access(self, required: Ring) -> bool {
+        (self as u8) <= (required as u8)
+    }
+}
+
+// ── Error type ───────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum McpError {
+    /// Caller ring lacks privilege for the tool.
+    RingViolation { caller: u8, required: u8 },
+    /// Required parameter absent or wrong type.
+    InvalidParams(&'static str),
+    /// Daemon HTTP endpoint returned a non-2xx status.
+    DaemonError(String),
+    /// Daemon TCP connection refused or timed out.
+    DaemonUnreachable,
+}
+
+impl McpError {
+    pub fn json_rpc_code(&self) -> i32 {
+        match self {
+            Self::RingViolation { .. } => error_codes::RING_VIOLATION,
+            Self::InvalidParams(_) => error_codes::INVALID_PARAMS,
+            Self::DaemonError(_) => error_codes::DAEMON_ERROR,
+            Self::DaemonUnreachable => error_codes::DAEMON_UNREACHABLE,
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            Self::RingViolation { caller, required } => {
+                format!(
+                    "Ring violation: caller ring {caller} cannot access \
+                     tool requiring ring {required}"
+                )
+            }
+            Self::InvalidParams(msg) => format!("Invalid params: {msg}"),
+            Self::DaemonError(msg) => format!("Daemon error: {msg}"),
+            Self::DaemonUnreachable => "Daemon unreachable. Is the daemon running?".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for McpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message())
+    }
+}
+
+impl std::error::Error for McpError {}
+
+// ── Access check ─────────────────────────────────────────────────────────────
+
+/// Returns Ok if `caller` ring can access a tool at `required` ring level.
+pub fn check_ring_access(caller: Ring, required: Ring) -> Result<(), McpError> {
+    if caller.can_access(required) {
+        Ok(())
+    } else {
+        Err(McpError::RingViolation {
+            caller: caller.as_u8(),
+            required: required.as_u8(),
+        })
+    }
+}

--- a/daemon/crates/convergio-mcp/src/server.rs
+++ b/daemon/crates/convergio-mcp/src/server.rs
@@ -1,0 +1,174 @@
+//! McpServer: stdio loop + JSON-RPC dispatch.
+//!
+//! CRITICAL: stdout is protocol-only. All logs go to stderr via tracing.
+
+use std::io::{BufRead, BufReader, Write};
+
+use serde_json::{json, Value};
+use tracing::warn;
+
+use crate::handlers::handle_tool_call;
+use crate::protocol::{error_codes, JsonRpcRequest, JsonRpcResponse};
+use crate::ring::{check_ring_access, Ring};
+use crate::tools::list_tools;
+
+// ── Server ───────────────────────────────────────────────────────────────────
+
+pub struct McpServer {
+    ring: Ring,
+    daemon_url: String,
+    api_token: Option<String>,
+}
+
+impl McpServer {
+    pub fn new(ring_level: u8, daemon_url: &str, token: Option<&str>) -> Self {
+        Self {
+            ring: Ring::from_u8(ring_level),
+            daemon_url: daemon_url.to_string(),
+            api_token: token.map(|t| t.to_string()),
+        }
+    }
+
+    /// Blocking stdio loop: reads JSON-RPC lines from stdin, writes
+    /// responses to stdout. Returns when stdin is closed.
+    pub fn run_stdio(&self) {
+        let stdin = std::io::stdin();
+        let stdout = std::io::stdout();
+        let reader = BufReader::new(stdin.lock());
+
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    eprintln!("stdin read error: {e}");
+                    break;
+                }
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let response = self.handle_request(trimmed);
+            let mut out = stdout.lock();
+            if let Err(e) = writeln!(out, "{response}") {
+                eprintln!("stdout write error: {e}");
+                break;
+            }
+            let _ = out.flush();
+        }
+    }
+
+    /// Parse one JSON-RPC line and return the serialised response.
+    /// Never panics — all errors become JSON-RPC error responses.
+    pub fn handle_request(&self, raw: &str) -> String {
+        let req: JsonRpcRequest = match serde_json::from_str(raw) {
+            Ok(r) => r,
+            Err(_) => {
+                let resp = JsonRpcResponse::error(
+                    json!(null),
+                    error_codes::INVALID_REQUEST,
+                    "Invalid JSON-RPC request",
+                );
+                return serde_json::to_string(&resp).unwrap_or_default();
+            }
+        };
+
+        let id = req.id.clone().unwrap_or(json!(null));
+
+        let resp = match req.method.as_str() {
+            "initialize" => self.handle_initialize(id),
+            "tools/list" => self.handle_tools_list(id),
+            "tools/call" => self.handle_tools_call(id, req.params.unwrap_or(json!({}))),
+            _ => {
+                warn!(method = %req.method, "method not found");
+                JsonRpcResponse::error(id, error_codes::METHOD_NOT_FOUND, "Method not found")
+            }
+        };
+
+        serde_json::to_string(&resp).unwrap_or_default()
+    }
+
+    // ── Handlers ─────────────────────────────────────────────────────────────
+
+    fn handle_initialize(&self, id: Value) -> JsonRpcResponse {
+        JsonRpcResponse::success(
+            id,
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {
+                    "name": "convergio-mcp-server",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        )
+    }
+
+    fn handle_tools_list(&self, id: Value) -> JsonRpcResponse {
+        let tools: Vec<Value> = list_tools(self.ring)
+            .into_iter()
+            .map(|t| {
+                json!({
+                    "name": t.name,
+                    "description": t.description,
+                    "inputSchema": t.input_schema,
+                })
+            })
+            .collect();
+        JsonRpcResponse::success(id, json!({"tools": tools}))
+    }
+
+    fn handle_tools_call(&self, id: Value, params: Value) -> JsonRpcResponse {
+        let name = match params.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => {
+                return JsonRpcResponse::error(
+                    id,
+                    error_codes::INVALID_PARAMS,
+                    "tools/call requires params.name",
+                );
+            }
+        };
+        let args = params.get("arguments").cloned().unwrap_or(json!({}));
+
+        // Ring access enforcement
+        let tool_ring = min_ring_for_tool(name);
+        if let Err(e) = check_ring_access(self.ring, tool_ring) {
+            return JsonRpcResponse::error(id, e.json_rpc_code(), e.message());
+        }
+
+        match handle_tool_call(name, &args, &self.daemon_url, self.api_token.as_deref()) {
+            Ok(result) => {
+                let text = serde_json::to_string(&result).unwrap_or_else(|_| "{}".to_string());
+                JsonRpcResponse::success(
+                    id,
+                    json!({
+                        "content": [{"type": "text", "text": text}]
+                    }),
+                )
+            }
+            Err(e) => JsonRpcResponse::error(id, e.json_rpc_code(), e.message()),
+        }
+    }
+}
+
+// ── Ring map ─────────────────────────────────────────────────────────────────
+
+/// Minimum ring required to invoke a named tool.
+/// Unknown tools default to Core (most restrictive) to fail-safe.
+fn min_ring_for_tool(name: &str) -> Ring {
+    match name {
+        "cvg_restart_node" => Ring::Core,
+        "cvg_update_task"
+        | "cvg_checkpoint_save"
+        | "cvg_agent_start"
+        | "cvg_agent_complete"
+        | "cvg_kernel_ask"
+        | "cvg_notify"
+        | "cvg_interrupt_agent" => Ring::Trusted,
+        "cvg_list_plans" | "cvg_list_agents" => Ring::Sandboxed,
+        "cvg_get_plan" | "cvg_mesh_status" | "cvg_node_readiness" | "cvg_cost_summary"
+        | "cvg_kernel_status" => Ring::Community,
+        _ => Ring::Core,
+    }
+}

--- a/daemon/crates/convergio-mcp/src/server_tests.rs
+++ b/daemon/crates/convergio-mcp/src/server_tests.rs
@@ -1,0 +1,144 @@
+//! Tests for JSON-RPC protocol parsing and server dispatch.
+
+use serde_json::{json, Value};
+
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
+use crate::server::McpServer;
+
+// ── Protocol parsing ─────────────────────────────────────────────────────────
+
+#[test]
+fn parse_initialize_request() {
+    let raw = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let req: JsonRpcRequest = serde_json::from_str(raw).unwrap();
+    assert_eq!(req.method, "initialize");
+    assert_eq!(req.id, Some(json!(1)));
+}
+
+#[test]
+fn parse_tools_list_request() {
+    let raw = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+    let req: JsonRpcRequest = serde_json::from_str(raw).unwrap();
+    assert_eq!(req.method, "tools/list");
+}
+
+#[test]
+fn parse_tools_call_request() {
+    let raw = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"cvg_list_plans","arguments":{}}}"#;
+    let req: JsonRpcRequest = serde_json::from_str(raw).unwrap();
+    let params = req.params.unwrap();
+    assert_eq!(
+        params.get("name").and_then(|v| v.as_str()),
+        Some("cvg_list_plans")
+    );
+}
+
+#[test]
+fn parse_malformed_json_fails() {
+    let result = serde_json::from_str::<JsonRpcRequest>("not json{{{");
+    assert!(result.is_err());
+}
+
+// ── Response serialization ───────────────────────────────────────────────────
+
+#[test]
+fn response_success_serializes() {
+    let resp = JsonRpcResponse::success(json!(1), json!({"ok": true}));
+    let v: Value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(v.get("jsonrpc").and_then(|v| v.as_str()), Some("2.0"));
+    assert!(v.get("result").is_some());
+    assert!(v.get("error").is_none());
+}
+
+#[test]
+fn response_error_serializes() {
+    let resp = JsonRpcResponse::error(json!(1), -32601, "Method not found");
+    let v: Value = serde_json::to_value(&resp).unwrap();
+    assert!(v.get("error").is_some());
+    assert!(v.get("result").is_none());
+    let err = v.get("error").unwrap();
+    assert_eq!(err.get("code").and_then(|v| v.as_i64()), Some(-32601));
+}
+
+// ── Server dispatch ──────────────────────────────────────────────────────────
+
+#[test]
+fn handle_initialize_returns_server_info() {
+    let server = McpServer::new(1, "http://localhost:1", None);
+    let raw = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#;
+    let resp_str = server.handle_request(raw);
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    let result = v.get("result").expect("must return result");
+    assert_eq!(
+        result
+            .get("serverInfo")
+            .and_then(|s| s.get("name"))
+            .and_then(|v| v.as_str()),
+        Some("convergio-mcp-server")
+    );
+}
+
+#[test]
+fn handle_tools_list_returns_array() {
+    let server = McpServer::new(1, "http://localhost:1", None);
+    let raw = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+    let resp_str = server.handle_request(raw);
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    let tools = v
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .expect("must return tools");
+    assert!(tools.is_array());
+    assert_eq!(tools.as_array().unwrap().len(), 14);
+}
+
+#[test]
+fn handle_unknown_method_returns_error() {
+    let server = McpServer::new(1, "http://localhost:1", None);
+    let raw = r#"{"jsonrpc":"2.0","id":5,"method":"foo/bar","params":{}}"#;
+    let resp_str = server.handle_request(raw);
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    let err = v.get("error").expect("must return error");
+    assert_eq!(err.get("code").and_then(|c| c.as_i64()), Some(-32601));
+}
+
+#[test]
+fn handle_ring_violation_returns_ring_error() {
+    let server = McpServer::new(2, "http://localhost:1", None);
+    let raw = r#"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"cvg_update_task","arguments":{"task_id":1,"status":"done"}}}"#;
+    let resp_str = server.handle_request(raw);
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    let err = v.get("error").expect("ring violation must return error");
+    assert_eq!(err.get("code").and_then(|c| c.as_i64()), Some(-32001));
+}
+
+#[test]
+fn handle_daemon_unreachable_returns_error() {
+    let server = McpServer::new(1, "http://localhost:1", None);
+    let raw = r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"cvg_list_plans","arguments":{}}}"#;
+    let resp_str = server.handle_request(raw);
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    assert!(
+        v.get("error").is_some(),
+        "unreachable daemon must return error"
+    );
+}
+
+#[test]
+fn handle_invalid_json_returns_parse_error() {
+    let server = McpServer::new(0, "http://localhost:1", None);
+    let resp_str = server.handle_request("not valid json");
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    let err = v.get("error").expect("must return error");
+    assert_eq!(err.get("code").and_then(|c| c.as_i64()), Some(-32600));
+}
+
+#[test]
+fn handle_tools_call_missing_name_returns_invalid_params() {
+    let server = McpServer::new(0, "http://localhost:1", None);
+    let raw = r#"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"arguments":{}}}"#;
+    let resp_str = server.handle_request(raw);
+    let v: Value = serde_json::from_str(&resp_str).unwrap();
+    let err = v.get("error").expect("must return error");
+    assert_eq!(err.get("code").and_then(|c| c.as_i64()), Some(-32602));
+}

--- a/daemon/crates/convergio-mcp/src/tests.rs
+++ b/daemon/crates/convergio-mcp/src/tests.rs
@@ -1,0 +1,152 @@
+//! Tests for ring enforcement and tool registry.
+
+use crate::ring::{check_ring_access, McpError, Ring};
+use crate::tools::{all_tools, list_tools};
+
+// ── Ring access ──────────────────────────────────────────────────────────────
+
+#[test]
+fn ring_core_can_access_all() {
+    assert!(check_ring_access(Ring::Core, Ring::Core).is_ok());
+    assert!(check_ring_access(Ring::Core, Ring::Trusted).is_ok());
+    assert!(check_ring_access(Ring::Core, Ring::Community).is_ok());
+    assert!(check_ring_access(Ring::Core, Ring::Sandboxed).is_ok());
+}
+
+#[test]
+fn ring_trusted_cannot_access_core() {
+    assert!(check_ring_access(Ring::Trusted, Ring::Core).is_err());
+    assert!(check_ring_access(Ring::Trusted, Ring::Trusted).is_ok());
+    assert!(check_ring_access(Ring::Trusted, Ring::Community).is_ok());
+}
+
+#[test]
+fn ring_community_cannot_access_trusted() {
+    assert!(check_ring_access(Ring::Community, Ring::Core).is_err());
+    assert!(check_ring_access(Ring::Community, Ring::Trusted).is_err());
+    assert!(check_ring_access(Ring::Community, Ring::Community).is_ok());
+    assert!(check_ring_access(Ring::Community, Ring::Sandboxed).is_ok());
+}
+
+#[test]
+fn ring_sandboxed_only_sandboxed() {
+    assert!(check_ring_access(Ring::Sandboxed, Ring::Core).is_err());
+    assert!(check_ring_access(Ring::Sandboxed, Ring::Trusted).is_err());
+    assert!(check_ring_access(Ring::Sandboxed, Ring::Community).is_err());
+    assert!(check_ring_access(Ring::Sandboxed, Ring::Sandboxed).is_ok());
+}
+
+#[test]
+fn ring_violation_error_contains_levels() {
+    let err = check_ring_access(Ring::Community, Ring::Trusted).unwrap_err();
+    match err {
+        McpError::RingViolation { caller, required } => {
+            assert_eq!(caller, 2);
+            assert_eq!(required, 1);
+        }
+        _ => panic!("expected RingViolation, got {err:?}"),
+    }
+}
+
+#[test]
+fn ring_default_is_sandboxed() {
+    assert_eq!(Ring::default(), Ring::Sandboxed);
+}
+
+#[test]
+fn ring_from_u8_overflow_becomes_sandboxed() {
+    assert_eq!(Ring::from_u8(255), Ring::Sandboxed);
+}
+
+// ── Tool registry ────────────────────────────────────────────────────────────
+
+#[test]
+fn all_tools_count() {
+    let tools = all_tools();
+    assert_eq!(tools.len(), 15, "expected 15 tools, got {}", tools.len());
+}
+
+#[test]
+fn list_tools_core_returns_all() {
+    let tools = list_tools(Ring::Core);
+    assert_eq!(tools.len(), 15);
+}
+
+#[test]
+fn list_tools_trusted_excludes_core_only() {
+    let tools = list_tools(Ring::Trusted);
+    let names: Vec<&str> = tools.iter().map(|t| t.name).collect();
+    assert!(!names.contains(&"cvg_restart_node"));
+    assert_eq!(tools.len(), 14);
+}
+
+#[test]
+fn list_tools_community_excludes_write_tools() {
+    let tools = list_tools(Ring::Community);
+    let names: Vec<&str> = tools.iter().map(|t| t.name).collect();
+    assert!(!names.contains(&"cvg_update_task"));
+    assert!(!names.contains(&"cvg_checkpoint_save"));
+    assert!(!names.contains(&"cvg_agent_start"));
+    assert!(!names.contains(&"cvg_restart_node"));
+    assert!(names.contains(&"cvg_get_plan"));
+}
+
+#[test]
+fn list_tools_sandboxed_minimal() {
+    let tools = list_tools(Ring::Sandboxed);
+    let names: Vec<&str> = tools.iter().map(|t| t.name).collect();
+    assert!(names.contains(&"cvg_list_plans"));
+    assert!(names.contains(&"cvg_list_agents"));
+    assert!(!names.contains(&"cvg_notify"));
+    assert_eq!(tools.len(), 2);
+}
+
+#[test]
+fn all_tools_have_valid_schema() {
+    for tool in &all_tools() {
+        assert!(!tool.name.is_empty());
+        assert!(!tool.description.is_empty());
+        assert_eq!(
+            tool.input_schema.get("type").and_then(|v| v.as_str()),
+            Some("object"),
+            "tool {} schema must have type:object",
+            tool.name
+        );
+    }
+}
+
+#[test]
+fn all_tool_names_use_cvg_prefix() {
+    for tool in &all_tools() {
+        assert!(
+            tool.name.starts_with("cvg_"),
+            "tool '{}' must start with cvg_",
+            tool.name
+        );
+    }
+}
+
+// ── McpError display ─────────────────────────────────────────────────────────
+
+#[test]
+fn mcp_error_display() {
+    let e = McpError::DaemonUnreachable;
+    assert!(e.to_string().contains("unreachable"));
+
+    let e = McpError::InvalidParams("test");
+    assert!(e.to_string().contains("test"));
+
+    let e = McpError::DaemonError("bad".into());
+    assert_eq!(e.json_rpc_code(), -32003);
+}
+
+#[test]
+fn mcp_error_ring_violation_code() {
+    let e = McpError::RingViolation {
+        caller: 3,
+        required: 0,
+    };
+    assert_eq!(e.json_rpc_code(), -32001);
+    assert!(e.message().contains("3"));
+    assert!(e.message().contains("0"));
+}

--- a/daemon/crates/convergio-mcp/src/tools.rs
+++ b/daemon/crates/convergio-mcp/src/tools.rs
@@ -1,0 +1,233 @@
+//! MCP tool registry: definitions + ring-filtered listing.
+//!
+//! Each tool maps to a daemon API endpoint. The catalog defines
+//! name, description, JSON Schema, and minimum ring.
+
+use serde_json::{json, Value};
+
+use crate::ring::Ring;
+
+// ── Tool definition ──────────────────────────────────────────────────────────
+
+pub struct McpTool {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+    pub min_ring: Ring,
+}
+
+/// Returns all tools visible to `caller_ring`.
+pub fn list_tools(caller_ring: Ring) -> Vec<McpTool> {
+    all_tools()
+        .into_iter()
+        .filter(|t| caller_ring.can_access(t.min_ring))
+        .collect()
+}
+
+/// Full tool catalogue (unfiltered).
+pub fn all_tools() -> Vec<McpTool> {
+    let mut tools = Vec::with_capacity(20);
+    tools.extend(plan_tools());
+    tools.extend(agent_tools());
+    tools.extend(mesh_tools());
+    tools.extend(kernel_tools());
+    tools.extend(action_tools());
+    tools
+}
+
+// ── Plan tools ───────────────────────────────────────────────────────────────
+
+fn plan_tools() -> Vec<McpTool> {
+    vec![
+        McpTool {
+            name: "cvg_list_plans",
+            description: "List all plans with optional status filter.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "status_filter": {
+                        "type": "string",
+                        "description": "Filter by status (pending/doing/done)"
+                    }
+                }
+            }),
+            min_ring: Ring::Sandboxed,
+        },
+        McpTool {
+            name: "cvg_get_plan",
+            description: "Get full plan details by ID.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "plan_id": {
+                        "type": "integer",
+                        "description": "Plan ID"
+                    }
+                },
+                "required": ["plan_id"]
+            }),
+            min_ring: Ring::Community,
+        },
+        McpTool {
+            name: "cvg_update_task",
+            description: "Update task status and optional summary.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "task_id": {"type": "integer"},
+                    "status": {"type": "string"},
+                    "summary": {"type": "string"}
+                },
+                "required": ["task_id", "status"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+        McpTool {
+            name: "cvg_checkpoint_save",
+            description: "Save a checkpoint for a plan.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "plan_id": {"type": "integer"}
+                },
+                "required": ["plan_id"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+    ]
+}
+
+// ── Agent tools ──────────────────────────────────────────────────────────────
+
+fn agent_tools() -> Vec<McpTool> {
+    vec![
+        McpTool {
+            name: "cvg_list_agents",
+            description: "List registered agents with status and last heartbeat.",
+            input_schema: json!({"type": "object", "properties": {}}),
+            min_ring: Ring::Sandboxed,
+        },
+        McpTool {
+            name: "cvg_agent_start",
+            description: "Register an agent as active.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Agent name"},
+                    "task_id": {"type": "integer", "description": "Associated task (optional)"}
+                },
+                "required": ["name"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+        McpTool {
+            name: "cvg_agent_complete",
+            description: "Mark an agent as completed.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "exit_reason": {"type": "string"}
+                },
+                "required": ["name"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+    ]
+}
+
+// ── Mesh tools ───────────────────────────────────────────────────────────────
+
+fn mesh_tools() -> Vec<McpTool> {
+    vec![
+        McpTool {
+            name: "cvg_mesh_status",
+            description: "Get peer topology and active connections.",
+            input_schema: json!({"type": "object", "properties": {}}),
+            min_ring: Ring::Community,
+        },
+        McpTool {
+            name: "cvg_node_readiness",
+            description: "Run node health checks and return readiness report.",
+            input_schema: json!({"type": "object", "properties": {}}),
+            min_ring: Ring::Community,
+        },
+        McpTool {
+            name: "cvg_cost_summary",
+            description: "Get spending overview: total cost, active and total plans.",
+            input_schema: json!({"type": "object", "properties": {}}),
+            min_ring: Ring::Community,
+        },
+    ]
+}
+
+// ── Kernel tools ─────────────────────────────────────────────────────────────
+
+fn kernel_tools() -> Vec<McpTool> {
+    vec![
+        McpTool {
+            name: "cvg_kernel_status",
+            description: "Get kernel status: models loaded, uptime.",
+            input_schema: json!({"type": "object", "properties": {}}),
+            min_ring: Ring::Community,
+        },
+        McpTool {
+            name: "cvg_kernel_ask",
+            description: "Ask the local LLM a question with platform context.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "prompt": {"type": "string", "description": "Question for the LLM"}
+                },
+                "required": ["prompt"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+    ]
+}
+
+// ── Action tools ─────────────────────────────────────────────────────────────
+
+fn action_tools() -> Vec<McpTool> {
+    vec![
+        McpTool {
+            name: "cvg_notify",
+            description: "Send a notification via configured channel.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "message": {"type": "string"},
+                    "title": {"type": "string"},
+                    "severity": {"type": "string", "enum": ["info","warning","error"]}
+                },
+                "required": ["message"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+        McpTool {
+            name: "cvg_restart_node",
+            description: "Trigger recovery for a target node. Core ring only.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "target": {"type": "string", "description": "Target node hostname"}
+                },
+                "required": ["target"]
+            }),
+            min_ring: Ring::Core,
+        },
+        McpTool {
+            name: "cvg_interrupt_agent",
+            description: "Interrupt a blocked/stalled agent via IPC bus.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "agent_name": {"type": "string"},
+                    "reason": {"type": "string"}
+                },
+                "required": ["agent_name", "reason"]
+            }),
+            min_ring: Ring::Trusted,
+        },
+    ]
+}


### PR DESCRIPTION
## Summary
- New crate `convergio-mcp` with standalone binary `convergio-mcp-server`
- MCP protocol over JSON-RPC stdio transport — bridges Claude Code/Copilot to daemon API
- Ring-based access control (Core/Trusted/Community/Sandboxed) for all 15 tools
- Tools cover: plans (list/get/update/checkpoint), agents (list/start/complete), mesh (status/readiness/cost), kernel (status/ask), actions (notify/restart/interrupt)
- HTTP bridge to daemon API with 5-second timeout and bearer token auth
- 29 tests covering ring enforcement, tool registry, protocol parsing, server dispatch

## Test plan
- [x] `cargo fmt --all` — no formatting issues
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo check --workspace` — full workspace compiles
- [x] `cargo test -p convergio-mcp` — 29 tests passing
- [x] `cargo test --workspace` — no regressions in other crates
- [x] All files under 250-line limit
- [ ] Manual: configure in Claude Code settings, verify `tools/list` returns expected tools
- [ ] Manual: with daemon running, verify `tools/call` round-trips to daemon API

🤖 Generated with [Claude Code](https://claude.com/claude-code)