### PR TITLE
feat: fase 23d — SSE domain events via DomainEventSink

### DIFF
--- a/daemon/crates/convergio-ipc/src/ext.rs
+++ b/daemon/crates/convergio-ipc/src/ext.rs
@@ -19,10 +19,15 @@ pub struct IpcExtension {
 
 impl IpcExtension {
     pub fn new(pool: ConnPool) -> Self {
+        Self::with_bus(pool, Arc::new(EventBus::new(1024)))
+    }
+
+    /// Create with an externally-provided EventBus (for sharing via AppContext).
+    pub fn with_bus(pool: ConnPool, event_bus: Arc<EventBus>) -> Self {
         Self {
             pool,
             notify: Arc::new(Notify::new()),
-            event_bus: Arc::new(EventBus::new(1024)),
+            event_bus,
             rate_limit: crate::messaging::DEFAULT_RATE_LIMIT,
         }
     }

--- a/daemon/crates/convergio-ipc/src/sse.rs
+++ b/daemon/crates/convergio-ipc/src/sse.rs
@@ -88,6 +88,31 @@ fn futures_core_stream(
     }
 }
 
+impl convergio_types::events::DomainEventSink for EventBus {
+    fn emit(&self, event: convergio_types::events::DomainEvent) {
+        let event_type = match &event.kind {
+            convergio_types::events::EventKind::PlanCreated { .. } => "plan_created",
+            convergio_types::events::EventKind::TaskAssigned { .. } => "task_assigned",
+            convergio_types::events::EventKind::TaskCompleted { .. } => "task_completed",
+            convergio_types::events::EventKind::MessageSent { .. } => "message_sent",
+            convergio_types::events::EventKind::DelegationStarted { .. } => "delegation_started",
+            convergio_types::events::EventKind::AgentOnline { .. } => "agent_online",
+            convergio_types::events::EventKind::AgentOffline { .. } => "agent_offline",
+            convergio_types::events::EventKind::HealthDegraded { .. } => "health_degraded",
+            convergio_types::events::EventKind::BudgetAlert { .. } => "budget_alert",
+            convergio_types::events::EventKind::ExtensionLoaded { .. } => "extension_loaded",
+        };
+        let content = serde_json::to_string(&event).unwrap_or_default();
+        self.publish(IpcEvent {
+            from: event.actor.name,
+            to: None,
+            content,
+            event_type: event_type.into(),
+            ts: event.timestamp.to_rfc3339(),
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -59,9 +59,11 @@ impl Extension for OrchestratorExtension {
         m
     }
 
-    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+    fn routes(&self, ctx: &AppContext) -> Option<axum::Router> {
+        let sink = ctx.get_arc::<Arc<dyn convergio_types::events::DomainEventSink>>();
         let state = Arc::new(crate::plan_routes::PlanState {
             pool: self.pool.clone(),
+            event_sink: sink.map(|s| (*s).clone()),
         });
         let router = crate::scaffold::scaffold_routes()
             .merge(crate::plan_routes::plan_routes(Arc::clone(&state)))

--- a/daemon/crates/convergio-orchestrator/src/plan_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes.rs
@@ -19,9 +19,11 @@ use serde::Deserialize;
 use serde_json::json;
 
 use convergio_db::pool::ConnPool;
+use convergio_types::events::DomainEventSink;
 
 pub struct PlanState {
     pub pool: ConnPool,
+    pub event_sink: Option<Arc<dyn DomainEventSink>>,
 }
 
 pub fn plan_routes(state: Arc<PlanState>) -> Router {
@@ -122,6 +124,19 @@ async fn handle_create(
     ) {
         Ok(_) => {
             let id = conn.last_insert_rowid();
+            if let Some(ref sink) = state.event_sink {
+                sink.emit(convergio_types::events::make_event(
+                    "orchestrator",
+                    convergio_types::events::EventKind::PlanCreated {
+                        plan_id: id,
+                        name: body.name.clone(),
+                    },
+                    convergio_types::events::EventContext {
+                        plan_id: Some(id),
+                        ..Default::default()
+                    },
+                ));
+            }
             Json(json!({"id": id, "status": "created"}))
         }
         Err(e) => Json(json!({"error": e.to_string()})),

--- a/daemon/crates/convergio-types/src/events.rs
+++ b/daemon/crates/convergio-types/src/events.rs
@@ -100,3 +100,23 @@ pub struct EventFilter {
     /// Only events from this actor.
     pub actor: Option<String>,
 }
+
+/// Trait for publishing domain events. Implemented by the IPC EventBus.
+/// Extensions retrieve `Arc<dyn DomainEventSink>` from AppContext to emit events.
+pub trait DomainEventSink: Send + Sync {
+    fn emit(&self, event: DomainEvent);
+}
+
+/// Helper: create and emit a simple domain event.
+pub fn make_event(actor_name: &str, kind: EventKind, context: EventContext) -> DomainEvent {
+    DomainEvent {
+        actor: ActorName {
+            name: actor_name.to_string(),
+            org: None,
+            node: None,
+        },
+        kind,
+        timestamp: Utc::now(),
+        context,
+    }
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -12,12 +12,18 @@ use convergio_types::extension::{AppContext, Extension};
 use std::sync::{Arc, RwLock};
 use tokio::sync::Notify;
 
-fn register_extensions(pool: ConnPool) -> Vec<Arc<dyn Extension>> {
+fn register_extensions(
+    pool: ConnPool,
+    event_bus: Arc<convergio_ipc::sse::EventBus>,
+) -> Vec<Arc<dyn Extension>> {
     let notify = Arc::new(Notify::new());
 
     vec![
         // Infrastructure
-        Arc::new(convergio_ipc::IpcExtension::new(pool.clone())),
+        Arc::new(convergio_ipc::IpcExtension::with_bus(
+            pool.clone(),
+            event_bus,
+        )),
         Arc::new(convergio_mesh::ext::MeshExtension::new(pool.clone())),
         // Platform services
         Arc::new(convergio_orchestrator::OrchestratorExtension::new(
@@ -112,9 +118,12 @@ async fn main() {
             .expect("core migrations failed");
     }
 
-    // 5. Register extensions
-    let extensions = register_extensions(pool.clone());
-    let ctx = AppContext::new();
+    // 5. Register extensions (shared EventBus for domain events → SSE)
+    let event_bus = Arc::new(convergio_ipc::sse::EventBus::new(1024));
+    let extensions = register_extensions(pool.clone(), Arc::clone(&event_bus));
+    let mut ctx = AppContext::new();
+    let sink: Arc<dyn convergio_types::events::DomainEventSink> = event_bus;
+    ctx.insert(sink);
 
     // 6. Extension migrations
     {


### PR DESCRIPTION
## Summary

Wires domain events into the SSE stream so frontends can see real-time events.

- **DomainEventSink trait** in convergio-types — zero-dep interface for publishing events
- **EventBus implements DomainEventSink** in convergio-ipc — converts DomainEvent → IpcEvent → SSE
- **Shared EventBus via AppContext** — main.rs creates bus, inserts in ctx, extensions retrieve it
- **Orchestrator emits plan_created** when a plan is created via API

Flow: `orchestrator → DomainEventSink → EventBus → broadcast → SSE stream → frontend`

## Test plan
- [x] `cargo check --workspace` — 0 errors
- [x] `cargo test --workspace` — 820 tests pass
- [x] Smoke test: SSE stream receives `plan_created` event with full DomainEvent payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)