### PR TITLE
feat: integration hardening — fase 23

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
 name = "convergio-mesh"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "base64",
  "chrono",
  "convergio-db",

--- a/daemon/crates/convergio-backup/src/ext.rs
+++ b/daemon/crates/convergio-backup/src/ext.rs
@@ -70,8 +70,7 @@ impl Extension for BackupExtension {
             pool: self.pool.clone(),
             db_path: data_dir.join("convergio.db"),
             backup_dir: crate::snapshot::backup_dir(&data_dir),
-            node_name: std::env::var("CONVERGIO_NODE_NAME")
-                .unwrap_or_else(|_| "local".into()),
+            node_name: std::env::var("CONVERGIO_NODE_NAME").unwrap_or_else(|_| "local".into()),
         });
         Some(crate::routes::router(state))
     }

--- a/daemon/crates/convergio-backup/src/ext.rs
+++ b/daemon/crates/convergio-backup/src/ext.rs
@@ -64,6 +64,18 @@ impl Extension for BackupExtension {
         }
     }
 
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        let data_dir = convergio_types::platform_paths::convergio_data_dir();
+        let state = std::sync::Arc::new(crate::routes::BackupState {
+            pool: self.pool.clone(),
+            db_path: data_dir.join("convergio.db"),
+            backup_dir: crate::snapshot::backup_dir(&data_dir),
+            node_name: std::env::var("CONVERGIO_NODE_NAME")
+                .unwrap_or_else(|_| "local".into()),
+        });
+        Some(crate::routes::router(state))
+    }
+
     fn migrations(&self) -> Vec<Migration> {
         crate::schema::migrations()
     }

--- a/daemon/crates/convergio-ipc/src/ext.rs
+++ b/daemon/crates/convergio-ipc/src/ext.rs
@@ -143,10 +143,6 @@ impl Extension for IpcExtension {
         }
     }
 
-    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
-        Some(crate::routes::ipc_routes(self.state()))
-    }
-
     fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
         tracing::info!("IPC extension started");
         Ok(())

--- a/daemon/crates/convergio-ipc/src/ext.rs
+++ b/daemon/crates/convergio-ipc/src/ext.rs
@@ -47,6 +47,15 @@ impl IpcExtension {
         self.rate_limit = limit;
     }
 
+    fn state(&self) -> Arc<crate::routes::IpcState> {
+        Arc::new(crate::routes::IpcState {
+            pool: self.pool.clone(),
+            notify: Arc::clone(&self.notify),
+            event_bus: Arc::clone(&self.event_bus),
+            rate_limit: self.rate_limit,
+        })
+    }
+
     pub fn stats(&self) -> Result<IpcStats, crate::types::IpcError> {
         let conn = self.pool.get()?;
         let agents: u64 = conn.query_row("SELECT count(*) FROM ipc_agents", [], |r| r.get(0))?;
@@ -94,6 +103,10 @@ impl Extension for IpcExtension {
         }
     }
 
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::routes::ipc_routes(self.state()))
+    }
+
     fn migrations(&self) -> Vec<Migration> {
         crate::schema::migrations()
     }
@@ -131,7 +144,7 @@ impl Extension for IpcExtension {
     }
 
     fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
-        Some(crate::routes::event_routes(self.event_bus.clone()))
+        Some(crate::routes::ipc_routes(self.state()))
     }
 
     fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {

--- a/daemon/crates/convergio-ipc/src/routes.rs
+++ b/daemon/crates/convergio-ipc/src/routes.rs
@@ -1,28 +1,187 @@
-//! HTTP routes for IPC — currently just the SSE event stream.
+//! HTTP API routes for IPC.
+//!
+//! - GET  /api/ipc/status   — IPC stats (agents, messages, channels)
+//! - GET  /api/ipc/agents   — registered agents list
+//! - GET  /api/ipc/channels — channel list
+//! - GET  /api/ipc/context  — shared context entries
+//! - GET  /api/ipc/messages — message history (query: agent, channel, limit)
+//! - GET  /api/ipc/stream   — SSE event stream (query: agent filter)
+//! - GET  /api/events/stream — SSE event stream (legacy path)
+//! - POST /api/ipc/send     — send a direct message
 
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
 use axum::response::sse::{self, Sse};
-use axum::routing::get;
+use axum::response::Json;
+use axum::routing::{get, post};
 use axum::Router;
+use serde::Deserialize;
+use tokio::sync::Notify;
+
+use convergio_db::pool::ConnPool;
 
 use crate::sse::{create_sse_stream, EventBus};
 
+pub struct IpcState {
+    pub pool: ConnPool,
+    pub notify: Arc<Notify>,
+    pub event_bus: Arc<EventBus>,
+    pub rate_limit: u32,
+}
+
+pub fn ipc_routes(state: Arc<IpcState>) -> Router {
+    let bus = Arc::clone(&state.event_bus);
+    Router::new()
+        .route("/api/ipc/status", get(handle_status))
+        .route("/api/ipc/agents", get(handle_agents))
+        .route("/api/ipc/channels", get(handle_channels))
+        .route("/api/ipc/context", get(handle_context))
+        .route("/api/ipc/messages", get(handle_messages))
+        .route("/api/ipc/stream", get(handle_stream))
+        .route("/api/ipc/send", post(handle_send))
+        .with_state(state)
+        .merge(event_routes(bus))
+}
+
+/// Legacy SSE stream at /api/events/stream (from main branch).
+pub fn event_routes(bus: Arc<EventBus>) -> Router {
+    Router::new()
+        .route("/api/events/stream", get(legacy_stream_handler))
+        .with_state(bus)
+}
+
 #[derive(serde::Deserialize, Default)]
-pub struct StreamQuery {
+pub struct LegacyStreamQuery {
     agent_filter: Option<String>,
 }
 
-async fn stream_handler(
+async fn legacy_stream_handler(
     State(bus): State<Arc<EventBus>>,
-    Query(q): Query<StreamQuery>,
+    Query(q): Query<LegacyStreamQuery>,
 ) -> Sse<impl futures_core::Stream<Item = Result<sse::Event, std::convert::Infallible>>> {
     Sse::new(create_sse_stream(bus, q.agent_filter)).keep_alive(sse::KeepAlive::default())
 }
 
-pub fn event_routes(bus: Arc<EventBus>) -> Router {
-    Router::new()
-        .route("/api/events/stream", get(stream_handler))
-        .with_state(bus)
+async fn handle_status(
+    State(state): State<Arc<IpcState>>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(serde_json::json!({"error": e.to_string()})),
+    };
+    let agents: u64 = conn
+        .query_row("SELECT count(*) FROM ipc_agents", [], |r| r.get(0))
+        .unwrap_or(0);
+    let messages: u64 = conn
+        .query_row("SELECT count(*) FROM ipc_messages", [], |r| r.get(0))
+        .unwrap_or(0);
+    let channels: u64 = conn
+        .query_row("SELECT count(*) FROM ipc_channels", [], |r| r.get(0))
+        .unwrap_or(0);
+    Json(serde_json::json!({
+        "agents": agents,
+        "messages": messages,
+        "channels": channels,
+    }))
+}
+
+async fn handle_agents(
+    State(state): State<Arc<IpcState>>,
+) -> Json<serde_json::Value> {
+    match crate::agents::list(&state.pool) {
+        Ok(agents) => Json(serde_json::json!(agents)),
+        Err(e) => Json(serde_json::json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_channels(
+    State(state): State<Arc<IpcState>>,
+) -> Json<serde_json::Value> {
+    match crate::channels::list_channels(&state.pool) {
+        Ok(ch) => Json(serde_json::json!(ch)),
+        Err(e) => Json(serde_json::json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_context(
+    State(state): State<Arc<IpcState>>,
+) -> Json<serde_json::Value> {
+    match crate::channels::context_list(&state.pool) {
+        Ok(ctx) => Json(serde_json::json!(ctx)),
+        Err(e) => Json(serde_json::json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessagesQuery {
+    pub agent: Option<String>,
+    pub channel: Option<String>,
+    pub limit: Option<u32>,
+}
+
+async fn handle_messages(
+    State(state): State<Arc<IpcState>>,
+    Query(params): Query<MessagesQuery>,
+) -> Json<serde_json::Value> {
+    let limit = params.limit.unwrap_or(50).min(200);
+    match crate::messaging::history(
+        &state.pool,
+        params.agent.as_deref(),
+        params.channel.as_deref(),
+        limit,
+        None,
+    ) {
+        Ok(msgs) => Json(serde_json::json!(msgs)),
+        Err(e) => Json(serde_json::json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamQuery {
+    pub agent: Option<String>,
+}
+
+async fn handle_stream(
+    State(state): State<Arc<IpcState>>,
+    Query(params): Query<StreamQuery>,
+) -> Sse<impl futures_core::Stream<Item = Result<sse::Event, std::convert::Infallible>>>
+{
+    Sse::new(create_sse_stream(
+        Arc::clone(&state.event_bus),
+        params.agent,
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SendRequest {
+    pub from: String,
+    pub to: String,
+    pub content: String,
+    #[serde(default = "default_msg_type")]
+    pub msg_type: String,
+    #[serde(default)]
+    pub priority: i32,
+}
+
+fn default_msg_type() -> String {
+    "text".into()
+}
+
+async fn handle_send(
+    State(state): State<Arc<IpcState>>,
+    Json(body): Json<SendRequest>,
+) -> Json<serde_json::Value> {
+    let params = crate::messaging::SendParams {
+        from: &body.from,
+        to: &body.to,
+        content: &body.content,
+        msg_type: &body.msg_type,
+        priority: body.priority,
+        rate_limit: state.rate_limit,
+    };
+    match crate::messaging::send(&state.pool, &state.notify, &params) {
+        Ok(id) => Json(serde_json::json!({"id": id})),
+        Err(e) => Json(serde_json::json!({"error": e.to_string()})),
+    }
 }

--- a/daemon/crates/convergio-ipc/src/routes.rs
+++ b/daemon/crates/convergio-ipc/src/routes.rs
@@ -63,9 +63,7 @@ async fn legacy_stream_handler(
     Sse::new(create_sse_stream(bus, q.agent_filter)).keep_alive(sse::KeepAlive::default())
 }
 
-async fn handle_status(
-    State(state): State<Arc<IpcState>>,
-) -> Json<serde_json::Value> {
+async fn handle_status(State(state): State<Arc<IpcState>>) -> Json<serde_json::Value> {
     let conn = match state.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(serde_json::json!({"error": e.to_string()})),
@@ -86,27 +84,21 @@ async fn handle_status(
     }))
 }
 
-async fn handle_agents(
-    State(state): State<Arc<IpcState>>,
-) -> Json<serde_json::Value> {
+async fn handle_agents(State(state): State<Arc<IpcState>>) -> Json<serde_json::Value> {
     match crate::agents::list(&state.pool) {
         Ok(agents) => Json(serde_json::json!(agents)),
         Err(e) => Json(serde_json::json!({"error": e.to_string()})),
     }
 }
 
-async fn handle_channels(
-    State(state): State<Arc<IpcState>>,
-) -> Json<serde_json::Value> {
+async fn handle_channels(State(state): State<Arc<IpcState>>) -> Json<serde_json::Value> {
     match crate::channels::list_channels(&state.pool) {
         Ok(ch) => Json(serde_json::json!(ch)),
         Err(e) => Json(serde_json::json!({"error": e.to_string()})),
     }
 }
 
-async fn handle_context(
-    State(state): State<Arc<IpcState>>,
-) -> Json<serde_json::Value> {
+async fn handle_context(State(state): State<Arc<IpcState>>) -> Json<serde_json::Value> {
     match crate::channels::context_list(&state.pool) {
         Ok(ctx) => Json(serde_json::json!(ctx)),
         Err(e) => Json(serde_json::json!({"error": e.to_string()})),
@@ -145,8 +137,7 @@ pub struct StreamQuery {
 async fn handle_stream(
     State(state): State<Arc<IpcState>>,
     Query(params): Query<StreamQuery>,
-) -> Sse<impl futures_core::Stream<Item = Result<sse::Event, std::convert::Infallible>>>
-{
+) -> Sse<impl futures_core::Stream<Item = Result<sse::Event, std::convert::Infallible>>> {
     Sse::new(create_sse_stream(
         Arc::clone(&state.event_bus),
         params.agent,

--- a/daemon/crates/convergio-mesh/Cargo.toml
+++ b/daemon/crates/convergio-mesh/Cargo.toml
@@ -22,6 +22,7 @@ hmac = { workspace = true }
 sha2 = { workspace = true }
 rand = { workspace = true }
 rusqlite = { workspace = true }
+axum = { workspace = true }
 hex = "0.4"
 hostname = "0.4"
 

--- a/daemon/crates/convergio-mesh/src/ext.rs
+++ b/daemon/crates/convergio-mesh/src/ext.rs
@@ -87,6 +87,13 @@ impl Extension for MeshExtension {
         }
     }
 
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        let state = std::sync::Arc::new(crate::routes::MeshState {
+            pool: self.pool.clone(),
+        });
+        Some(crate::routes::mesh_routes(state))
+    }
+
     fn migrations(&self) -> Vec<Migration> {
         crate::schema::migrations()
     }

--- a/daemon/crates/convergio-mesh/src/lib.rs
+++ b/daemon/crates/convergio-mesh/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ext;
 pub mod peers_parser;
 pub mod peers_registry;
 pub mod peers_types;
+pub mod routes;
 pub mod schema;
 pub mod sync;
 pub mod sync_apply;

--- a/daemon/crates/convergio-mesh/src/routes.rs
+++ b/daemon/crates/convergio-mesh/src/routes.rs
@@ -1,0 +1,194 @@
+//! HTTP API routes for mesh sync and peer management.
+//!
+//! - GET  /api/mesh           — mesh status (peers online, sync stats)
+//! - GET  /api/mesh/peers     — list peers from heartbeat table
+//! - GET  /api/sync/export    — export changes since timestamp (query: table, since)
+//! - POST /api/sync/import    — apply SyncChange[] from a peer
+//! - GET  /api/sync/status    — sync metadata per peer
+//! - POST /api/heartbeat      — receive heartbeat from a peer
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use rusqlite::params;
+use serde::Deserialize;
+use serde_json::json;
+
+use convergio_db::pool::ConnPool;
+
+use crate::sync_apply;
+use crate::types::SyncChange;
+
+pub struct MeshState {
+    pub pool: ConnPool,
+}
+
+pub fn mesh_routes(state: Arc<MeshState>) -> Router {
+    Router::new()
+        .route("/api/mesh", get(handle_status))
+        .route("/api/mesh/peers", get(handle_peers))
+        .route("/api/sync/export", get(handle_export))
+        .route("/api/sync/import", post(handle_import))
+        .route("/api/sync/status", get(handle_sync_status))
+        .route("/api/heartbeat", post(handle_heartbeat))
+        .with_state(state)
+}
+
+async fn handle_status(
+    State(state): State<Arc<MeshState>>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let peers_online: u64 = conn
+        .query_row(
+            "SELECT count(*) FROM peer_heartbeats \
+             WHERE last_seen > unixepoch() - 600",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    let total_synced: u64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(total_applied), 0) FROM mesh_sync_stats",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    Json(json!({
+        "peers_online": peers_online,
+        "total_synced": total_synced,
+    }))
+}
+
+async fn handle_peers(
+    State(state): State<Arc<MeshState>>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT peer_name, last_seen, version, \
+         CASE WHEN last_seen > unixepoch() - 600 THEN 'online' \
+         ELSE 'offline' END as status \
+         FROM peer_heartbeats ORDER BY peer_name",
+    ) {
+        Ok(s) => s,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let peers: Vec<serde_json::Value> = match stmt.query_map([], |row| {
+        Ok(json!({
+            "peer": row.get::<_, String>(0)?,
+            "last_seen": row.get::<_, i64>(1)?,
+            "version": row.get::<_, Option<String>>(2)?,
+            "status": row.get::<_, String>(3)?,
+        }))
+    }) {
+        Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+        Err(_) => vec![],
+    };
+    Json(json!(peers))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExportQuery {
+    pub table: String,
+    pub since: Option<String>,
+}
+
+async fn handle_export(
+    State(state): State<Arc<MeshState>>,
+    Query(params): Query<ExportQuery>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match sync_apply::export_changes_since(
+        &conn,
+        &params.table,
+        params.since.as_deref(),
+    ) {
+        Ok(changes) => Json(json!({"changes": changes})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_import(
+    State(state): State<Arc<MeshState>>,
+    Json(changes): Json<Vec<SyncChange>>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match sync_apply::apply_changes(&conn, &changes) {
+        Ok(applied) => Json(json!({"applied": applied})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_sync_status(
+    State(state): State<Arc<MeshState>>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT peer_name, total_applied, last_sync_at, \
+         last_latency_ms, consecutive_failures \
+         FROM mesh_sync_stats ORDER BY peer_name",
+    ) {
+        Ok(s) => s,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let rows: Vec<serde_json::Value> = match stmt.query_map([], |row| {
+        Ok(json!({
+            "peer": row.get::<_, String>(0)?,
+            "total_applied": row.get::<_, i64>(1)?,
+            "last_sync_at": row.get::<_, Option<String>>(2)?,
+            "latency_ms": row.get::<_, Option<i64>>(3)?,
+            "failures": row.get::<_, i64>(4)?,
+        }))
+    }) {
+        Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+        Err(_) => vec![],
+    };
+    Json(json!(rows))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HeartbeatRequest {
+    pub peer: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub capabilities: Option<String>,
+}
+
+async fn handle_heartbeat(
+    State(state): State<Arc<MeshState>>,
+    Json(body): Json<HeartbeatRequest>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match conn.execute(
+        "INSERT INTO peer_heartbeats (peer_name, last_seen, version, capabilities) \
+         VALUES (?1, unixepoch(), ?2, ?3) \
+         ON CONFLICT(peer_name) DO UPDATE SET \
+         last_seen = unixepoch(), version = excluded.version, \
+         capabilities = excluded.capabilities",
+        params![body.peer, body.version, body.capabilities],
+    ) {
+        Ok(_) => Json(json!({"status": "ok"})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}

--- a/daemon/crates/convergio-mesh/src/routes.rs
+++ b/daemon/crates/convergio-mesh/src/routes.rs
@@ -37,9 +37,7 @@ pub fn mesh_routes(state: Arc<MeshState>) -> Router {
         .with_state(state)
 }
 
-async fn handle_status(
-    State(state): State<Arc<MeshState>>,
-) -> Json<serde_json::Value> {
+async fn handle_status(State(state): State<Arc<MeshState>>) -> Json<serde_json::Value> {
     let conn = match state.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"error": e.to_string()})),
@@ -65,9 +63,7 @@ async fn handle_status(
     }))
 }
 
-async fn handle_peers(
-    State(state): State<Arc<MeshState>>,
-) -> Json<serde_json::Value> {
+async fn handle_peers(State(state): State<Arc<MeshState>>) -> Json<serde_json::Value> {
     let conn = match state.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"error": e.to_string()})),
@@ -109,11 +105,7 @@ async fn handle_export(
         Ok(c) => c,
         Err(e) => return Json(json!({"error": e.to_string()})),
     };
-    match sync_apply::export_changes_since(
-        &conn,
-        &params.table,
-        params.since.as_deref(),
-    ) {
+    match sync_apply::export_changes_since(&conn, &params.table, params.since.as_deref()) {
         Ok(changes) => Json(json!({"changes": changes})),
         Err(e) => Json(json!({"error": e.to_string()})),
     }
@@ -133,9 +125,7 @@ async fn handle_import(
     }
 }
 
-async fn handle_sync_status(
-    State(state): State<Arc<MeshState>>,
-) -> Json<serde_json::Value> {
+async fn handle_sync_status(State(state): State<Arc<MeshState>>) -> Json<serde_json::Value> {
     let conn = match state.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"error": e.to_string()})),

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -58,7 +58,13 @@ impl Extension for OrchestratorExtension {
     }
 
     fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
-        Some(crate::scaffold::scaffold_routes())
+        let state = Arc::new(crate::plan_routes::PlanState {
+            pool: self.pool.clone(),
+        });
+        let router = crate::scaffold::scaffold_routes()
+            .merge(crate::plan_routes::plan_routes(Arc::clone(&state)))
+            .merge(crate::plan_routes_ext::plan_routes_ext(state));
+        Some(router)
     }
 
     fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -63,7 +63,8 @@ impl Extension for OrchestratorExtension {
         });
         let router = crate::scaffold::scaffold_routes()
             .merge(crate::plan_routes::plan_routes(Arc::clone(&state)))
-            .merge(crate::plan_routes_ext::plan_routes_ext(state));
+            .merge(crate::plan_routes_ext::plan_routes_ext(Arc::clone(&state)))
+            .merge(crate::task_routes::task_routes(state));
         Some(router)
     }
 

--- a/daemon/crates/convergio-orchestrator/src/lib.rs
+++ b/daemon/crates/convergio-orchestrator/src/lib.rs
@@ -8,6 +8,8 @@ pub mod executor;
 pub mod ext;
 pub mod handlers;
 pub mod plan_hierarchy;
+pub mod plan_routes;
+pub mod plan_routes_ext;
 pub mod policy;
 pub mod reactor;
 pub mod reaper;

--- a/daemon/crates/convergio-orchestrator/src/lib.rs
+++ b/daemon/crates/convergio-orchestrator/src/lib.rs
@@ -18,6 +18,7 @@ pub mod scaffold;
 pub mod scaffold_gen;
 pub mod scaffold_templates;
 pub mod schema;
+pub mod task_routes;
 pub mod types;
 pub mod validator;
 

--- a/daemon/crates/convergio-orchestrator/src/plan_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes.rs
@@ -1,0 +1,263 @@
+//! HTTP routes for plan-db CRUD operations.
+//!
+//! - GET  /api/plan-db/list         — list plans (optional ?status, ?project_id)
+//! - POST /api/plan-db/create       — create a new plan
+//! - GET  /api/plan-db/json/:id     — get plan with waves and tasks
+//! - POST /api/plan-db/start/:id    — set plan status to in_progress
+//! - POST /api/plan-db/complete/:id — set plan status to done
+//! - POST /api/plan-db/cancel/:id   — set plan status to cancelled
+//! - POST /api/plan-db/task/update  — update task status/notes/output
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use rusqlite::params;
+use serde::Deserialize;
+use serde_json::json;
+
+use convergio_db::pool::ConnPool;
+
+pub struct PlanState {
+    pub pool: ConnPool,
+}
+
+pub fn plan_routes(state: Arc<PlanState>) -> Router {
+    Router::new()
+        .route("/api/plan-db/list", get(handle_list))
+        .route("/api/plan-db/create", post(handle_create))
+        .route("/api/plan-db/json/:plan_id", get(handle_get))
+        .route("/api/plan-db/start/:plan_id", post(handle_start))
+        .route("/api/plan-db/complete/:plan_id", post(handle_complete))
+        .route("/api/plan-db/cancel/:plan_id", post(handle_cancel))
+        .route("/api/plan-db/task/update", post(handle_task_update))
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    pub status: Option<String>,
+    pub project_id: Option<String>,
+}
+
+async fn handle_list(
+    State(state): State<Arc<PlanState>>,
+    Query(q): Query<ListQuery>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut sql = "SELECT id, project_id, name, status, tasks_done, tasks_total, \
+                   created_at, updated_at FROM plans"
+        .to_string();
+    let mut conds: Vec<String> = Vec::new();
+    let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(ref s) = q.status {
+        p.push(Box::new(s.clone()));
+        conds.push(format!("status = ?{}", p.len()));
+    }
+    if let Some(ref pid) = q.project_id {
+        p.push(Box::new(pid.clone()));
+        conds.push(format!("project_id = ?{}", p.len()));
+    }
+    if !conds.is_empty() {
+        sql.push_str(&format!(" WHERE {}", conds.join(" AND ")));
+    }
+    sql.push_str(" ORDER BY id DESC LIMIT 100");
+    let refs: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|v| v.as_ref()).collect();
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(s) => s,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let plans: Vec<serde_json::Value> = match stmt.query_map(refs.as_slice(), |row| {
+        Ok(json!({
+            "id": row.get::<_, i64>(0)?,
+            "project_id": row.get::<_, String>(1)?,
+            "name": row.get::<_, String>(2)?,
+            "status": row.get::<_, String>(3)?,
+            "tasks_done": row.get::<_, i64>(4)?,
+            "tasks_total": row.get::<_, i64>(5)?,
+            "created_at": row.get::<_, String>(6)?,
+            "updated_at": row.get::<_, String>(7)?,
+        }))
+    }) {
+        Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    Json(json!(plans))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePlan {
+    pub project_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub depends_on: Option<String>,
+    #[serde(default)]
+    pub execution_mode: Option<String>,
+    #[serde(default)]
+    pub tasks_total: i64,
+}
+
+async fn handle_create(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<CreatePlan>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match conn.execute(
+        "INSERT INTO plans (project_id, name, depends_on, execution_mode, tasks_total) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![body.project_id, body.name, body.depends_on, body.execution_mode, body.tasks_total],
+    ) {
+        Ok(_) => {
+            let id = conn.last_insert_rowid();
+            Json(json!({"id": id, "status": "created"}))
+        }
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_get(
+    State(state): State<Arc<PlanState>>,
+    Path(plan_id): Path<i64>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let plan = conn.query_row(
+        "SELECT id, project_id, name, status, tasks_done, tasks_total, \
+         depends_on, execution_mode, created_at, updated_at FROM plans WHERE id = ?1",
+        params![plan_id],
+        |row| {
+            Ok(json!({
+                "id": row.get::<_, i64>(0)?,
+                "project_id": row.get::<_, String>(1)?,
+                "name": row.get::<_, String>(2)?,
+                "status": row.get::<_, String>(3)?,
+                "tasks_done": row.get::<_, i64>(4)?,
+                "tasks_total": row.get::<_, i64>(5)?,
+                "depends_on": row.get::<_, Option<String>>(6)?,
+                "execution_mode": row.get::<_, Option<String>>(7)?,
+                "created_at": row.get::<_, String>(8)?,
+                "updated_at": row.get::<_, String>(9)?,
+            }))
+        },
+    );
+    match plan {
+        Ok(p) => Json(p),
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            Json(json!({"error": "plan not found"}))
+        }
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+fn set_plan_status(pool: &ConnPool, plan_id: i64, status: &str) -> serde_json::Value {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return json!({"error": e.to_string()}),
+    };
+    match conn.execute(
+        "UPDATE plans SET status = ?1, updated_at = datetime('now') WHERE id = ?2",
+        params![status, plan_id],
+    ) {
+        Ok(0) => json!({"error": "plan not found"}),
+        Ok(_) => json!({"id": plan_id, "status": status}),
+        Err(e) => json!({"error": e.to_string()}),
+    }
+}
+
+async fn handle_start(
+    State(s): State<Arc<PlanState>>,
+    Path(id): Path<i64>,
+) -> Json<serde_json::Value> {
+    Json(set_plan_status(&s.pool, id, "in_progress"))
+}
+
+async fn handle_complete(
+    State(s): State<Arc<PlanState>>,
+    Path(id): Path<i64>,
+) -> Json<serde_json::Value> {
+    Json(set_plan_status(&s.pool, id, "done"))
+}
+
+async fn handle_cancel(
+    State(s): State<Arc<PlanState>>,
+    Path(id): Path<i64>,
+) -> Json<serde_json::Value> {
+    Json(set_plan_status(&s.pool, id, "cancelled"))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TaskUpdate {
+    pub task_id: i64,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub output_data: Option<String>,
+    #[serde(default)]
+    pub executor_agent: Option<String>,
+    #[serde(default)]
+    pub tokens: Option<i64>,
+}
+
+async fn handle_task_update(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<TaskUpdate>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut sets: Vec<String> = Vec::new();
+    let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(ref s) = body.status {
+        p.push(Box::new(s.clone()));
+        sets.push(format!("status = ?{}", p.len()));
+        if s == "in_progress" {
+            sets.push("started_at = datetime('now')".into());
+        } else if s == "done" || s == "submitted" {
+            sets.push("completed_at = datetime('now')".into());
+        }
+    }
+    if let Some(ref n) = body.notes {
+        p.push(Box::new(n.clone()));
+        sets.push(format!("notes = ?{}", p.len()));
+    }
+    if let Some(ref o) = body.output_data {
+        p.push(Box::new(o.clone()));
+        sets.push(format!("output_data = ?{}", p.len()));
+    }
+    if let Some(ref a) = body.executor_agent {
+        p.push(Box::new(a.clone()));
+        sets.push(format!("executor_agent = ?{}", p.len()));
+    }
+    if let Some(t) = body.tokens {
+        p.push(Box::new(t));
+        sets.push(format!("tokens = ?{}", p.len()));
+    }
+    if sets.is_empty() {
+        return Json(json!({"error": "no fields to update"}));
+    }
+    p.push(Box::new(body.task_id));
+    let sql = format!(
+        "UPDATE tasks SET {} WHERE id = ?{}",
+        sets.join(", "),
+        p.len()
+    );
+    let refs: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|v| v.as_ref()).collect();
+    match conn.execute(&sql, refs.as_slice()) {
+        Ok(0) => Json(json!({"error": "task not found"})),
+        Ok(_) => Json(json!({"task_id": body.task_id, "updated": true})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}

--- a/daemon/crates/convergio-orchestrator/src/plan_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes.rs
@@ -32,7 +32,6 @@ pub fn plan_routes(state: Arc<PlanState>) -> Router {
         .route("/api/plan-db/start/:plan_id", post(handle_start))
         .route("/api/plan-db/complete/:plan_id", post(handle_complete))
         .route("/api/plan-db/cancel/:plan_id", post(handle_cancel))
-        .route("/api/plan-db/task/update", post(handle_task_update))
         .with_state(state)
 }
 
@@ -113,7 +112,13 @@ async fn handle_create(
     match conn.execute(
         "INSERT INTO plans (project_id, name, depends_on, execution_mode, tasks_total) \
          VALUES (?1, ?2, ?3, ?4, ?5)",
-        params![body.project_id, body.name, body.depends_on, body.execution_mode, body.tasks_total],
+        params![
+            body.project_id,
+            body.name,
+            body.depends_on,
+            body.execution_mode,
+            body.tasks_total
+        ],
     ) {
         Ok(_) => {
             let id = conn.last_insert_rowid();
@@ -152,9 +157,7 @@ async fn handle_get(
     );
     match plan {
         Ok(p) => Json(p),
-        Err(rusqlite::Error::QueryReturnedNoRows) => {
-            Json(json!({"error": "plan not found"}))
-        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Json(json!({"error": "plan not found"})),
         Err(e) => Json(json!({"error": e.to_string()})),
     }
 }
@@ -193,71 +196,4 @@ async fn handle_cancel(
     Path(id): Path<i64>,
 ) -> Json<serde_json::Value> {
     Json(set_plan_status(&s.pool, id, "cancelled"))
-}
-
-#[derive(Debug, Deserialize)]
-pub struct TaskUpdate {
-    pub task_id: i64,
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub notes: Option<String>,
-    #[serde(default)]
-    pub output_data: Option<String>,
-    #[serde(default)]
-    pub executor_agent: Option<String>,
-    #[serde(default)]
-    pub tokens: Option<i64>,
-}
-
-async fn handle_task_update(
-    State(state): State<Arc<PlanState>>,
-    Json(body): Json<TaskUpdate>,
-) -> Json<serde_json::Value> {
-    let conn = match state.pool.get() {
-        Ok(c) => c,
-        Err(e) => return Json(json!({"error": e.to_string()})),
-    };
-    let mut sets: Vec<String> = Vec::new();
-    let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-    if let Some(ref s) = body.status {
-        p.push(Box::new(s.clone()));
-        sets.push(format!("status = ?{}", p.len()));
-        if s == "in_progress" {
-            sets.push("started_at = datetime('now')".into());
-        } else if s == "done" || s == "submitted" {
-            sets.push("completed_at = datetime('now')".into());
-        }
-    }
-    if let Some(ref n) = body.notes {
-        p.push(Box::new(n.clone()));
-        sets.push(format!("notes = ?{}", p.len()));
-    }
-    if let Some(ref o) = body.output_data {
-        p.push(Box::new(o.clone()));
-        sets.push(format!("output_data = ?{}", p.len()));
-    }
-    if let Some(ref a) = body.executor_agent {
-        p.push(Box::new(a.clone()));
-        sets.push(format!("executor_agent = ?{}", p.len()));
-    }
-    if let Some(t) = body.tokens {
-        p.push(Box::new(t));
-        sets.push(format!("tokens = ?{}", p.len()));
-    }
-    if sets.is_empty() {
-        return Json(json!({"error": "no fields to update"}));
-    }
-    p.push(Box::new(body.task_id));
-    let sql = format!(
-        "UPDATE tasks SET {} WHERE id = ?{}",
-        sets.join(", "),
-        p.len()
-    );
-    let refs: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|v| v.as_ref()).collect();
-    match conn.execute(&sql, refs.as_slice()) {
-        Ok(0) => Json(json!({"error": "task not found"})),
-        Ok(_) => Json(json!({"task_id": body.task_id, "updated": true})),
-        Err(e) => Json(json!({"error": e.to_string()})),
-    }
 }

--- a/daemon/crates/convergio-orchestrator/src/plan_routes_ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes_ext.rs
@@ -29,11 +29,6 @@ pub fn plan_routes_ext(state: Arc<PlanState>) -> Router {
             "/api/plan-db/checkpoint/restore",
             get(handle_checkpoint_restore),
         )
-        .route("/api/plan-db/task/evidence", post(handle_record_evidence))
-        .route(
-            "/api/plan-db/task/evidence/:task_id",
-            get(handle_get_evidence),
-        )
         .route(
             "/api/plan-db/execution-tree/:plan_id",
             get(handle_execution_tree),
@@ -121,8 +116,12 @@ async fn handle_checkpoint_save(
     let plan = match conn.query_row(
         "SELECT id, name, status, project_id FROM plans WHERE id = ?1",
         params![body.plan_id],
-        |r| Ok(json!({"id": r.get::<_,i64>(0)?, "name": r.get::<_,String>(1)?,
-                       "status": r.get::<_,String>(2)?, "project_id": r.get::<_,String>(3)?})),
+        |r| {
+            Ok(
+                json!({"id": r.get::<_,i64>(0)?, "name": r.get::<_,String>(1)?,
+                       "status": r.get::<_,String>(2)?, "project_id": r.get::<_,String>(3)?}),
+            )
+        },
     ) {
         Ok(p) => p,
         Err(e) => return Json(json!({"error": e.to_string()})),
@@ -133,7 +132,10 @@ async fn handle_checkpoint_save(
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    match std::fs::write(&path, serde_json::to_string_pretty(&checkpoint).unwrap_or_default()) {
+    match std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&checkpoint).unwrap_or_default(),
+    ) {
         Ok(()) => Json(json!({"plan_id": body.plan_id, "saved": true,
                               "path": path.to_string_lossy()})),
         Err(e) => Json(json!({"error": e.to_string()})),
@@ -163,57 +165,6 @@ async fn handle_checkpoint_restore(
     }
 }
 
-#[derive(Debug, Deserialize)]
-pub struct RecordEvidence {
-    pub task_id: i64,
-    pub evidence_type: String,
-    pub content: String,
-}
-
-async fn handle_record_evidence(
-    State(state): State<Arc<PlanState>>,
-    Json(body): Json<RecordEvidence>,
-) -> Json<serde_json::Value> {
-    let conn = match state.pool.get() {
-        Ok(c) => c,
-        Err(e) => return Json(json!({"error": e.to_string()})),
-    };
-    // Store evidence as a note/output on the task
-    match conn.execute(
-        "UPDATE tasks SET notes = COALESCE(notes, '') || ?1, \
-         output_data = ?2 WHERE id = ?3",
-        params![
-            format!("\n[{}] {}", body.evidence_type, body.content),
-            body.content,
-            body.task_id,
-        ],
-    ) {
-        Ok(0) => Json(json!({"error": "task not found"})),
-        Ok(_) => Json(json!({"task_id": body.task_id, "recorded": true})),
-        Err(e) => Json(json!({"error": e.to_string()})),
-    }
-}
-
-async fn handle_get_evidence(
-    State(state): State<Arc<PlanState>>,
-    Path(task_id): Path<i64>,
-) -> Json<serde_json::Value> {
-    let conn = match state.pool.get() {
-        Ok(c) => c,
-        Err(e) => return Json(json!({"error": e.to_string()})),
-    };
-    match conn.query_row(
-        "SELECT notes, output_data FROM tasks WHERE id = ?1",
-        params![task_id],
-        |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
-    ) {
-        Ok((notes, output)) => Json(json!({
-            "task_id": task_id, "notes": notes, "output_data": output
-        })),
-        Err(e) => Json(json!({"error": e.to_string()})),
-    }
-}
-
 async fn handle_execution_tree(
     State(state): State<Arc<PlanState>>,
     Path(plan_id): Path<i64>,
@@ -226,9 +177,13 @@ async fn handle_execution_tree(
     let plan = match conn.query_row(
         "SELECT id, name, status, tasks_done, tasks_total FROM plans WHERE id = ?1",
         params![plan_id],
-        |r| Ok(json!({"id": r.get::<_,i64>(0)?, "name": r.get::<_,String>(1)?,
+        |r| {
+            Ok(
+                json!({"id": r.get::<_,i64>(0)?, "name": r.get::<_,String>(1)?,
                        "status": r.get::<_,String>(2)?, "tasks_done": r.get::<_,i64>(3)?,
-                       "tasks_total": r.get::<_,i64>(4)?})),
+                       "tasks_total": r.get::<_,i64>(4)?}),
+            )
+        },
     ) {
         Ok(p) => p,
         Err(e) => return Json(json!({"error": e.to_string()})),
@@ -240,8 +195,11 @@ async fn handle_execution_tree(
         Err(e) => return Json(json!({"error": e.to_string()})),
     };
     let waves: Vec<serde_json::Value> = match wave_stmt.query_map(params![plan_id], |r| {
-        Ok((r.get::<_, i64>(0)?, json!({"id": r.get::<_,i64>(0)?, "wave_id": r.get::<_,String>(1)?,
-             "name": r.get::<_,String>(2)?, "status": r.get::<_,String>(3)?})))
+        Ok((
+            r.get::<_, i64>(0)?,
+            json!({"id": r.get::<_,i64>(0)?, "wave_id": r.get::<_,String>(1)?,
+             "name": r.get::<_,String>(2)?, "status": r.get::<_,String>(3)?}),
+        ))
     }) {
         Ok(rows) => rows.filter_map(|r| r.ok()).map(|(_, v)| v).collect(),
         Err(_) => vec![],

--- a/daemon/crates/convergio-orchestrator/src/plan_routes_ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes_ext.rs
@@ -100,16 +100,20 @@ pub struct CheckpointSave {
     pub plan_id: i64,
 }
 
+/// Build checkpoint file path. plan_id is validated by callers to be > 0.
+/// Since plan_id is i64 (integer only), no path traversal is possible.
 fn checkpoint_path(plan_id: i64) -> std::path::PathBuf {
-    convergio_types::platform_paths::convergio_data_dir()
-        .join("checkpoints")
-        .join(format!("plan-{plan_id}.json"))
+    let base = convergio_types::platform_paths::convergio_data_dir().join("checkpoints");
+    base.join(format!("plan-{plan_id}.json"))
 }
 
 async fn handle_checkpoint_save(
     State(state): State<Arc<PlanState>>,
     Json(body): Json<CheckpointSave>,
 ) -> Json<serde_json::Value> {
+    if body.plan_id <= 0 {
+        return Json(json!({"error": "invalid plan_id"}));
+    }
     let conn = match state.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"error": e.to_string()})),
@@ -145,6 +149,9 @@ async fn handle_checkpoint_restore(
     State(_state): State<Arc<PlanState>>,
     Query(q): Query<CheckpointQuery>,
 ) -> Json<serde_json::Value> {
+    if q.plan_id <= 0 {
+        return Json(json!({"error": "invalid plan_id"}));
+    }
     let path = checkpoint_path(q.plan_id);
     match std::fs::read_to_string(&path) {
         Ok(contents) => {

--- a/daemon/crates/convergio-orchestrator/src/plan_routes_ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes_ext.rs
@@ -1,0 +1,243 @@
+//! Extended plan-db routes: waves, checkpoints, evidence, knowledge base.
+//!
+//! - POST /api/plan-db/wave/create         — create wave in plan
+//! - POST /api/plan-db/wave/update         — update wave status
+//! - POST /api/plan-db/checkpoint/save     — save execution checkpoint
+//! - GET  /api/plan-db/checkpoint/restore  — restore checkpoint
+//! - POST /api/plan-db/task/evidence       — record task evidence
+//! - GET  /api/plan-db/task/evidence/:id   — get task evidence
+//! - GET  /api/plan-db/execution-tree/:id  — full plan tree
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use rusqlite::params;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::plan_routes::PlanState;
+
+pub fn plan_routes_ext(state: Arc<PlanState>) -> Router {
+    Router::new()
+        .route("/api/plan-db/wave/create", post(handle_wave_create))
+        .route("/api/plan-db/wave/update", post(handle_wave_update))
+        .route("/api/plan-db/checkpoint/save", post(handle_checkpoint_save))
+        .route(
+            "/api/plan-db/checkpoint/restore",
+            get(handle_checkpoint_restore),
+        )
+        .route("/api/plan-db/task/evidence", post(handle_record_evidence))
+        .route(
+            "/api/plan-db/task/evidence/:task_id",
+            get(handle_get_evidence),
+        )
+        .route(
+            "/api/plan-db/execution-tree/:plan_id",
+            get(handle_execution_tree),
+        )
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WaveCreate {
+    pub plan_id: i64,
+    pub wave_id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+async fn handle_wave_create(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<WaveCreate>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match conn.execute(
+        "INSERT INTO waves (wave_id, plan_id, name) VALUES (?1, ?2, ?3)",
+        params![body.wave_id, body.plan_id, body.name],
+    ) {
+        Ok(_) => {
+            let id = conn.last_insert_rowid();
+            Json(json!({"id": id, "wave_id": body.wave_id}))
+        }
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WaveUpdate {
+    pub wave_id: i64,
+    pub status: String,
+}
+
+async fn handle_wave_update(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<WaveUpdate>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut sql = "UPDATE waves SET status = ?1".to_string();
+    if body.status == "in_progress" {
+        sql.push_str(", started_at = datetime('now')");
+    }
+    sql.push_str(" WHERE id = ?2");
+    match conn.execute(&sql, params![body.status, body.wave_id]) {
+        Ok(0) => Json(json!({"error": "wave not found"})),
+        Ok(_) => Json(json!({"wave_id": body.wave_id, "status": body.status})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckpointSave {
+    pub plan_id: i64,
+}
+
+fn checkpoint_path(plan_id: i64) -> std::path::PathBuf {
+    convergio_types::platform_paths::convergio_data_dir()
+        .join("checkpoints")
+        .join(format!("plan-{plan_id}.json"))
+}
+
+async fn handle_checkpoint_save(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<CheckpointSave>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let plan = match conn.query_row(
+        "SELECT id, name, status, project_id FROM plans WHERE id = ?1",
+        params![body.plan_id],
+        |r| Ok(json!({"id": r.get::<_,i64>(0)?, "name": r.get::<_,String>(1)?,
+                       "status": r.get::<_,String>(2)?, "project_id": r.get::<_,String>(3)?})),
+    ) {
+        Ok(p) => p,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let checkpoint = json!({"plan_id": body.plan_id, "plan": plan,
+                            "saved_at": chrono::Utc::now().to_rfc3339()});
+    let path = checkpoint_path(body.plan_id);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::write(&path, serde_json::to_string_pretty(&checkpoint).unwrap_or_default()) {
+        Ok(()) => Json(json!({"plan_id": body.plan_id, "saved": true,
+                              "path": path.to_string_lossy()})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CheckpointQuery {
+    pub plan_id: i64,
+}
+
+async fn handle_checkpoint_restore(
+    State(_state): State<Arc<PlanState>>,
+    Query(q): Query<CheckpointQuery>,
+) -> Json<serde_json::Value> {
+    let path = checkpoint_path(q.plan_id);
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let data = serde_json::from_str::<serde_json::Value>(&contents)
+                .unwrap_or(json!({"raw": contents}));
+            Json(json!({"plan_id": q.plan_id, "data": data}))
+        }
+        Err(e) => Json(json!({"error": format!("checkpoint not found: {e}")})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RecordEvidence {
+    pub task_id: i64,
+    pub evidence_type: String,
+    pub content: String,
+}
+
+async fn handle_record_evidence(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<RecordEvidence>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    // Store evidence as a note/output on the task
+    match conn.execute(
+        "UPDATE tasks SET notes = COALESCE(notes, '') || ?1, \
+         output_data = ?2 WHERE id = ?3",
+        params![
+            format!("\n[{}] {}", body.evidence_type, body.content),
+            body.content,
+            body.task_id,
+        ],
+    ) {
+        Ok(0) => Json(json!({"error": "task not found"})),
+        Ok(_) => Json(json!({"task_id": body.task_id, "recorded": true})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_get_evidence(
+    State(state): State<Arc<PlanState>>,
+    Path(task_id): Path<i64>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match conn.query_row(
+        "SELECT notes, output_data FROM tasks WHERE id = ?1",
+        params![task_id],
+        |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+    ) {
+        Ok((notes, output)) => Json(json!({
+            "task_id": task_id, "notes": notes, "output_data": output
+        })),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_execution_tree(
+    State(state): State<Arc<PlanState>>,
+    Path(plan_id): Path<i64>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    // Build plan -> waves -> tasks tree
+    let plan = match conn.query_row(
+        "SELECT id, name, status, tasks_done, tasks_total FROM plans WHERE id = ?1",
+        params![plan_id],
+        |r| Ok(json!({"id": r.get::<_,i64>(0)?, "name": r.get::<_,String>(1)?,
+                       "status": r.get::<_,String>(2)?, "tasks_done": r.get::<_,i64>(3)?,
+                       "tasks_total": r.get::<_,i64>(4)?})),
+    ) {
+        Ok(p) => p,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut wave_stmt = match conn
+        .prepare("SELECT id, wave_id, name, status FROM waves WHERE plan_id = ?1 ORDER BY id")
+    {
+        Ok(s) => s,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let waves: Vec<serde_json::Value> = match wave_stmt.query_map(params![plan_id], |r| {
+        Ok((r.get::<_, i64>(0)?, json!({"id": r.get::<_,i64>(0)?, "wave_id": r.get::<_,String>(1)?,
+             "name": r.get::<_,String>(2)?, "status": r.get::<_,String>(3)?})))
+    }) {
+        Ok(rows) => rows.filter_map(|r| r.ok()).map(|(_, v)| v).collect(),
+        Err(_) => vec![],
+    };
+    Json(json!({"plan": plan, "waves": waves}))
+}

--- a/daemon/crates/convergio-orchestrator/src/task_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/task_routes.rs
@@ -1,0 +1,85 @@
+//! HTTP route for task updates.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::Json;
+use axum::routing::post;
+use axum::Router;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::plan_routes::PlanState;
+
+pub fn task_routes(state: Arc<PlanState>) -> Router {
+    Router::new()
+        .route("/api/plan-db/task/update", post(handle_task_update))
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TaskUpdate {
+    pub task_id: i64,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+    #[serde(default)]
+    pub output_data: Option<String>,
+    #[serde(default)]
+    pub executor_agent: Option<String>,
+    #[serde(default)]
+    pub tokens: Option<i64>,
+}
+
+async fn handle_task_update(
+    State(state): State<Arc<PlanState>>,
+    Json(body): Json<TaskUpdate>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut sets: Vec<String> = Vec::new();
+    let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(ref s) = body.status {
+        p.push(Box::new(s.clone()));
+        sets.push(format!("status = ?{}", p.len()));
+        if s == "in_progress" {
+            sets.push("started_at = datetime('now')".into());
+        } else if s == "done" || s == "submitted" {
+            sets.push("completed_at = datetime('now')".into());
+        }
+    }
+    if let Some(ref n) = body.notes {
+        p.push(Box::new(n.clone()));
+        sets.push(format!("notes = ?{}", p.len()));
+    }
+    if let Some(ref o) = body.output_data {
+        p.push(Box::new(o.clone()));
+        sets.push(format!("output_data = ?{}", p.len()));
+    }
+    if let Some(ref a) = body.executor_agent {
+        p.push(Box::new(a.clone()));
+        sets.push(format!("executor_agent = ?{}", p.len()));
+    }
+    if let Some(t) = body.tokens {
+        p.push(Box::new(t));
+        sets.push(format!("tokens = ?{}", p.len()));
+    }
+    if sets.is_empty() {
+        return Json(json!({"error": "no fields to update"}));
+    }
+    p.push(Box::new(body.task_id));
+    let sql = format!(
+        "UPDATE tasks SET {} WHERE id = ?{}",
+        sets.join(", "),
+        p.len()
+    );
+    let refs: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|v| v.as_ref()).collect();
+    match conn.execute(&sql, refs.as_slice()) {
+        Ok(0) => Json(json!({"error": "task not found"})),
+        Ok(_) => Json(json!({"task_id": body.task_id, "updated": true})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}

--- a/daemon/crates/convergio-prompts/src/ext.rs
+++ b/daemon/crates/convergio-prompts/src/ext.rs
@@ -70,6 +70,10 @@ impl Extension for PromptsExtension {
         }
     }
 
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::routes::routes(self.pool.clone()))
+    }
+
     fn migrations(&self) -> Vec<Migration> {
         crate::schema::migrations()
     }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -4,6 +4,7 @@
 //! Business logic lives in the crates; this is just the entry point.
 
 use convergio_db::pool::{create_pool, ConnPool};
+use convergio_server::config_watcher::spawn_config_watcher;
 use convergio_server::{build_router, load_config, run_server, ServerState};
 use convergio_telemetry::health::HealthRegistry;
 use convergio_telemetry::metrics::MetricsCollector;
@@ -89,6 +90,11 @@ async fn main() {
     let port = config.daemon.port;
     let config = Arc::new(RwLock::new(config));
 
+    // 2b. Config hot-reload watcher
+    if let Err(e) = spawn_config_watcher(Arc::clone(&config)) {
+        tracing::warn!("config watcher not started: {e}");
+    }
+
     // 3. Database
     let db_path = convergio_types::platform_paths::convergio_data_dir().join("convergio.db");
     if let Some(parent) = db_path.parent() {
@@ -155,6 +161,7 @@ async fn main() {
     if dev_mode {
         tracing::info!("dev-mode enabled (no CONVERGIO_AUTH_TOKEN set)");
     }
+    let shutdown_pool = pool.clone();
     let state = ServerState::new(pool, config, health, metrics, dev_mode);
     let router = build_router(state, &extensions, &ctx);
 
@@ -168,6 +175,13 @@ async fn main() {
     }
 
     // 11. Shutdown
+    // WAL checkpoint: flush pending writes to main DB before dropping pool
+    if let Ok(conn) = shutdown_pool.get() {
+        match conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+            Ok(()) => tracing::info!("WAL checkpoint completed"),
+            Err(e) => tracing::warn!("WAL checkpoint failed: {e}"),
+        }
+    }
     for ext in extensions.iter().rev() {
         let _ = ext.on_shutdown();
     }


### PR DESCRIPTION
## Summary
- Wire HTTP routes for 5 extensions (IPC, mesh, orchestrator plan-db, prompts, backup) — from `None` to working endpoints
- Add 30+ new API endpoints covering plan CRUD, IPC messaging, SSE streaming, mesh sync, checkpoint management
- Spawn config hot-reload watcher on startup
- Add SQLite WAL checkpoint on graceful shutdown

## Changes
| Area | What |
|---|---|
| IPC routes | `/api/ipc/{status,agents,channels,context,messages,stream,send}` |
| Mesh routes | `/api/mesh`, `/api/mesh/peers`, `/api/sync/{export,import,status}`, `/api/heartbeat` |
| Plan-DB routes | Full CRUD: list, create, get, start/complete/cancel, task/update, wave, checkpoint, execution-tree |
| Config watcher | `spawn_config_watcher()` called in main.rs |
| Shutdown | WAL checkpoint before pool drop |

## Test plan
- [x] `cargo check --workspace` — compiles
- [x] `cargo test --workspace` — 815 tests pass, 0 failures
- [x] `cargo build` + daemon startup on port 8421
- [x] `curl` smoke test: health, plan CRUD, IPC send/messages, SSE stream, mesh peers, heartbeat, checkpoint save/restore
- [x] No regressions from previous 793 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)