### PR TITLE
fix: exempt SSE stream from auth

### DIFF
--- a/daemon/crates/convergio-server/src/middleware_auth.rs
+++ b/daemon/crates/convergio-server/src/middleware_auth.rs
@@ -28,9 +28,16 @@ fn compare_tokens(a: &str, b: &str) -> bool {
 
 /// Routes that never require auth.
 const EXEMPT_ROUTES: &[&str] = &["/api/health"];
+const EXEMPT_PREFIXES: &[&str] = &["/api/events/"];
 
 fn needs_auth(path: &str) -> bool {
-    !EXEMPT_ROUTES.contains(&path)
+    if EXEMPT_ROUTES.contains(&path) {
+        return false;
+    }
+    if EXEMPT_PREFIXES.iter().any(|p| path.starts_with(p)) {
+        return false;
+    }
+    true
 }
 
 fn is_localhost(req: &Request<Body>) -> bool {


### PR DESCRIPTION
## Summary
- `/api/events/stream` returns 401 because cross-origin requests from frontend (`:3000`) don't get the ConnectInfo localhost bypass
- Adds `EXEMPT_PREFIXES` to auth middleware so `/api/events/*` is accessible without token

## Test plan
- [x] cargo check + test + clippy clean
- [ ] Rebuild, restart, verify `curl http://localhost:8420/api/events/stream` returns SSE (not 401)
- [ ] Frontend dashboard shows "connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)