### PR TITLE
feat: fase 27d — migrate config, schemas, reference docs

### DIFF
--- a/claude-config/config/models.yaml
+++ b/claude-config/config/models.yaml
@@ -1,0 +1,45 @@
+# models.yaml v1.0.0
+# Single source of truth for model IDs across Claude Code and Copilot CLI.
+# When a new model is released, update ONLY this file, then run:
+#   model-update.sh [--dry-run]
+
+# Claude Code uses short aliases (auto-resolved by the platform).
+# These NEVER need updating — they always point to the latest version.
+claude_code:
+  planner: opus
+  coordinator: sonnet
+  coordinator_max: opus
+  validator: sonnet
+  utility: haiku
+  task_executor: sonnet
+
+# Copilot CLI requires full model IDs (no alias support).
+# UPDATE THESE when new models are released.
+copilot:
+  opus: claude-opus-4.6
+  opus_1m: claude-opus-4.6-1m
+  opus_fast: claude-opus-4.6-fast
+  sonnet: claude-sonnet-4.6
+  sonnet_prev: claude-sonnet-4.5
+  haiku: claude-haiku-4.5
+  codex: gpt-5.3-codex
+  codex_mini: gpt-5.1-codex-mini
+  gpt5: gpt-5
+  gpt4: gpt-4.1
+  gemini: gemini-3-pro-preview
+
+# Agent-to-model mapping for Copilot agents
+# Key = agent filename (without .agent.md), Value = config key from copilot section
+copilot_agents:
+  planner: opus_1m
+  strategic-planner: opus_1m
+  deep-repo-auditor: opus
+  validate: opus
+  prompt: opus
+  code-reviewer: opus
+  compliance-checker: opus_1m
+  ecosystem-sync: sonnet
+  optimize-project: gpt5
+  execute: gpt5
+  tdd-executor: gpt5
+  check: codex_mini

--- a/claude-config/config/notifications.conf
+++ b/claude-config/config/notifications.conf
@@ -1,0 +1,18 @@
+# Notification channels configuration
+# Enable/disable each channel. Default: all disabled except dashboard.
+
+[macos]
+enabled=true
+
+[ntfy]
+enabled=true
+server=https://ntfy.sh
+topic=convergio-mesh
+
+[dashboard]
+enabled=true
+
+[telegram]
+enabled=true
+bot_token=
+chat_id=

--- a/claude-config/config/orchestrator.yaml
+++ b/claude-config/config/orchestrator.yaml
@@ -1,0 +1,217 @@
+# Convergio Orchestrator Configuration
+# Version: 1.0.0
+# Supports: macOS, Linux, Windows (paths via $CLAUDE_HOME)
+# Do NOT hardcode user-specific paths — use $CLAUDE_HOME throughout.
+
+# ---------------------------------------------------------------------------
+# PROVIDERS
+# ---------------------------------------------------------------------------
+providers:
+  claude:
+    cli_path: '$CLAUDE_HOME/scripts/claude-run.sh'
+    auth_check: 'claude --version'
+    privacy_level: public          # data sent to Anthropic cloud
+    cost_tier: premium
+    models:
+      - id: claude-opus-4-6
+        multiplier: 1.0
+        privacy_safe: false        # not safe for sensitive data (cloud)
+      - id: claude-sonnet-4-6
+        multiplier: 0.6
+        privacy_safe: false
+      - id: claude-haiku-4
+        multiplier: 0.1
+        privacy_safe: false
+
+  copilot:
+    cli_path: '$CLAUDE_HOME/scripts/copilot-run.sh'
+    auth_check: 'gh auth status'
+    privacy_level: public          # data sent to GitHub/Azure
+    cost_tier: zero                # included in GitHub Copilot subscription
+    models:
+      - id: gpt-5
+        multiplier: 1.0
+        privacy_safe: false
+      - id: gpt-4.1
+        multiplier: 0
+        privacy_safe: false
+      - id: gpt-5-mini
+        multiplier: 0
+        privacy_safe: false
+      - id: o3
+        multiplier: 1.0
+        privacy_safe: false
+      - id: claude-sonnet-4-6
+        multiplier: 1.0
+        privacy_safe: false
+
+  opencode:
+    cli_path: '$CLAUDE_HOME/scripts/opencode-run.sh'
+    auth_check: 'opencode --version'
+    privacy_level: local           # runs fully on-device via Ollama or local endpoint
+    cost_tier: free
+    models:
+      - id: qwen3-30b
+        multiplier: 0
+        privacy_safe: true         # local model — safe for sensitive data
+      - id: deepseek-coder-v2
+        multiplier: 0
+        privacy_safe: true
+      - id: codestral-latest
+        multiplier: 0
+        privacy_safe: true
+      - id: llama3.3-70b
+        multiplier: 0
+        privacy_safe: true
+
+  gemini:
+    cli_path: '$CLAUDE_HOME/scripts/gemini-run.sh'
+    auth_check: 'gemini --version'
+    privacy_level: public          # data sent to Google cloud
+    cost_tier: premium
+    models:
+      - id: gemini-2.5-pro
+        multiplier: 1.0
+        privacy_safe: false
+      - id: gemini-2.5-flash
+        multiplier: 0.3
+        privacy_safe: false
+      - id: gemini-2.0-flash
+        multiplier: 0.1
+        privacy_safe: false
+
+# ---------------------------------------------------------------------------
+# ROUTING RULES
+# ---------------------------------------------------------------------------
+routing:
+  # Priority tiers (P0 = highest, P3 = lowest)
+  by_priority:
+    P0:
+      description: 'Critical / production incident'
+      preferred_providers: [claude, gemini]
+      fallback_providers: [copilot]
+      max_cost_tier: premium
+    P1:
+      description: 'Feature work / sprint tasks'
+      preferred_providers: [copilot, claude]
+      fallback_providers: [gemini]
+      max_cost_tier: premium
+    P2:
+      description: 'Routine / backlog tasks'
+      preferred_providers: [copilot, gemini]
+      fallback_providers: [opencode]
+      max_cost_tier: zero
+    P3:
+      description: 'Bulk / background jobs'
+      preferred_providers: [opencode, copilot]
+      fallback_providers: []
+      max_cost_tier: free
+
+  # Task-type routing
+  by_type:
+    coding:
+      preferred_providers: [copilot, claude]
+      default_model: claude-sonnet-4-6
+    research:
+      preferred_providers: [gemini, claude]
+      default_model: gemini-2.5-pro
+    review:
+      preferred_providers: [claude, copilot]
+      default_model: claude-opus-4-6
+    test:
+      preferred_providers: [copilot, opencode]
+      default_model: gpt-5-mini
+    bulk:
+      preferred_providers: [opencode, copilot]
+      default_model: qwen3-30b
+    pr-ops:
+      preferred_providers: [copilot, claude]
+      default_model: gpt-5-mini
+
+  # Privacy-aware routing
+  by_privacy:
+    public:
+      allowed_providers: [claude, copilot, gemini, opencode]
+    internal:
+      allowed_providers: [copilot, opencode]
+      note: 'Avoid sending internal business data to non-enterprise clouds'
+    sensitive:
+      allowed_providers: [opencode]
+      note: 'Only local/on-prem providers for PII or confidential data'
+
+# ---------------------------------------------------------------------------
+# PROJECTS
+# ---------------------------------------------------------------------------
+projects:
+  virtual-bpm:
+    privacy: sensitive
+    allowed_providers: [opencode]
+    default_model: qwen3-30b
+    description: 'Virtual BPM platform — contains sensitive business process data'
+
+  mirrorbuddy:
+    privacy: sensitive
+    allowed_providers: [opencode]
+    default_model: qwen3-30b
+    description: 'MirrorBuddy app — contains user PII and health-adjacent data'
+
+  myconvergio:
+    privacy: public
+    allowed_providers: [claude, copilot, gemini, opencode]
+    default_model: claude-sonnet-4-6
+    description: 'MyConvergio orchestration layer — no sensitive data in source'
+
+# ---------------------------------------------------------------------------
+# BUDGET
+# ---------------------------------------------------------------------------
+budget:
+  max_premium_per_day: 10.00      # USD — hard cap on premium API calls per day
+  fallback_chain:
+    - claude                       # 1st choice premium
+    - copilot                      # 2nd: zero-cost (subscription)
+    - gemini                       # 3rd: metered premium
+    - opencode                     # last resort: free / local
+  alert_threshold_pct: 80         # send alert when 80% of daily budget consumed
+  enforce_budget: true            # block calls once cap is reached
+
+# ---------------------------------------------------------------------------
+# VAULT (per-project secrets / Key Vault references)
+# ---------------------------------------------------------------------------
+vault:
+  virtual-bpm:
+    keyvault_name: 'kv-virtual-bpm-prod'
+    gh_repo: 'MyConvergio/virtual-bpm'
+    env_files:
+      - '$CLAUDE_HOME/projects/virtual-bpm/.env.local'
+      - '$CLAUDE_HOME/projects/virtual-bpm/.env.secrets'
+
+  mirrorbuddy:
+    keyvault_name: 'kv-mirrorbuddy-prod'
+    gh_repo: 'MyConvergio/mirrorbuddy'
+    env_files:
+      - '$CLAUDE_HOME/projects/mirrorbuddy/.env.local'
+      - '$CLAUDE_HOME/projects/mirrorbuddy/.env.secrets'
+
+  myconvergio:
+    keyvault_name: 'kv-myconvergio-prod'
+    gh_repo: 'MyConvergio/myconvergio'
+    env_files:
+      - '$CLAUDE_HOME/projects/myconvergio/.env.local'
+
+# ---------------------------------------------------------------------------
+# MESH
+# ---------------------------------------------------------------------------
+mesh:
+  max_tasks_per_peer: 3
+  dispatch_timeout: 600
+  load_threshold: 0.8
+  heartbeat_interval: 30
+  heartbeat_dead_after: 60
+  cost_priority: [free, zero, premium]
+  # cost_tier mapping: capability -> tier name (from providers above)
+  cost_tiers:
+    claude: premium
+    copilot: zero
+    gemini: premium
+    opencode: free
+    ollama: free

--- a/claude-config/reference/agent-routing.md
+++ b/claude-config/reference/agent-routing.md
@@ -1,0 +1,50 @@
+<!-- v4.1.0 -->
+
+# Agent Routing
+
+Route: `claude-config/agents/` first, fallback `~/.claude/agents/`.
+
+## Skill Routing (NON-NEGOTIABLE)
+
+| Trigger | Use | NOT |
+|---------|-----|-----|
+| Plan (3+ tasks) | `Skill(skill="planner")` / `@planner` | EnterPlanMode |
+| Execute | `Skill(skill="execute", args="{id}")` / `@execute {id}` | Direct edit |
+| Validate | `Task(subagent_type="thor")` / `@validate` | Self-declare done |
+
+_Why: Plan 225 — bypassing planner skips DB registration, breaking Thor tracking and wave validation._
+
+## EnterPlanMode — Canonical Definition
+
+**EnterPlanMode** is Claude's built-in planning UX (markdown task lists, no DB, no agent routing).
+
+**It is ALWAYS a VIOLATION** because:
+- No plan DB entry → Thor has nothing to validate against
+- No wave/task tracking → progress invisible to dashboard
+- No worktree isolation → risk of main branch corruption
+
+Correct alternative: `Skill(skill="planner")` (Claude Code) or `@planner` (Copilot CLI).
+
+Hook `guard-plan-mode` blocks EnterPlanMode at the PreToolUse level on both platforms.
+
+## Thor — Name Aliases
+
+Thor is the quality validation agent. Multiple names are used interchangeably:
+
+| Name | Context |
+|------|---------|
+| `thor` | Subagent type: `Task(subagent_type="thor")` |
+| `thor-quality-assurance-guardian` | Agent file name in `agents/` |
+| `@validate` | Copilot CLI skill invocation |
+| `cvg plan validate` | `cvg` CLI subcommand (plan-db.sh is DEPRECATED) |
+
+All refer to the same role: **skeptical, independent quality gate**. Use `thor` as the canonical short name.
+
+## Task Routing
+
+Explore: `Explore` | Plan task: `task-executor` | Validation: `thor` (aka `thor-quality-assurance-guardian`) | Debug: `adversarial-debugger` | Parallel: Agent Teams (`TeamCreate`/`SendMessage`)
+
+## Repo Knowledge
+
+`repo-index.sh` | `repo-info` | `agent-versions.sh [--json|--check]` | `script-versions.sh [--json|--stale]`
+

--- a/claude-config/reference/convergio-capabilities.md
+++ b/claude-config/reference/convergio-capabilities.md
@@ -1,0 +1,198 @@
+# Convergio Platform — Complete Capability Reference
+
+> Single source of truth for what Convergio can do. Load this in every agent session.
+> Updated: 1 Aprile 2026 | v20.4.0
+
+## Core Architecture
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Daemon (Rust) | daemon/ | Control plane: HTTP API (:8420), mesh, IPC, kernel |
+| Kernel | daemon/src/kernel/ | Jarvis — Local LLM (Qwen 7B), monitor, verify, recover, TTS, Telegram |
+| MCP Server | daemon/src/mcp_server/ | Expose daemon as MCP tools for any LLM client |
+| Evolution Engine | evolution/ | Self-improvement: observe → measure → propose → experiment |
+| CLI | `cvg` | All operations: plans, tasks, waves, agents, mesh, kernel |
+| Web UI | convergio-web (separate repo) | Next.js 15 + Tauri 2.0 dashboard |
+| Design System | convergio-design (separate repo) | Maranello Luce DS, 5 themes, WCAG 2.2 AA |
+
+## What Convergio CAN Do
+
+### Plan Management
+- `cvg plan create/list/show/start/complete/cancel`
+- `cvg plan import <id> spec.yaml` — import from YAML spec (detailed error messages)
+- `cvg plan template` — generate example spec YAML with all supported fields
+- `cvg plan tree <id>` — execution tree (alias: `execution-tree`)
+- `cvg plan validate <id>` — Thor wave-level validation
+- `cvg plan readiness <id>` — pre-execution checks
+- `cvg checkpoint save/restore <id>` — fault tolerance
+
+### Task Execution
+- `cvg task update <id> <status>` — pending/in_progress/submitted/done
+- `cvg task validate <id> <plan>` — individual task validation
+- Kernel verify gate: blocks "done" without evidence (tests pass, build green, files exist)
+
+### Agent Orchestration (89 agents)
+- `cvg agent start/complete "<name>"` — register/deregister
+- `cvg who agents` — list active agents across mesh
+- Ali (Opus) — chief of staff, planning, complex reasoning
+- Thor — quality gates, validation
+- Domain specialists: baccio (arch), dario (debug), marco (devops), etc.
+
+### Mesh / Swarm (P2P multi-node)
+- `cvg mesh status` — peer topology
+- `cvg mesh sync` — force sync
+- Multi-transport: Tailscale, SSH, LAN mDNS, HTTP
+- HMAC-SHA256 auth, CRDT sync
+- `scripts/mesh/deploy-node.sh <node> --kernel` — one-command deploy
+- `cvg mesh sync` — daemon-managed DB replication
+
+### Jarvis — Kernel (Local LLM on M1 Pro)
+- `cvg kernel status/start/stop/logs/test/here/say`
+- Qwen 2.5 7B — context-stuffed intelligent answers
+- Monitor loop (30s) — health, stall detection, rate limits
+- Verify gate — evidence check before task completion
+- Recover — restart crashed daemons, checkpoint, notify
+- TTS — Voxtral 4B neural (mlx-audio) + macOS say (Siri) fallback
+- STT — whisper-rs native GGML inference (lazy model loading)
+- Telegram bidirectional — text + voice, long polling
+- Telegram poll health check: detect and report dead poll task
+- Peer failure tracker: 3-strike consecutive failure alerts for remote nodes
+- Deterministic problem triage: auto-fix daemon crash, DB lock, stale worktrees, high FD count
+
+### Voice Engine (Plan 748, feature-gated)
+- Full pipeline: Audio Capture → VAD → Wake Word → ASR → Intent → TTS
+- Audio capture: `cpal` native, stereo-to-mono, linear resampling to 16kHz
+- VAD: `webrtc-vad` (libwebrtc), 4 aggressiveness levels, ~10ms frame detection
+- STT: `whisper-rs` (GGML), lazy model loading, Metal acceleration on Apple Silicon
+- Wake word: VAD + Whisper micro-transcription for "convergio" detection
+- TTS: Voxtral 4B (`mlx-community/Voxtral-4B-TTS-2603-mlx-4bit`), Italian/English voices
+- Intent: rule-based classifier → cvg commands, queries, navigation, control
+- State machine: Idle → Listening → WakeDetected → Processing → Speaking
+- Feature flag: `cargo build --features voice` (opt-in, not default)
+- Models required: `~/.cache/whisper/ggml-small.bin` (Whisper), Voxtral 4B via mlx-audio
+- `mlx-audio` installed from git main (PyPI 0.4.1 lacks voxtral_tts)
+
+### Ali Escalation / EscalateToAli
+- "ali dimmi..." via Telegram/API → Claude CLI (Sonnet/Opus) subprocess
+- Full system context injected automatically
+- Fallback to Qwen local if Claude CLI unavailable
+- Unknown problems: creates micro-plans and launches copilot-plan-runner automatically
+- EscalateToAli (v20.4.0): unrecognized messages and keyword intents (report/analysis/action) escalate to Claude with full platform context — replaces AskAli
+
+### Telegram Bot (@ConvergioBot)
+- Inbound text: any message → classify intent → respond
+- Inbound voice: OGG → Whisper → classify → respond text + voice
+- Outbound: alerts, daily/weekly reports, plan completions
+- Long polling (zero wasted requests)
+- Quiet hours (23:00-07:00 CET)
+
+### Mesh Auto-Update (v20.4.0)
+- `GET /api/mesh/update-status` — version comparison across all mesh peers
+- `version` + `rustc_version` fields in peer heartbeats
+- Background auto-update task: 5min interval, quiet hours (23:00-07:00 CET), 30min rate limit
+- Coordinator builds once, workers rsync binary from coordinator
+- `start.sh` restart loop with automatic rollback on health failure
+- Backup stored in `~/.convergio/bin/*.bak`
+
+### Node Management
+- `GET /api/node/readiness` — 10-check health report per node
+- Role-based provisioning (kernel, executor, coordinator)
+- Background DB sync via HTTP between mesh nodes (replaces rsync-only)
+- Auto-rebuild: daemon rebuilds after git pull, launchd plist (5min interval)
+- `caffeinate` anti-sleep for kernel node
+- Secrets replication via ~/.convergio/env
+
+### Nightly Jobs
+- `GET/POST /api/nightly/jobs` — CRUD for scheduled tasks
+- Model Calibration: Sunday 03:00, compare local vs cloud
+- MirrorBuddy Guardian: daily 01:30
+- VirtualBPM Guardian: daily 02:15
+
+### MCP Server (convergio-mcp-server)
+- Separate binary, stdio transport, JSON-RPC
+- 17 tools: plans(4), agents(3), mesh(2), metrics(1), kernel(2), actions(2), control(3)
+- Ring-based security (0=core, 1=trusted, 2=community, 3=sandboxed)
+- Wired into Claude Code via .mcp.json
+- Control tools: assign_role, interrupt_agent, reschedule_task
+
+### Node Role Management
+- `POST /api/node/assign-role` — assign kernel/executor/coordinator role
+- `GET /api/node/roles` — list all node roles
+- Roles stored in DB, replicated via sync
+
+### Agent Control (kernel intervention)
+- `POST /api/agent/interrupt` — stop a blocked agent via IPC bus
+- `POST /api/task/reschedule` — move task to another node
+- Kernel auto-detects stalls and can intervene autonomously
+
+### Channels (OpenClaw bridge)
+- 30+ platforms: WhatsApp, Telegram, Slack, Discord, etc.
+- Webhook + polling support
+- Channel adapters in daemon/src/channels/
+
+### Document Ingestion
+- PDF → MD, DOCX → MD, XLSX → CSV, URL, images, folders
+- `cvg ingest` or daemon API with graceful fallback
+
+### Evolution Engine
+- Observe → Measure → Propose → Experiment → Validate → Learn
+- A/B testing, multi-armed bandit
+- Cost calibration, model routing optimization
+- Proposals require human approval
+
+### Developer Experience (v18.5.0)
+- `cvg cheatsheet` / `cvg commands` — all commands grouped by domain
+- `cvg api` — all daemon HTTP API endpoints with methods
+- `cvg plan template` — example spec YAML with all fields + aliases
+- Improved `cvg plan import` error messages: YAML location, missing keys, type hints
+- `cvg plan tree` alias for `cvg plan execution-tree`
+- Peer resolver: single source of truth for peer addressing (3-stage fuzzy match)
+- Docs: spec-yaml-schema, mesh-delegation, delegation-guide, peer-resolver, telegram-credentials, decision-tree
+
+## API Surface (250+ endpoints)
+
+| Domain | GET | POST | Key endpoints |
+|--------|-----|------|---------------|
+| Plans | 6 | 8 | /api/plan-db/list, /json/:id, /task/update |
+| Agents | 4 | 5 | /api/agents, /api/ipc/agents |
+| Mesh | 8 | 4 | /api/mesh, /api/mesh/status, /api/heartbeat |
+| Kernel | 3 | 5 | /api/kernel/status, /ask, /speak, /transcribe |
+| Node | 1 | 0 | /api/node/readiness |
+| Metrics | 4 | 1 | /api/metrics/summary, /api/tokens/daily |
+| Chat | 3 | 4 | /api/chat/session, /message |
+| Nightly | 3 | 3 | /api/nightly/jobs |
+| Workspace | 4 | 4 | /api/workspace/create, /quality-gate |
+| Memory | 2 | 2 | /api/memory/list, /stats, /gc, /delete/:file |
+| Voice | 2 | 3 | /api/voice/start, /stop, /status, /wake-word |
+
+## NON-NEGOTIABLE Rules
+
+1. **No direct sqlite3** — use cvg CLI or daemon API only
+2. **250 lines max per file** — CONSTITUTION Article V
+3. **TDD mandatory** — RED → GREEN → evidence
+4. **Thor validates** — executors submit, only Thor promotes to done
+5. **Zero tech debt** — touch file = own all issues
+6. **Verify before claim** — evidence required for every "done"
+7. **Mesh delegation** — use cvg delegation for remote execution
+8. **Agent identity** — cvg agent start/complete on every session
+
+## Storage
+
+| Path | Content |
+|------|---------|
+| data/dashboard.db | SQLite WAL + CRDT (plans, tasks, waves, KB) |
+| ~/.claude/data/ | Symlink to data/ |
+| ~/.convergio/env | Secrets (Telegram token, HF token) |
+| ~/.cache/huggingface/hub/ | MLX models (Qwen, Voxtral, Whisper) |
+| ~/Library/LaunchAgents/ | launchd plists (kernel, sync-db) |
+
+## Active Repos (28 Marzo 2026)
+
+| Repo | Status | Purpose |
+|------|--------|---------|
+| ConvergioPlatform | ACTIVE (SoT) | Daemon, kernel, evolution, scripts |
+| convergio | ACTIVE | Meta: specs, ADR, CI, governance |
+| convergio-design | ACTIVE | Design system (Maranello Luce) |
+| convergio-web | ACTIVE | Web UI (Next.js + Tauri) |
+| convergio-daemon | ARCHIVED | Standalone daemon (superseded) |
+| convergio-app | ARCHIVED | Native macOS app (superseded) |

--- a/claude-config/reference/convergio-decision-tree.md
+++ b/claude-config/reference/convergio-decision-tree.md
@@ -1,0 +1,113 @@
+# Convergio Decision Tree
+
+"What tool to use when" — quick reference for common operations.
+
+## I Need To...
+
+### Work on Code
+
+| Situation | Action |
+|-----------|--------|
+| Quick single-file fix | Direct edit (no branch needed) |
+| Multi-file feature | `/solve` → `/planner` → `/execute` |
+| Bug fix with tests | `/solve` → `/planner` → `/execute` |
+| Existing plan task | `cvg task update <id> in_progress` → work → `submitted` |
+
+### Manage Plans
+
+| Situation | Action |
+|-----------|--------|
+| Create a plan | `/solve` → `/planner` (NEVER create without planner) |
+| See plan status | `cvg plan tree <id> --human` |
+| Import spec YAML | `cvg plan import <id> spec.yaml` |
+| Generate spec template | `cvg plan template` |
+| Check readiness | `cvg plan readiness <id>` |
+| Validate wave | `cvg plan validate <id>` |
+| Cancel plan | `cvg plan cancel <id> "reason"` |
+
+### Delegate Work
+
+| Situation | Action |
+|-----------|--------|
+| To remote peer (Claude) | `cvg delegation start <plan> <peer>` |
+| To Copilot worker | `copilot-worker.sh <task_id> --model claude-opus-4.6` |
+| Full plan auto-run | `copilot-plan-runner.sh <plan_id>` |
+| Check delegation | `cvg delegation status <plan>` |
+| NEVER | GitHub Issues or `@copilot` assignee |
+
+### Manage Branches & Worktrees
+
+| Situation | Action |
+|-----------|--------|
+| Wave work | `cvg wave create <plan> <wave>` |
+| Feature branch | `cvg workspace create-feature <branch>` |
+| Task isolation | `Task(..., isolation="worktree")` |
+| NEVER | `git branch` / `git checkout -b` / `git switch -c` |
+| Rebase to main | `git rebase origin/main` (NEVER `git merge main`) |
+
+### Debug & Diagnose
+
+| Situation | Action |
+|-----------|--------|
+| Plan execution tree | `cvg plan tree <id> --human` |
+| Plan staleness | `cvg plan drift <id>` |
+| Active agents | `cvg who agents` |
+| Mesh health | `cvg mesh status` |
+| Node readiness | `curl localhost:8420/api/node/readiness` |
+| DB repair | `cvg ops db-repair` or restart daemon |
+| Stale worktrees | `cvg reap worktrees --dry-run` |
+
+### Access Data
+
+| Situation | Action |
+|-----------|--------|
+| Query plans | `cvg plan list` (NEVER `sqlite3`) |
+| Query tasks | `cvg plan tree <id>` |
+| Search KB | `cvg kb search "<query>"` |
+| Metrics | `cvg metrics summary` |
+| Project audit | `cvg audit --project <id>` |
+
+### Kernel & Mesh
+
+| Situation | Action |
+|-----------|--------|
+| Start kernel | `cvg kernel start` |
+| Set audio node | `cvg kernel here` |
+| TTS | `cvg kernel say "<text>"` |
+| Sync DB across nodes | `cvg mesh sync` or daemon auto-sync |
+| Mesh peer status | `cvg mesh status` |
+| Send heartbeat | `cvg mesh heartbeat` |
+
+### Recovery
+
+| Situation | Action |
+|-----------|--------|
+| Save checkpoint | `cvg checkpoint save <plan_id>` |
+| Restore checkpoint | `cvg checkpoint restore <plan_id>` |
+| After compaction | `cvg checkpoint restore` → `cvg plan execution-tree` |
+| Zombie cleanup | `cvg reap worktrees && cvg reap branches && cvg reap locks` |
+| Session cleanup | `session-reaper.sh --max-age 0` |
+
+### Review & Validate
+
+| Situation | Action |
+|-----------|--------|
+| Register review | `cvg review register` |
+| Task validation | `cvg task validate <id> <plan>` |
+| Wave validation | `cvg plan validate <plan_id>` |
+| File audit | `cvg audit --path .` |
+| Project audit | `cvg audit --project <id>` |
+
+### CI & Builds
+
+| Situation | Action |
+|-----------|--------|
+| Check CI | `ci-digest.sh checks <pr>` |
+| Watch CI | `ci-watch.sh <branch> --repo owner/repo` |
+| Run tests | `test-digest.sh` |
+| Build | `build-digest.sh` |
+| Full audit | `project-audit.sh --project-root $(pwd)` |
+
+## All Commands
+
+Run `cvg cheatsheet` for a complete list of all available commands.

--- a/claude-config/reference/core-tools.md
+++ b/claude-config/reference/core-tools.md
@@ -1,0 +1,40 @@
+<!-- v1.0.0 — Merged: tool-preferences + agent-routing -->
+
+# Tools & Routing
+
+## Tool Mapping
+
+| Task | Use | NOT |
+|---|---|---|
+| Find file | Glob | `find`/`ls` |
+| Search content | Grep | `grep`/`rg` |
+| Read/Edit/Create | Read/Edit/Write | `cat`/`sed`/`echo >` |
+| Definition/Usages | LSP | Grep |
+| Symbol search | `codegraph_search` (if `.codegraph/`) | Grep |
+| Explore codebase | `Task(subagent_type='Explore')` | Multiple grep/glob |
+| Audit | `project-audit.sh --project-root $(pwd)` | Manual scripts |
+
+- ALWAYS parallelize independent tool calls
+- Shell: single-quote URLs with `?`/`&`
+- NEVER `!=` in SQL → use `<>`
+- **NEVER pipe Bash output to `tail`/`head`/`grep`/`cat`** — PreToolUse hook blocks it. Use Grep/Read/Glob tools instead. Example: `cvg plan 2>&1 | grep import` → run `cvg plan 2>&1` alone, read output directly
+
+## CI/Build (MANDATORY)
+
+| AVOID | USE |
+|---|---|
+| `npm run lint/typecheck/build/test` | `ci-summary.sh --lint/--types/--build/--unit` |
+| `gh run view --log` | `ci-digest.sh <id>` |
+| `gh pr checks` | `ci-digest.sh checks <pr>` |
+| `gh pr view/merge` | `cvg workspace release` / `ci-digest.sh checks <pr>` |
+
+## Routing (NON-NEGOTIABLE)
+
+| Trigger | Use | NOT |
+|---|---|---|
+| Plan (3+ tasks) | `Skill(skill="planner")` | EnterPlanMode |
+| Execute | `Skill(skill="execute")` | Direct edit |
+| Validate | Thor subagent | Self-declare done |
+
+- Explore → `Explore` | Plan task → `task-executor` | Validation → `thor` | Debug → `adversarial-debugger`
+- Repo knowledge: `repo-index.sh` | `agent-versions.sh [--json]`

--- a/claude-config/reference/ds-integration-playbook.md
+++ b/claude-config/reference/ds-integration-playbook.md
@@ -1,0 +1,212 @@
+# Convergio Design System — Release & Integration Playbook
+
+> Generato da sessione 2026-03-29. Replica questo processo per qualsiasi
+> repo che consuma `@convergio/design-elements` o `@convergio/design-tokens`.
+
+---
+
+## 1. Fix nel Design System upstream
+
+### 1.1 Trovare il bug
+
+Il barrel TypeScript (`packages/elements/src/ts/index.ts`) potrebbe non
+esportare tutte le funzioni presenti nel runtime ESM. Per verificare:
+
+```bash
+# Nel bundle ESM, trova tutti gli export assegnati al namespace M
+grep "M\.\w\+ = " packages/elements/dist/esm/index.js | sort
+
+# Confronta con le righe export nel barrel dei tipi
+grep "^export" packages/elements/dist/types/index.d.ts | sort
+```
+
+Ogni `M.xxx = xxx` senza corrispondente `export { xxx }` è un bug.
+In questa sessione il bug era `aiChat`: presente in ESM, assente dai tipi.
+
+### 1.2 Creare il fix
+
+```bash
+cd /path/to/convergio-design
+git checkout main && git pull
+git checkout -b fix/nome-descrittivo
+
+# Editare packages/elements/src/ts/index.ts (o index-extras.ts se > 244 righe)
+# Aggiungere: export { aiChat } from './ai-chat-iife';
+
+# Verificare localmente
+pnpm run build   # deve passare senza errori
+pnpm run test     # tutti i test devono passare (82 al momento)
+```
+
+### 1.3 PR → CI → Merge
+
+```bash
+git add -A && git commit -m "fix: export aiChat from barrel index"
+git push -u origin fix/nome-descrittivo
+
+gh pr create \
+  --title "fix: export aiChat from barrel index" \
+  --body "Descrizione dettagliata del problema e del fix" \
+  --base main
+
+# Aspettare CI (2 workflow: push + pull_request, ~3-4 minuti)
+gh pr checks <PR_NUMBER> --watch
+
+# Merge (SQUASH DISABILITATO nel repo — usare merge commit)
+gh pr merge <PR_NUMBER> --merge
+```
+
+### 1.4 Release e publish npm
+
+```bash
+git checkout main && git pull origin main
+
+# 1) Bump versione in TUTTI e 3 i package.json
+#    - package.json (root)
+#    - packages/elements/package.json
+#    - packages/tokens/package.json
+
+# 2) Aggiornare CHANGELOG.md (formato Keep a Changelog)
+
+# 3) Rebuild con nuova versione
+pnpm run build
+
+# 4) Commit + tag + push
+git add -A
+git commit -m "chore: release vX.Y.Z"
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+Il push del tag `v*` triggera automaticamente:
+- **`publish.yml`** → `pnpm -r publish --access public --no-git-checks`
+  (pubblica su npmjs.org via `NPM_TOKEN` secret)
+- **`release.yml`** → crea GitHub Release con asset (CSS, IIFE, sourcemap)
+
+### 1.5 Verificare
+
+```bash
+# Aspettare ~1 minuto, poi:
+npm view @convergio/design-elements version   # deve mostrare X.Y.Z
+npm view @convergio/design-tokens version     # deve mostrare X.Y.Z
+
+# Verificare GitHub Release
+gh release view vX.Y.Z
+```
+
+---
+
+## 2. Consumare la nuova versione nel progetto web
+
+```bash
+cd /path/to/convergio-web-rebuild
+npm install @convergio/design-elements@X.Y.Z @convergio/design-tokens@X.Y.Z --save
+npx next build   # deve passare
+npm test          # deve passare
+```
+
+---
+
+## 3. Pattern di integrazione DS (imperative API in React)
+
+### Pattern corretto
+
+```tsx
+'use client';
+import { useRef, useEffect } from 'react';
+
+export function MyComponent({ data }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || data.length === 0) return;
+    let ctrl: { destroy?: () => void } | null = null;
+
+    import('@convergio/design-elements').then(({ dataTable }) => {
+      if (!containerRef.current) return;
+      containerRef.current.innerHTML = '';      // pulisci prima di montare
+      ctrl = dataTable(containerRef.current, {
+        columns: [...],
+        data: data as unknown as Record<string, unknown>[],
+      });
+    });
+
+    return () => { ctrl?.destroy?.(); };        // SEMPRE cleanup
+  }, [data]);                                    // deps corrette
+
+  // Loading: early return, NON AnimatePresence
+  if (!data) return <Skeleton />;
+
+  return <div ref={containerRef} className="min-h-[200px]" />;
+}
+```
+
+### Trappole da evitare
+
+| Trappola | Perché è un problema | Soluzione |
+|----------|---------------------|-----------|
+| `<AnimatePresence>` attorno al container ref | L'exit animation ritarda l'attacco del ref. Il `useEffect` trova `ref.current === null` e non monta nulla. | Usa `if (!loaded) return <Skeleton />;` (early return condizionale). |
+| `edges: [{source, target}]` per neuralNodes | L'API usa `connections: [{from, to, strength}]`. Build error silenzioso o crash. | Controlla SEMPRE `dist/types/*.d.ts` per i nomi corretti. |
+| `items: [...]` per dashboardStrip | L'API usa `zones: [StripBoardZone]`. | Idem: leggi i tipi, non il CKB/mapping doc. |
+| `addMessage({role, content})` per aiChat | L'API è `addMessage(role: 'user'|'ai', content: string, opts?)`. Restituisce `StreamingHandle` con `{append, finish}`. | Usa la signature esatta dai `.d.ts`. |
+| `selectEngagement(phaseId)` senza engagements | customerJourney seleziona engagement cards per ID. Se `engagements: []` non c'è nulla da selezionare. | Popola le fasi con engagement reali dai dati. |
+| Nessun cleanup SSE/EventSource | EventSource resta aperto dopo unmount, causando leak. | Traccia in un `useRef<EventSource>` e chiudi nel cleanup. |
+| Nodi neuralNodes oversize con molti dati | 136 nodi con `size: 18` = muro di cerchi sovrapposti. | Scala: `size = Math.round(base * (total > 80 ? 0.3 : total > 40 ? 0.5 : 1))`. Limita agenti a 20. |
+| `sessionId` in deps del useEffect di aiChat | Ogni cambio sessione distrugge e ricrea il widget. Il callback `onSend` chiude su un `ctrl` che viene distrutto mid-send. | Usa `useRef` per sessionId e controller. Monta aiChat una volta sola. |
+
+---
+
+## 4. Checklist pre-commit
+
+- [ ] `npx next build` passa senza errori
+- [ ] `npm test` (vitest) — tutti i test passano
+- [ ] Screenshot Playwright di OGNI pagina — verificare visivamente:
+  - Tabelle renderizzate con dati reali (non vuote)
+  - Grafici con nodi leggibili (non sovrapposti)
+  - Nessun testo fallback visibile (es. "Gauge: 1,")
+  - Header shell presente con navigazione
+- [ ] Nessun `console.error` nel browser
+- [ ] Max 250 righe per file
+- [ ] `'use client'` su ogni file con hooks
+- [ ] Ogni `useEffect` con dynamic import ha cleanup `ctrl?.destroy?.()`
+
+---
+
+## 5. Audit cross-modello
+
+Usare un modello AI diverso da quello di sviluppo per l'audit finale.
+In questa sessione: sviluppo con Claude Opus 4.6, audit con GPT-5.4.
+
+L'audit ha trovato 4 bug critici che lo sviluppatore non aveva visto:
+1. Chat widget distrutto mid-send (sessionId in deps)
+2. SSE stream mai chiuso su unmount
+3. Guard `ctrlRef.current?.update` su metodo inesistente (brain)
+4. `selectEngagement` con engagements vuoti (evolution)
+
+### Come lanciare l'audit
+
+Passare al modello auditor:
+- Il contesto completo dei file modificati
+- Le API signatures esatte dal DS (tipi `.d.ts`)
+- Il pattern di integrazione atteso
+- Istruzioni di concentrarsi SOLO su bug, API misuse, logica — MAI stile
+
+---
+
+## 6. DS Components utilizzati (9 su 17+ target)
+
+| Componente | File che lo usano |
+|-----------|-------------------|
+| `headerShell` | app-shell.tsx |
+| `createGauge` | kpi-strip.tsx |
+| `dataTable` | agents, mesh, evolution, mission-control, agent-sidebar, chat |
+| `kanbanBoard` | workspaces |
+| `neuralNodes` | brain, mesh-topology |
+| `aiChat` | chat |
+| `customerJourney` | evolution |
+| `dashboardStrip` | evolution |
+| `systemStatus` | mesh-section |
+
+Mancano ancora per raggiungere 17+: `mn-gantt`, `FacetWorkbench`,
+`tokenMeter`, `approvalChain`, `mn-chart` (sparkline), `socialGraph`,
+`mn-header-shell` (WC), `mn-theme-toggle` (WC).

--- a/claude-config/schemas/plan-spec-schema.json
+++ b/claude-config/schemas/plan-spec-schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MyConvergio Plan Spec",
+  "description": "JSON Schema for plan spec.json validation. Source: HVE Core pattern (schema-driven validation).",
+  "type": "object",
+  "required": ["user_request", "requirements", "constraints", "waves"],
+  "properties": {
+    "user_request": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Verbatim user request text"
+    },
+    "constraints": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Hard constraints that EVERY task must respect. Extracted from user brief. Violations = plan failure.",
+      "items": {
+        "type": "object",
+        "required": ["id", "text", "type"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^C-\\d{2,3}$",
+            "description": "Constraint ID (C-01, C-02, ...)"
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Constraint text — clear, machine-checkable where possible"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "permission",
+              "security",
+              "cost",
+              "compliance",
+              "technical",
+              "process"
+            ],
+            "description": "Constraint category"
+          },
+          "verify": {
+            "type": "string",
+            "description": "How to verify this constraint is respected (CLI command or check)"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "requirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "text", "wave"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^F-\\d{2,3}$" },
+          "text": { "type": "string", "minLength": 1 },
+          "wave": { "type": "string", "pattern": "^W[0-9F]" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "waves": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "merge_mode", "tasks"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^W[0-9F]" },
+          "name": { "type": "string", "minLength": 1 },
+          "estimated_hours": { "type": "number", "minimum": 0 },
+          "merge_mode": {
+            "type": "string",
+            "enum": ["sync", "batch", "none"],
+            "description": "Planner-decided merge strategy: sync (PR+merge, use at theme boundary), batch (accumulate on theme branch, no PR), none (docs/config only, no merge)"
+          },
+          "theme": {
+            "type": "string",
+            "description": "Theme group name (e.g., 'security', 'quality', 'infra'). Waves with same theme share one branch+PR. Planner assigns based on domain affinity."
+          },
+          "precondition": { "type": "object" },
+          "acceptance_invariants": {
+            "type": "array",
+            "description": "Machine-verifiable success criteria for the wave",
+            "items": {
+              "type": "object",
+              "required": ["description", "verify"],
+              "properties": {
+                "description": {
+                  "type": "string",
+                  "description": "Human-readable description of what must be true"
+                },
+                "verify": {
+                  "type": "string",
+                  "description": "CLI command that exits 0 on success"
+                },
+                "defined_by": {
+                  "type": "string",
+                  "enum": ["user", "solve", "collaborative"],
+                  "default": "collaborative",
+                  "description": "Who defined this invariant"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "tasks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "do",
+                "files",
+                "verify",
+                "ref",
+                "priority",
+                "type",
+                "model",
+                "effort"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "pattern": "^T[0-9F]-\\d{2}$|^TF-(doc|tests|pr)$"
+                },
+                "do": { "type": "string", "minLength": 1 },
+                "files": { "type": "array", "items": { "type": "string" } },
+                "verify": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "minItems": 1
+                },
+                "ref": { "type": "string", "minLength": 1 },
+                "priority": {
+                  "type": "string",
+                  "enum": ["P0", "P1", "P2", "P3"]
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "feature",
+                    "fix",
+                    "refactor",
+                    "test",
+                    "config",
+                    "documentation",
+                    "chore",
+                    "cleanup"
+                  ]
+                },
+                "model": {
+                  "type": "string",
+                  "enum": [
+                    "claude-opus-4.6",
+                    "claude-opus-4.6-fast",
+                    "claude-sonnet-4.6",
+                    "claude-sonnet-4.5",
+                    "claude-haiku-4.5",
+                    "gpt-5.3-codex",
+                    "gpt-5.2-codex",
+                    "gpt-5.1-codex-max",
+                    "gpt-5.1-codex",
+                    "gpt-5.1-codex-mini",
+                    "gpt-5",
+                    "gpt-5-mini",
+                    "gpt-4.1",
+                    "gemini-3-pro-preview",
+                    "claude-opus-4.5"
+                  ]
+                },
+                "effort": { "type": "integer", "minimum": 1, "maximum": 3 },
+                "summary": { "type": "string", "maxLength": 80 },
+                "executor_agent": {
+                  "type": "string",
+                  "description": "Agent name from catalog or tool type"
+                },
+                "output_type": {
+                  "type": "string",
+                  "enum": ["pr", "document", "analysis", "design", "legal_opinion", "plan", "review", "presentation", "other"],
+                  "default": "pr",
+                  "description": "Type of deliverable this task produces"
+                },
+                "validator_agent": {
+                  "type": "string",
+                  "enum": ["thor", "doc-validator", "plan-reviewer", "design-validator", "compliance-validator"],
+                  "default": "thor",
+                  "description": "Agent that validates this task output"
+                },
+                "skip_if": { "type": "string" },
+                "output_match": { "type": "object" },
+                "consumers": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Files that import/use what this task creates/changes. REQUIRED for feature/refactor tasks (enforced by planner Step 3.1b). Thor Gate 10 validates."
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/claude-config/schemas/skill-frontmatter.schema.json
+++ b/claude-config/schemas/skill-frontmatter.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Skill Protocol v1.0 — skill.yaml",
+  "type": "object",
+  "required": ["name", "version", "description", "domain", "constitution-version", "license", "copyright"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Kebab-case skill identifier"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver skill version"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Human-readable summary of what this skill does"
+    },
+    "domain": {
+      "type": "string",
+      "enum": ["workflow", "technical", "business", "legal", "creative", "security", "data", "design"],
+      "description": "Functional domain this skill belongs to"
+    },
+    "constitution-version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver of the Skill Protocol constitution this skill targets"
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier (e.g. MPL-2.0, MIT, Apache-2.0)"
+    },
+    "copyright": {
+      "type": "string",
+      "description": "Copyright statement (e.g. Copyright 2026 Acme Corp)"
+    },
+    "repo": {
+      "type": "string",
+      "description": "Source repository URL"
+    },
+    "tools": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Tool names this skill uses (e.g. Bash, Read, Grep)"
+    },
+    "model": {
+      "type": "string",
+      "description": "Canonical model ID required by this skill"
+    },
+    "min-context": {
+      "type": "integer",
+      "minimum": 4000,
+      "description": "Minimum context window in tokens required to run this skill"
+    },
+    "arguments": {
+      "type": "string",
+      "enum": ["none", "required", "optional"],
+      "description": "Whether the skill accepts invocation arguments"
+    },
+    "triggers": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Slash-command or keyword triggers (e.g. /planner)"
+    },
+    "provider-formats": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["claude-code", "copilot-cli", "generic-llm"]
+      },
+      "description": "Target provider formats this skill is packaged for"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
Migrates operational config, JSON schemas, and reference docs from ConvergioPlatform.

- **Config**: models.yaml, orchestrator.yaml, notifications.conf
- **Schemas**: plan-spec-schema.json, skill-frontmatter.schema.json
- **Reference**: 5 key operational docs for agent context

No code changes. Data/config migration only.

## Test plan
- [x] No code changes — no compilation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)