### PR TITLE
feat: migrate all guardrails from ConvergioPlatform

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,186 @@
 {
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(cargo check*)",
+      "Bash(cargo test*)",
+      "Bash(cargo build*)",
+      "Bash(cargo clippy*)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git branch*)",
+      "Bash(git show*)",
+      "Bash(git rev-parse*)",
+      "Bash(git worktree*)",
+      "Bash(curl http://localhost*)",
+      "Bash(curl -sf http://localhost*)",
+      "Bash(cvg *)",
+      "Bash(~/.local/bin/cvg *)",
+      "Bash(ls *)",
+      "Bash(wc *)",
+      "Bash(gh auth status*)",
+      "Bash(gh pr *)",
+      "Bash(tailscale status*)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push --force*)",
+      "Bash(git reset --hard*)",
+      "Bash(git checkout -- *)",
+      "Bash(git clean -f*)",
+      "Bash(sqlite3 *)",
+      "Bash(*credentials*)",
+      "Bash(*.env *)",
+      "Bash(*secrets*)"
+    ]
+  },
   "hooks": {
-    "PostToolUse": [
+    "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/Roberdan/GitHub/convergio/daemon && CHANGED=\"$CLAUDE_TOOL_ARG_FILE_PATH\" && case \"$CHANGED\" in *.rs) CRATE=$(echo \"$CHANGED\" | sed -n 's|.*/crates/\\([^/]*\\)/.*|\\1|p') && if [ -n \"$CRATE\" ]; then cargo clippy -p \"$CRATE\" -- -D warnings 2>&1; else cargo clippy --workspace -- -D warnings 2>&1; fi ;; esac",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/pre-tool-guard.sh\" bash",
+            "timeout": 10,
+            "statusMessage": "Pre-tool guard (bash)"
+          },
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/block-branch-creation.sh\"",
+            "timeout": 5,
+            "statusMessage": "Block branch creation"
+          },
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/thor-gate-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "ThorGateGuard"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/pre-tool-guard.sh\" edit",
+            "timeout": 10,
+            "statusMessage": "Pre-tool guard (edit)"
+          },
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/main-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "MainGuard"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/main-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "MainGuard"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then LINES=$(wc -l < \"$FILE\"); if [ \"$LINES\" -gt 250 ]; then echo \"BLOCKED: FileSizeGuard — $FILE has $LINES lines (max 250). Split this file.\" >&2; exit 2; fi; fi",
+            "timeout": 5,
+            "statusMessage": "FileSizeGuard"
+          },
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [ -n \"$FILE\" ] && echo \"$FILE\" | grep -qE 'daemon/src/.*\\.rs$'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); OUTPUT=$(\"$ROOT/scripts/hooks/check-rust-wiring.sh\" 2>&1) || echo \"$OUTPUT\" >&2; fi",
+            "timeout": 15,
+            "statusMessage": "Rust module wiring check"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then LINES=$(wc -l < \"$FILE\"); if [ \"$LINES\" -gt 250 ]; then echo \"BLOCKED: FileSizeGuard — $FILE has $LINES lines (max 250). Split this file.\" >&2; exit 2; fi; fi",
+            "timeout": 5,
+            "statusMessage": "FileSizeGuard"
+          },
+          {
+            "type": "command",
+            "command": "cd $(git rev-parse --show-toplevel 2>/dev/null || echo '.')/daemon && CHANGED=$(cat | jq -r '.file_path // empty' 2>/dev/null) && case \"$CHANGED\" in *.rs) if [ \"$(git rev-parse --is-inside-work-tree 2>/dev/null)\" = 'true' ]; then _wt=$(git rev-parse --show-toplevel 2>/dev/null); _main=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\\.git$||'); if [ -n \"$_main\" ] && [ \"$_wt\" != \"$_main\" ]; then export CARGO_TARGET_DIR=\"/tmp/convergio-target-$(basename \"$_wt\")\"; fi; fi; CRATE=$(echo \"$CHANGED\" | sed -n 's|.*/crates/\\([^/]*\\)/.*|\\1|p'); if [ -n \"$CRATE\" ]; then cargo clippy -p \"$CRATE\" -- -D warnings 2>&1; else cargo clippy --workspace -- -D warnings 2>&1; fi ;; esac",
             "timeout": 30,
+            "statusMessage": "Rust clippy check",
             "blocking": true
+          },
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [ -n \"$FILE\" ] && echo \"$FILE\" | grep -qE 'daemon/src/.*\\.rs$'; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); OUTPUT=$(\"$ROOT/scripts/hooks/check-rust-wiring.sh\" 2>&1) || echo \"$OUTPUT\" >&2; fi",
+            "timeout": 15,
+            "statusMessage": "Rust module wiring check"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "AGENT=\"${CONVERGIO_AGENT_NAME:-}\"; [ -z \"$AGENT\" ] && exit 0; API=\"${CONVERGIO_API_URL:-http://localhost:8420}\"; JSON=$(curl -sf \"$API/api/ipc/messages?to_agent=$AGENT&limit=5\" 2>/dev/null || true); [ -z \"$JSON\" ] && exit 0; COUNT=$(echo \"$JSON\" | python3 -c \"import sys,json; msgs=json.load(sys.stdin).get('messages',[]); unread=[m for m in msgs if not m.get('read_at')]; print(len(unread))\" 2>/dev/null || echo 0); [ \"${COUNT:-0}\" -gt 0 ] && echo \"INBOX: $COUNT message(s) for $AGENT. Read: cvg bus read $AGENT\" >&2; exit 0"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); \"$ROOT/scripts/hooks/main-dirty-check.sh\"",
+            "timeout": 5,
+            "statusMessage": "Main repo dirty check"
+          },
+          {
+            "type": "command",
+            "command": "FAIL=0; gh auth status >/dev/null 2>&1 || { echo '{\"systemMessage\":\"PRE-FLIGHT FAIL: gh auth expired. Run: gh auth login\"}'; FAIL=1; }; command -v cvg >/dev/null 2>&1 || { echo '{\"systemMessage\":\"PRE-FLIGHT FAIL: cvg not in PATH\"}'; FAIL=1; }; curl -sf http://localhost:8420/api/health >/dev/null 2>&1 || echo '{\"systemMessage\":\"PRE-FLIGHT WARN: daemon not running on :8420\"}'; [ -z \"${CONVERGIO_AGENT_NAME:-}\" ] && echo '{\"systemMessage\":\"WARNING: AgentIdentity — CONVERGIO_AGENT_NAME not set. Run: cvg agent start <name>\"}'; exit 0",
+            "timeout": 10,
+            "statusMessage": "Pre-flight checks"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); cat | \"$ROOT/scripts/hooks/subagent-completion-gate.sh\"",
+            "timeout": 15,
+            "statusMessage": "Subagent completion gate"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.'); \"$ROOT/scripts/hooks/pre-compaction-snapshot.sh\"",
+            "timeout": 10
           }
         ]
       }

--- a/scripts/hooks/block-branch-creation.sh
+++ b/scripts/hooks/block-branch-creation.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# block-branch-creation.sh — Enforce worktree discipline.
+# WHY: All work must happen in worktrees. Branches are managed by the
+#      release pipeline to prevent accidental branch pollution.
+# Triggered by: PreToolUse Bash hook.
+set -euo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && exit 0
+
+# Allow: git branch listing/delete
+if echo "$CMD" | grep -qE 'git branch[[:space:]]*(-[dD]|-v|--list|-a|-r|$)'; then
+  exit 0
+fi
+
+# Allow: git worktree add --detach
+if echo "$CMD" | grep -q 'git worktree add'; then
+  if echo "$CMD" | grep -q -- '--detach'; then
+    exit 0
+  fi
+  echo "BLOCKED: 'git worktree add' without --detach creates a branch." >&2
+  echo "Use: git worktree add --detach <path> HEAD" >&2
+  exit 2
+fi
+
+# Block: branch creation patterns
+if echo "$CMD" | grep -qE 'git (branch [^-]|checkout -b|switch -c|switch --create)'; then
+  echo "BLOCKED: Branch creation is forbidden. Use worktrees:" >&2
+  echo "  git worktree add --detach .worktrees/<name> HEAD" >&2
+  echo "  cd .worktrees/<name> && git checkout -b feat/<name>" >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/hooks/check-rust-wiring.sh
+++ b/scripts/hooks/check-rust-wiring.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check that every .rs file in daemon/src/ is wired in its parent
+# mod.rs/lib.rs/main.rs. Also checks router merge coverage and dead modules.
+# Override: DAEMON_SRC=/path/to/src ./check-rust-wiring.sh
+# Exit 0 = clean, Exit 1 = unwired files.
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo '.')
+SRC="${DAEMON_SRC:-$ROOT/daemon/src}"
+
+[ ! -d "$SRC" ] && exit 0
+
+UNWIRED=()
+
+collect_declared_mods() {
+  for pf in "$@"; do
+    sed -E -n 's/.*mod[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*).*/\1/p' \
+      "$pf" 2>/dev/null
+  done | sort -u
+}
+
+collect_path_refs() {
+  local dir="$1"
+  {
+    local -a files=()
+    for f in "$dir"/*.rs; do [ -f "$f" ] && files+=("$f"); done
+    if [ ${#files[@]} -gt 0 ]; then
+      { grep -h '#\[path.*=.*"[^"]*"' "${files[@]}" 2>/dev/null || true; } \
+        | sed -E -n 's/.*#\[path[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' \
+        | while read -r p; do basename "$p"; done
+    fi
+    { find "$dir" -mindepth 2 -name '*.rs' -print0 2>/dev/null \
+      | xargs -0 grep -h '#\[path.*=.*"\.\./[^"]*"' 2>/dev/null || true; } \
+      | sed -E -n 's/.*#\[path[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/p' \
+      | while read -r p; do
+          case "$p" in ../*) basename "$p" ;; esac
+        done
+  } | sort -u
+}
+
+check_dir() {
+  local dir="$1"; shift
+  local -a parent_files=("$@")
+
+  local -a declared=()
+  while IFS= read -r m; do
+    [ -n "$m" ] && declared+=("$m")
+  done < <(collect_declared_mods "${parent_files[@]}")
+
+  local -a path_refs=()
+  while IFS= read -r p; do
+    [ -n "$p" ] && path_refs+=("$p")
+  done < <(collect_path_refs "$dir")
+
+  for rs_file in "$dir"/*.rs; do
+    [ -f "$rs_file" ] || continue
+    local base; base=$(basename "$rs_file")
+    case "$base" in mod.rs|lib.rs|main.rs) continue ;; esac
+    case "$base" in *_tests.rs|*_test.rs|tests.rs) continue ;; esac
+
+    local stem="${base%.rs}" found=false
+    for d in "${declared[@]+"${declared[@]}"}"; do
+      [ "$d" = "$stem" ] && { found=true; break; }
+    done
+    $found && continue
+    for p in "${path_refs[@]+"${path_refs[@]}"}"; do
+      [ "$p" = "$base" ] && { found=true; break; }
+    done
+    $found && continue
+    UNWIRED+=("$rs_file")
+  done
+}
+
+CHECKED_DIRS=""
+while IFS= read -r parent_file; do
+  dir=$(dirname "$parent_file")
+  case ",$CHECKED_DIRS," in *",$dir,"*) continue ;; esac
+  CHECKED_DIRS="${CHECKED_DIRS:+$CHECKED_DIRS,}$dir"
+
+  local_parents=()
+  for candidate in "$dir/mod.rs" "$dir/lib.rs" "$dir/main.rs"; do
+    [ -f "$candidate" ] && local_parents+=("$candidate")
+  done
+  [ ${#local_parents[@]} -eq 0 ] && continue
+  check_dir "$dir" "${local_parents[@]}"
+done < <(find "$SRC" \( -name "mod.rs" -o -name "lib.rs" -o -name "main.rs" \) | sort)
+
+if [ ${#UNWIRED[@]} -gt 0 ]; then
+  echo "ERROR: ${#UNWIRED[@]} unwired .rs file(s):" >&2
+  for f in "${UNWIRED[@]}"; do echo "  $f" >&2; done
+  echo "Add 'mod <name>;' to the parent mod.rs/lib.rs" >&2
+  exit 1
+fi
+
+# Router merge coverage check
+check_router_merge() {
+  local server_dir="$SRC/server"
+  local routes_mod="$server_dir/routes/mod.rs"
+  [ ! -d "$server_dir" ] || [ ! -f "$routes_mod" ] && return 0
+
+  local warnings=0
+  while IFS= read -r api_file; do
+    [ -f "$api_file" ] || continue
+    local stem; stem=$(basename "$api_file" .rs)
+    if ! grep -q "${stem}::router()" "$routes_mod" 2>/dev/null; then
+      echo "WARNING: router() in $api_file not merged in $routes_mod" >&2
+      warnings=$((warnings + 1))
+    fi
+  done < <(grep -rl 'pub fn router()' "$server_dir"/api_*.rs 2>/dev/null || true)
+
+  [ "$warnings" -gt 0 ] && echo "  $warnings router(s) unreachable." >&2
+}
+check_router_merge
+
+# Dead module detection
+check_dead_modules() {
+  local warnings=0
+  while IFS= read -r rs_file; do
+    [ -f "$rs_file" ] || continue
+    local base; base=$(basename "$rs_file")
+    case "$base" in mod.rs|lib.rs|main.rs) continue ;; esac
+    case "$base" in *_tests.rs|*_test.rs|tests.rs) continue ;; esac
+
+    local stem="${base%.rs}"
+    grep -q 'pub fn' "$rs_file" 2>/dev/null || continue
+
+    local callers
+    callers=$(find "$SRC" -name '*.rs' \
+      ! -name '*_tests.rs' ! -name '*_test.rs' ! -name 'tests.rs' \
+      ! -name 'mod.rs' ! -name 'lib.rs' ! -name 'main.rs' \
+      ! -path "$rs_file" -print0 2>/dev/null \
+      | xargs -0 grep -l "${stem}::" 2>/dev/null | wc -l || true)
+
+    if [ "${callers:-0}" -eq 0 ]; then
+      echo "WARNING: $rs_file has pub fn but no callers — potential dead code." >&2
+      warnings=$((warnings + 1))
+    fi
+  done < <(find "$SRC" -name '*.rs' | sort)
+
+  [ "$warnings" -gt 0 ] && echo "  $warnings module(s) unreferenced." >&2
+}
+check_dead_modules
+
+exit 0

--- a/scripts/hooks/git-commit-msg.sh
+++ b/scripts/hooks/git-commit-msg.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Git commit-msg hook: G5 conventional commits.
+# Install: ln -sf ../../scripts/hooks/git-commit-msg.sh .git/hooks/commit-msg
+
+MSG_FILE="$1"
+MSG=$(head -1 "$MSG_FILE")
+
+VALID="feat|fix|docs|chore|refactor|test|ci|perf|build|style|revert"
+if ! echo "$MSG" | grep -qE "^(${VALID})(\([^)]+\))?!?:[[:space:]].+"; then
+  echo "BLOCKED: G5 CommitLint — '$MSG'" >&2
+  echo "Format: type(scope): message" >&2
+  echo "Types: $VALID" >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/hooks/git-pre-commit.sh
+++ b/scripts/hooks/git-pre-commit.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Git pre-commit hook for convergio repo.
+# Enforces: G1 (MainGuard), G2 (FileSizeGuard), G3 (SecretScan), G4 (SqliteBlock)
+# Install: ln -sf ../../scripts/hooks/git-pre-commit.sh .git/hooks/pre-commit
+
+# G1: No commits on main
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
+GITDIR=$(git rev-parse --git-dir 2>/dev/null)
+if [ "$COMMON" = "$GITDIR" ] && { [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; }; then
+  echo "BLOCKED: G1 MainGuard — cannot commit on $BRANCH. Use a worktree." >&2
+  exit 1
+fi
+
+# G2: Max 250 lines per file (.rs/.ts/.js/.sh)
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+for f in $STAGED; do
+  case "$f" in *.rs|*.ts|*.js|*.sh)
+    if [ -f "$f" ]; then
+      LINES=$(wc -l < "$f")
+      if [ "$LINES" -gt 250 ]; then
+        echo "BLOCKED: G2 FileSizeGuard — $f has $LINES lines (max 250)." >&2
+        exit 1
+      fi
+    fi
+  ;; esac
+done
+
+# G3: No secrets in code
+for f in $STAGED; do
+  if [ -f "$f" ]; then
+    if grep -qEi '(ANTHROPIC_API_KEY|OPENAI_API_KEY|sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|password\s*=\s*"[^"]{8,}")' "$f" 2>/dev/null; then
+      echo "BLOCKED: G3 SecretScan — potential secret in $f." >&2
+      exit 1
+    fi
+  fi
+done
+
+# G4: No sqlite3 direct usage
+for f in $STAGED; do
+  case "$f" in *.sh|*.py)
+    if [ -f "$f" ] && grep -qE '(^|[;&[:space:]])sqlite3[[:space:]]' "$f" 2>/dev/null; then
+      echo "BLOCKED: G4 SqliteBlock — direct sqlite3 in $f. Use cvg CLI." >&2
+      exit 1
+    fi
+  ;; esac
+done
+
+exit 0

--- a/scripts/hooks/main-dirty-check.sh
+++ b/scripts/hooks/main-dirty-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# main-dirty-check.sh — WARNING when main repo has uncommitted changes.
+# WHY: 2026-03-31 incident — copilot left 467 dirty files on main.
+# Triggered by: SubagentStart hook.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Only check the main repo, not worktrees
+COMMON=$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null) || exit 0
+GITDIR=$(git -C "$REPO_ROOT" rev-parse --git-dir 2>/dev/null) || exit 0
+[ "$COMMON" != "$GITDIR" ] && exit 0
+
+DIRTY=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | grep -c "^ M\|^M \|^??" || true)
+if [ "${DIRTY:-0}" -gt 5 ]; then
+  BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  echo "WARNING: Main repo has $DIRTY dirty files on '$BRANCH'." >&2
+  echo "Possible crashed agent. Verify PRs, then: git checkout -- . && git clean -fd" >&2
+fi
+
+exit 0

--- a/scripts/hooks/main-guard.sh
+++ b/scripts/hooks/main-guard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# main-guard.sh — BLOCK writes to daemon/ when on the main branch.
+# WHY: 2026-03-31 incident — copilot dirtied 467 files on main directly.
+# Triggered by: PreToolUse Edit/Write hooks.
+set -euo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.file_path // .input.file_path // empty' 2>/dev/null)
+[ -z "$FILE" ] && exit 0
+
+# Guard daemon source, tests, scripts, and config
+echo "$FILE" | grep -qE "daemon/|scripts/|\.claude/" || exit 0
+
+# Check if we're in the main repo on the main branch
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+BRANCH=$(git -C "$TOPLEVEL" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+
+# Allow if we're in a worktree (not the main checkout)
+COMMON=$(git -C "$TOPLEVEL" rev-parse --git-common-dir 2>/dev/null) || exit 0
+GITDIR=$(git -C "$TOPLEVEL" rev-parse --git-dir 2>/dev/null) || exit 0
+[ "$COMMON" != "$GITDIR" ] && exit 0
+
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  echo "BLOCKED: MainGuard — cannot modify $FILE on branch '$BRANCH'." >&2
+  echo "Create a worktree: git worktree add --detach .worktrees/<name> HEAD" >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/hooks/pre-compaction-snapshot.sh
+++ b/scripts/hooks/pre-compaction-snapshot.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# pre-compaction-snapshot.sh — PreCompact hook.
+# Saves plan state before context compaction.
+set -euo pipefail
+
+if command -v cvg &>/dev/null; then
+  cvg checkpoint save-auto 2>/dev/null || true
+fi
+
+exit 0

--- a/scripts/hooks/pre-tool-guard.sh
+++ b/scripts/hooks/pre-tool-guard.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Consolidated PreToolUse guard for convergio repo.
+# Usage: echo '{"command":"..."}' | pre-tool-guard.sh <tool>
+# Exit 0 = allow, Exit 2 = blocked (message on stderr)
+
+TOOL="${1:-}"
+INPUT=$(cat 2>/dev/null || true)
+
+block() { echo "BLOCKED: $1" >&2; exit 2; }
+warn()  { echo "WARNING: $1" >&2; }
+
+cmd()        { echo "$INPUT" | jq -r '.command // empty' 2>/dev/null || echo "$INPUT"; }
+file_path()  { echo "$INPUT" | jq -r '.file_path // empty' 2>/dev/null; }
+new_string() { echo "$INPUT" | jq -r '.new_string // empty' 2>/dev/null; }
+
+guard_bash() {
+  local CMD
+  CMD=$(cmd)
+  [ -z "$CMD" ] && return 0
+
+  # sqlite3 direct — use cvg CLI or daemon API
+  if echo "$CMD" | grep -qE '(^|[;&[:space:]])sqlite3[[:space:]]'; then
+    block "Never use sqlite3 directly — use cvg CLI or daemon API"
+  fi
+
+  # CommitLint: conventional commit format
+  if echo "$CMD" | grep -qE '(^|[;&[:space:]])git[[:space:]]+commit.*-m'; then
+    local MSG
+    MSG=$(echo "$CMD" | sed -n "s/.*-m[[:space:]]*['\"]\\{0,1\\}//p" | sed "s/['\"].*//")
+    if [ -n "$MSG" ]; then
+      local VALID_TYPES="feat|fix|docs|chore|refactor|test|ci|perf|build|style|revert"
+      if ! echo "$MSG" | grep -qE "^(${VALID_TYPES})(\([^)]+\))?!?:[[:space:]].+"; then
+        block "CommitLint: message must match 'type(scope): message'. Got: $MSG"
+      fi
+    fi
+  fi
+
+  # EvidenceGate: mark test runs
+  if echo "$CMD" | grep -qE \
+     '(^|[;&[:space:]])(cargo[[:space:]]+test|npx[[:space:]]+vitest|pytest|bats)'; then
+    touch "/tmp/.convergio-test-ran" 2>/dev/null || true
+  fi
+
+  # EvidenceGate: block commit of code files without recent test run
+  if echo "$CMD" | grep -qE '(^|[;&[:space:]])git[[:space:]]+commit'; then
+    STAGED_CODE=$(git diff --cached --name-only 2>/dev/null \
+      | grep -cE '\.(rs|ts|py|sh)$' 2>/dev/null || echo 0)
+    if [ "${STAGED_CODE}" -gt 0 ]; then
+      MARKER="/tmp/.convergio-test-ran"
+      if [ ! -f "${MARKER}" ]; then
+        block "EvidenceGate: no test run detected. Run cargo test first."
+      fi
+      if command -v find >/dev/null 2>&1; then
+        FRESH=$(find "${MARKER}" -mmin -10 2>/dev/null | wc -l | tr -d ' ')
+        if [ "${FRESH}" = "0" ]; then
+          block "EvidenceGate: test marker older than 10 min. Re-run tests."
+        fi
+      fi
+    fi
+  fi
+}
+
+guard_edit() {
+  local FILE
+  FILE=$(file_path)
+  [ -z "$FILE" ] && return 0
+
+  # FailLoud: warn on silent fallback patterns in Rust
+  if echo "$FILE" | grep -qE '\.rs$'; then
+    local NS
+    NS=$(new_string)
+    if echo "$NS" | grep -qE 'unwrap_or_default\(\)'; then
+      warn "FailLoud: unwrap_or_default() silently swallows errors. Use expect() or ?."
+    fi
+    if echo "$NS" | grep -qE 'let[[:space:]]+_[[:space:]]*='; then
+      warn "FailLoud: 'let _ = ...' discards a Result. Handle the error explicitly."
+    fi
+  fi
+}
+
+case "$TOOL" in
+  bash) guard_bash ;;
+  edit) guard_edit ;;
+  *)    ;;
+esac

--- a/scripts/hooks/subagent-completion-gate.sh
+++ b/scripts/hooks/subagent-completion-gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# subagent-completion-gate.sh — SubagentStop safety net.
+# Catches: uncommitted work, auth failures, missing evidence.
+# WHY: ~30% of subagents exhaust tool budget before git commit.
+set -euo pipefail
+
+INPUT=$(cat)
+AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null)
+LAST_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null)
+
+# --- EvidenceGate: warn on "done" without evidence ---
+CLAIMS_DONE=false
+EVIDENCE_FOUND=false
+
+if echo "$LAST_MSG" | grep -qiE '\b(done|completed|submitted|finished)\b'; then
+  CLAIMS_DONE=true
+fi
+if echo "$LAST_MSG" | grep -qiE 'cargo test|test result|tests passed|passing|curl.*output|exit 0|ok \([0-9]+ test'; then
+  EVIDENCE_FOUND=true
+fi
+if $CLAIMS_DONE && ! $EVIDENCE_FOUND; then
+  echo "WARNING: EvidenceGate — agent claims done but no test evidence found." >&2
+fi
+
+# --- Auth failure detection ---
+if echo "$LAST_MSG" | grep -qiE "401|unauthorized|auth.*fail"; then
+  echo '{"decision":"block","reason":"Auth failure detected. Check tokens."}'
+  exit 0
+fi
+
+# --- AgentIdentity warning ---
+if [ -z "${CONVERGIO_AGENT_NAME:-}" ]; then
+  echo "WARNING: CONVERGIO_AGENT_NAME not set. Run: cvg agent start <name>" >&2
+fi
+
+# --- Auto-commit uncommitted work in worktree ---
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+[ -z "$ROOT" ] && exit 0
+
+SHORT_ID="${AGENT_ID:0:8}"
+WORKTREE=""
+for wt in "$ROOT/.claude/worktrees"/agent-"$SHORT_ID"* "$ROOT/.worktrees"/agent-"$SHORT_ID"*; do
+  [ -d "$wt" ] && WORKTREE="$wt" && break
+done
+[ -z "$WORKTREE" ] && exit 0
+
+DIRTY=$(cd "$WORKTREE" && git status --porcelain 2>/dev/null | head -1)
+if [ -n "$DIRTY" ]; then
+  cd "$WORKTREE"
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  git add -A 2>/dev/null
+  git commit -m "fix: auto-commit uncommitted subagent work ($BRANCH)
+
+Agent $AGENT_ID exhausted budget before committing.
+Auto-committed by subagent-completion-gate.sh.
+
+Co-Authored-By: subagent-completion-gate <noreply@convergio.dev>" 2>/dev/null || true
+  echo "AUTO-COMMITTED: Agent $AGENT_ID work saved in $WORKTREE" >&2
+fi
+
+exit 0

--- a/scripts/hooks/thor-gate-guard.sh
+++ b/scripts/hooks/thor-gate-guard.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# thor-gate-guard.sh — Enforce correct plan execution workflow.
+# Constitution Article VI, ADR-0001: ONLY Thor can set task status=done.
+# Flow: pending → in_progress → submitted (executor) → done (Thor only)
+# Triggered by: PreToolUse Bash hook.
+set -euo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.command // empty' 2>/dev/null)
+[ -z "$CMD" ] && exit 0
+
+# Block: cvg task update <id> done
+if echo "$CMD" | grep -qE 'cvg\s+task\s+update\s+\S+\s+done'; then
+  echo "BLOCKED: ThorGateGuard — cannot set task status=done directly." >&2
+  echo "  ONLY Thor can promote tasks to done." >&2
+  echo "  Use: cvg task update <id> submitted" >&2
+  echo "  Then: cvg plan validate <plan_id>" >&2
+  exit 2
+fi
+
+# Block: per-task validate
+if echo "$CMD" | grep -qE 'cvg\s+task\s+validate'; then
+  echo "BLOCKED: ThorGateGuard — validate at wave level, not per-task." >&2
+  echo "  Use: cvg plan validate <plan_id>" >&2
+  exit 2
+fi
+
+# Block: forced-admin validate endpoint
+if echo "$CMD" | grep -qE '/api/plans/[0-9]+/validate'; then
+  echo "BLOCKED: ThorGateGuard — use cvg plan validate <plan_id>." >&2
+  exit 2
+fi
+
+# Block: direct SQL/API status=done
+if echo "$CMD" | grep -qiE "UPDATE.*tasks.*SET.*status.*=.*['\"]done['\"]"; then
+  echo "BLOCKED: ThorGateGuard — cannot set done via SQL." >&2
+  exit 2
+fi
+if echo "$CMD" | grep -qE 'curl.*status.*done.*task|curl.*task.*status.*done'; then
+  echo "BLOCKED: ThorGateGuard — cannot set done via API." >&2
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Port and optimize 20+ guardrails from ConvergioPlatform → convergio
- Permissions: 23 allow + 9 deny rules for granular access control
- 6 Claude Code hook events: PreToolUse, PostToolUse, SubagentStart, SubagentStop, PreCompact, Notification
- 10 external hook scripts in `scripts/hooks/`
- Git hooks: pre-commit (G1-G4) + commit-msg (G5)
- Removed 8 ConvergioPlatform-specific guards (plan-db, npm, gh digest, etc.)
- Consolidated pre-tool-guard from 181→86 lines
- Added CARGO_TARGET_DIR worktree isolation for clippy

## Guards migrated

| Guard | Event | Status |
|---|---|---|
| MainGuard | PreToolUse Edit/Write + git pre-commit | BLOCK |
| BlockBranchCreation | PreToolUse Bash | BLOCK |
| ThorGateGuard | PreToolUse Bash | BLOCK |
| FileSizeGuard | PostToolUse Edit/Write + git pre-commit | BLOCK |
| CommitLint | PreToolUse Bash + git commit-msg | BLOCK |
| EvidenceGate (commit) | PreToolUse Bash | BLOCK |
| SqliteBlock | PreToolUse Bash + git pre-commit | BLOCK |
| FailLoud | PreToolUse Edit | WARNING |
| RustModWiring | PostToolUse Edit/Write | WARNING |
| Clippy | PostToolUse Edit | BLOCK |
| MainDirtyCheck | SubagentStart | WARNING |
| Preflight | SubagentStart | WARNING |
| EvidenceGate (stop) | SubagentStop | WARNING |
| Auto-commit | SubagentStop | AUTO |
| PreCompact snapshot | PreCompact | AUTO |
| IPC Notification | Notification | INFO |
| SecretScan | git pre-commit | BLOCK |

## Test plan
- [ ] Verify settings.json is valid JSON
- [ ] Verify all scripts are executable
- [ ] Test MainGuard blocks writes on main
- [ ] Test CommitLint rejects non-conventional messages
- [ ] Test FileSizeGuard blocks >250 line files
- [ ] Verify clippy runs per-crate on .rs edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)