### PR TITLE
feat: add convergio-pm agent to seed catalog

### DIFF
--- a/daemon/crates/convergio-agents/src/seed/seed_core.rs
+++ b/daemon/crates/convergio-agents/src/seed/seed_core.rs
@@ -1,4 +1,4 @@
-//! Seed data: core_utility agents (19 agents).
+//! Seed data: core_utility agents (20 agents).
 
 use crate::types::{AgentCategory, AgentInput};
 
@@ -29,6 +29,12 @@ pub fn agents() -> Vec<AgentInput> {
             "thor",
             "Validation guardian — reviews all submitted work",
             "t4",
+            Some("ali-orchestrator"),
+        ),
+        a(
+            "convergio-pm",
+            "Convergio Project Manager — audits plans, tracks costs, extracts learnings, writes reports",
+            "t3",
             Some("ali-orchestrator"),
         ),
         a(


### PR DESCRIPTION
## Summary
- Add `convergio-pm` to core_utility agent seed (structural role like CEO/Thor)
- PM audits plans, tracks costs, extracts learnings, writes honest reports
- Full prompt definition in ConvergioPlatform repo: `claude-config/agents/core_utility/convergio-pm.md`

## Context
Part of Fase 24 (Plan Protocol System). Every org MUST have a PM — created automatically with the org.

## Test plan
- [x] `cargo check -p convergio-agents` passes
- [x] Seed count updated from 19 to 20 core_utility agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)