### PR TITLE
fix: expose SSE event stream at /api/events/stream

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "convergio-telemetry",
  "convergio-types",
  "convergio-voice",
+ "dirs 6.0.0",
  "tokio",
  "tracing",
 ]

--- a/daemon/crates/convergio-ipc/src/ext.rs
+++ b/daemon/crates/convergio-ipc/src/ext.rs
@@ -130,6 +130,10 @@ impl Extension for IpcExtension {
         }
     }
 
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::routes::event_routes(self.event_bus.clone()))
+    }
+
     fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
         tracing::info!("IPC extension started");
         Ok(())

--- a/daemon/crates/convergio-ipc/src/lib.rs
+++ b/daemon/crates/convergio-ipc/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ext;
 pub mod locks;
 pub mod messaging;
 pub mod models;
+pub mod routes;
 pub mod schema;
 pub mod skills;
 pub mod sse;

--- a/daemon/crates/convergio-ipc/src/routes.rs
+++ b/daemon/crates/convergio-ipc/src/routes.rs
@@ -1,0 +1,28 @@
+//! HTTP routes for IPC — currently just the SSE event stream.
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::response::sse::{self, Sse};
+use axum::routing::get;
+use axum::Router;
+
+use crate::sse::{create_sse_stream, EventBus};
+
+#[derive(serde::Deserialize, Default)]
+pub struct StreamQuery {
+    agent_filter: Option<String>,
+}
+
+async fn stream_handler(
+    State(bus): State<Arc<EventBus>>,
+    Query(q): Query<StreamQuery>,
+) -> Sse<impl futures_core::Stream<Item = Result<sse::Event, std::convert::Infallible>>> {
+    Sse::new(create_sse_stream(bus, q.agent_filter)).keep_alive(sse::KeepAlive::default())
+}
+
+pub fn event_routes(bus: Arc<EventBus>) -> Router {
+    Router::new()
+        .route("/api/events/stream", get(stream_handler))
+        .with_state(bus)
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -57,9 +57,7 @@ async fn main() {
     // 0. Load env file (auth tokens, API keys)
     // Check ~/.convergio/env first (legacy), then data_dir/env
     let env_candidates = [
-        dirs::home_dir()
-            .unwrap_or_default()
-            .join(".convergio/env"),
+        dirs::home_dir().unwrap_or_default().join(".convergio/env"),
         convergio_types::platform_paths::convergio_data_dir().join("env"),
     ];
     for env_path in &env_candidates {


### PR DESCRIPTION
## Summary
- Adds `routes.rs` to convergio-ipc with `GET /api/events/stream` handler
- Mounts the route via `Extension::routes()` in IpcExtension
- Frontend expects this endpoint for live updates — was missing, causing "disconnected"

## Test plan
- [x] cargo check --workspace
- [x] cargo test -p convergio-ipc
- [x] cargo fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)