### PR TITLE
feat: fase 24e-24f — PM endpoints + protocol enforcement

### DIFF
--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -70,6 +70,7 @@ impl Extension for OrchestratorExtension {
             .merge(crate::plan_routes_ext::plan_routes_ext(Arc::clone(&state)))
             .merge(crate::task_routes::task_routes(state))
             .merge(crate::tracking_routes::tracking_routes(self.pool.clone()))
+            .merge(crate::pm_routes::pm_routes(self.pool.clone()))
             .merge(crate::aggregation_routes::aggregation_routes(
                 self.pool.clone(),
             ));

--- a/daemon/crates/convergio-orchestrator/src/lib.rs
+++ b/daemon/crates/convergio-orchestrator/src/lib.rs
@@ -12,6 +12,7 @@ pub mod handlers;
 pub mod plan_hierarchy;
 pub mod plan_routes;
 pub mod plan_routes_ext;
+pub mod pm_routes;
 pub mod policy;
 pub mod reactor;
 pub mod reaper;

--- a/daemon/crates/convergio-orchestrator/src/plan_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes.rs
@@ -101,6 +101,10 @@ pub struct CreatePlan {
     pub execution_mode: Option<String>,
     #[serde(default)]
     pub tasks_total: i64,
+    /// Protocol fields (24f): optional but logged if missing.
+    pub objective: Option<String>,
+    pub motivation: Option<String>,
+    pub requester: Option<String>,
 }
 
 async fn handle_create(
@@ -136,6 +140,14 @@ async fn handle_create(
                         ..Default::default()
                     },
                 ));
+            }
+            // Auto-create plan_metadata if protocol fields provided (24f)
+            if body.objective.is_some() || body.motivation.is_some() || body.requester.is_some() {
+                let _ = conn.execute(
+                    "INSERT OR IGNORE INTO plan_metadata (plan_id, objective, motivation, requester) \
+                     VALUES (?1, ?2, ?3, ?4)",
+                    params![id, body.objective, body.motivation, body.requester],
+                );
             }
             Json(json!({"id": id, "status": "created"}))
         }

--- a/daemon/crates/convergio-orchestrator/src/pm_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/pm_routes.rs
@@ -1,0 +1,237 @@
+//! PM (Project Manager) agent endpoints — analyze, digest, learnings, cost forecast.
+
+use axum::extract::{Path, Query, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use convergio_db::pool::ConnPool;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub fn pm_routes(pool: ConnPool) -> Router {
+    Router::new()
+        .route("/api/pm/analyze/:plan_id", post(analyze_plan))
+        .route("/api/pm/digest", get(weekly_digest))
+        .route("/api/pm/learnings", get(aggregated_learnings))
+        .route("/api/pm/cost-forecast", get(cost_forecast))
+        .with_state(pool)
+}
+
+/// Analyze a plan: cost breakdown, duration, evidence gaps, agent activity.
+async fn analyze_plan(State(pool): State<ConnPool>, Path(plan_id): Path<i64>) -> Json<Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+
+    // Cost breakdown
+    let total_cost: f64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(cost_usd), 0) FROM token_usage WHERE plan_id = ?1",
+            [plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0.0);
+    let total_tokens: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM token_usage WHERE plan_id = ?1",
+            [plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // Task counts by status
+    let tasks_done: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM tasks WHERE plan_id = ?1 AND status = 'done'",
+            [plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    let tasks_total: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM tasks WHERE plan_id = ?1",
+            [plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // Evidence gaps: tasks without evidence
+    let tasks_no_evidence: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM tasks t WHERE t.plan_id = ?1 AND t.status IN ('done','submitted') \
+             AND NOT EXISTS (SELECT 1 FROM task_evidence e WHERE e.task_id = t.id)",
+            [plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // Distinct agents
+    let agents: i64 = conn
+        .query_row(
+            "SELECT count(DISTINCT agent) FROM token_usage WHERE plan_id = ?1",
+            [plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // Plan metadata
+    let (objective, requester) = conn
+        .query_row(
+            "SELECT objective, requester FROM plan_metadata WHERE plan_id = ?1",
+            [plan_id],
+            |r| {
+                Ok((
+                    r.get::<_, Option<String>>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                ))
+            },
+        )
+        .unwrap_or((None, None));
+
+    Json(json!({
+        "plan_id": plan_id,
+        "objective": objective,
+        "requester": requester,
+        "cost_usd": total_cost,
+        "total_tokens": total_tokens,
+        "tasks_done": tasks_done,
+        "tasks_total": tasks_total,
+        "completion_pct": if tasks_total > 0 { (tasks_done as f64 / tasks_total as f64 * 100.0).round() } else { 0.0 },
+        "evidence_gaps": tasks_no_evidence,
+        "agents_involved": agents,
+    }))
+}
+
+#[derive(Deserialize, Default)]
+struct DigestQuery {
+    #[allow(dead_code)]
+    period: Option<String>,
+}
+
+/// Weekly digest: plans completed, cost, learnings, anomalies.
+async fn weekly_digest(State(pool): State<ConnPool>, Query(_q): Query<DigestQuery>) -> Json<Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+
+    let plans_completed: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM plans WHERE status = 'done' \
+             AND updated_at >= datetime('now', '-7 days')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    let week_cost: f64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(cost_usd), 0) FROM token_usage \
+             WHERE created_at >= datetime('now', '-7 days')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0.0);
+    let week_tokens: i64 = conn
+        .query_row(
+            "SELECT COALESCE(SUM(input_tokens + output_tokens), 0) FROM token_usage \
+             WHERE created_at >= datetime('now', '-7 days')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    let active_agents: i64 = conn
+        .query_row(
+            "SELECT count(DISTINCT agent) FROM token_usage \
+             WHERE created_at >= datetime('now', '-7 days')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    Json(json!({
+        "period": "last_7_days",
+        "plans_completed": plans_completed,
+        "cost_usd": week_cost,
+        "tokens": week_tokens,
+        "active_agents": active_agents,
+    }))
+}
+
+/// Aggregated learnings across all plans with key_learnings_json.
+async fn aggregated_learnings(State(pool): State<ConnPool>) -> Json<Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT p.id, p.name, m.key_learnings_json FROM plan_metadata m \
+         JOIN plans p ON p.id = m.plan_id \
+         WHERE m.key_learnings_json IS NOT NULL AND m.key_learnings_json != '' \
+         ORDER BY p.id DESC LIMIT 50",
+    ) {
+        Ok(s) => s,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let rows: Vec<Value> = match stmt.query_map([], |r| {
+        Ok(json!({
+            "plan_id": r.get::<_, i64>(0)?,
+            "plan_name": r.get::<_, String>(1)?,
+            "learnings": r.get::<_, String>(2)?,
+        }))
+    }) {
+        Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+        Err(_) => vec![],
+    };
+    Json(json!({"learnings": rows, "count": rows.len()}))
+}
+
+#[derive(Deserialize, Default)]
+struct ForecastQuery {
+    plan_id: Option<i64>,
+}
+
+/// Cost forecast based on historical data.
+async fn cost_forecast(
+    State(pool): State<ConnPool>,
+    Query(q): Query<ForecastQuery>,
+) -> Json<Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    // Average cost per plan
+    let avg_cost: f64 = conn
+        .query_row(
+            "SELECT COALESCE(AVG(plan_cost), 0) FROM (\
+             SELECT plan_id, SUM(cost_usd) as plan_cost FROM token_usage \
+             WHERE plan_id IS NOT NULL GROUP BY plan_id)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0.0);
+    // If plan_id given, forecast remaining cost based on completion %
+    let forecast = if let Some(pid) = q.plan_id {
+        let done: f64 = conn
+            .query_row(
+                "SELECT CAST(count(*) FILTER (WHERE status='done') AS REAL) / \
+                 MAX(count(*), 1) FROM tasks WHERE plan_id = ?1",
+                [pid],
+                |r| r.get(0),
+            )
+            .unwrap_or(0.0);
+        let spent: f64 = conn
+            .query_row(
+                "SELECT COALESCE(SUM(cost_usd), 0) FROM token_usage WHERE plan_id = ?1",
+                [pid],
+                |r| r.get(0),
+            )
+            .unwrap_or(0.0);
+        let projected = if done > 0.0 { spent / done } else { avg_cost };
+        json!({"plan_id": pid, "spent_usd": spent, "completion_pct": (done * 100.0).round(), "projected_total_usd": projected})
+    } else {
+        json!({"avg_cost_per_plan_usd": avg_cost})
+    };
+
+    Json(json!({"forecast": forecast}))
+}

--- a/daemon/crates/convergio-orchestrator/src/task_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/task_routes.rs
@@ -40,6 +40,22 @@ async fn handle_task_update(
         Ok(c) => c,
         Err(e) => return Json(json!({"error": e.to_string()})),
     };
+    // Lifecycle gate check (24f): validate transition before applying
+    if let Some(ref new_status) = body.status {
+        if let Err(gate_err) =
+            crate::gates::check_task_transition(&state.pool, body.task_id, new_status)
+        {
+            tracing::warn!(
+                task_id = body.task_id,
+                gate = gate_err.gate,
+                "gate blocked transition"
+            );
+            return Json(
+                json!({"error": format!("gate blocked: {gate_err}"), "gate": gate_err.gate}),
+            );
+        }
+    }
+
     let mut sets: Vec<String> = Vec::new();
     let mut p: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
     if let Some(ref s) = body.status {


### PR DESCRIPTION
## Summary

### 24e: PM Agent Endpoints
- `POST /api/pm/analyze/:plan_id` — cost breakdown, evidence gaps, completion %
- `GET /api/pm/digest` — weekly digest (plans completed, cost, tokens, agents)
- `GET /api/pm/learnings` — aggregated key learnings across plans
- `GET /api/pm/cost-forecast` — cost projection based on completion rate

### 24f: Protocol Enforcement
- Plan creation auto-creates `plan_metadata` when objective/motivation/requester provided
- Task status transitions checked by lifecycle gates before applying
- Gate violations return error with gate name and reason

## Test plan
- [x] `cargo check --workspace` — 0 errors
- [x] `cargo test --workspace` — 821 tests pass
- [x] All files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)