### PR TITLE
feat: TOML agent definitions for convergio-default org

### DIFF
--- a/claude-config/orgs/convergio-default/agents/ali-cos.toml
+++ b/claude-config/orgs/convergio-default/agents/ali-cos.toml
@@ -1,0 +1,16 @@
+[agent]
+name = "ali-cos"
+role = "Chief of Staff — strategic oversight"
+category = "leadership_strategy"
+department = "Leadership"
+model_tier = "t4"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+
+[capabilities]
+provides = [
+  "strategic-oversight",
+  "executive-coordination",
+  "org-alignment",
+  "priority-arbitration",
+]

--- a/claude-config/orgs/convergio-default/agents/ali-orchestrator.toml
+++ b/claude-config/orgs/convergio-default/agents/ali-orchestrator.toml
@@ -1,0 +1,16 @@
+[agent]
+name = "ali-orchestrator"
+role = "Chief of Staff — orchestrates all agent work"
+category = "core_utility"
+department = "Core"
+model_tier = "t4"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+
+[capabilities]
+provides = [
+  "task-dispatch",
+  "agent-coordination",
+  "workflow-orchestration",
+  "escalation-routing",
+]

--- a/claude-config/orgs/convergio-default/agents/baccio.toml
+++ b/claude-config/orgs/convergio-default/agents/baccio.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "baccio"
+role = "Executor — implements code changes from plans"
+category = "technical_development"
+department = "Engineering"
+model_tier = "t3"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "thor"
+
+[capabilities]
+provides = [
+  "code-implementation",
+  "plan-execution",
+  "crate-development",
+  "integration-wiring",
+]

--- a/claude-config/orgs/convergio-default/agents/convergio-pm.toml
+++ b/claude-config/orgs/convergio-default/agents/convergio-pm.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "convergio-pm"
+role = "Convergio Project Manager — audits plans, tracks costs, extracts learnings, writes reports"
+category = "core_utility"
+department = "Core"
+model_tier = "t3"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "ali-orchestrator"
+
+[capabilities]
+provides = [
+  "plan-audit",
+  "cost-tracking",
+  "learning-extraction",
+  "report-generation",
+]

--- a/claude-config/orgs/convergio-default/agents/elena.toml
+++ b/claude-config/orgs/convergio-default/agents/elena.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "elena"
+role = "Compliance officer — GDPR, legal review"
+category = "compliance_legal"
+department = "Legal"
+model_tier = "t3"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "ali-orchestrator"
+
+[capabilities]
+provides = [
+  "gdpr-compliance",
+  "legal-review",
+  "data-protection-audit",
+  "policy-enforcement",
+]

--- a/claude-config/orgs/convergio-default/agents/jony.toml
+++ b/claude-config/orgs/convergio-default/agents/jony.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "jony"
+role = "Chief designer — UI/UX vision"
+category = "design_ux"
+department = "Design"
+model_tier = "t3"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "matteo"
+
+[capabilities]
+provides = [
+  "ui-design",
+  "ux-vision",
+  "design-system-governance",
+  "component-review",
+]

--- a/claude-config/orgs/convergio-default/agents/rex.toml
+++ b/claude-config/orgs/convergio-default/agents/rex.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "rex"
+role = "Refactoring expert — improves code quality"
+category = "technical_development"
+department = "Engineering"
+model_tier = "t3"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "thor"
+
+[capabilities]
+provides = [
+  "code-refactoring",
+  "quality-improvement",
+  "technical-debt-reduction",
+  "pattern-enforcement",
+]

--- a/claude-config/orgs/convergio-default/agents/sara.toml
+++ b/claude-config/orgs/convergio-default/agents/sara.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "sara"
+role = "UX researcher — user testing and flows"
+category = "design_ux"
+department = "Design"
+model_tier = "t2"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "jony"
+
+[capabilities]
+provides = [
+  "ux-research",
+  "user-testing",
+  "flow-analysis",
+  "usability-audit",
+]

--- a/claude-config/orgs/convergio-default/agents/thor.toml
+++ b/claude-config/orgs/convergio-default/agents/thor.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "thor"
+role = "Validation guardian — reviews all submitted work"
+category = "core_utility"
+department = "Core"
+model_tier = "t4"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "ali-orchestrator"
+
+[capabilities]
+provides = [
+  "code-validation",
+  "quality-gate-enforcement",
+  "merge-approval",
+  "regression-detection",
+]

--- a/claude-config/orgs/convergio-default/agents/wanda.toml
+++ b/claude-config/orgs/convergio-default/agents/wanda.toml
@@ -1,0 +1,17 @@
+[agent]
+name = "wanda"
+role = "Workspace manager — worktree lifecycle"
+category = "core_utility"
+department = "Core"
+model_tier = "t2"
+max_tokens = 200000
+hourly_budget_usd = 0.0
+escalation_target = "ali-orchestrator"
+
+[capabilities]
+provides = [
+  "worktree-management",
+  "branch-lifecycle",
+  "workspace-cleanup",
+  "environment-setup",
+]

--- a/claude-config/orgs/convergio-default/manifest.toml
+++ b/claude-config/orgs/convergio-default/manifest.toml
@@ -1,0 +1,16 @@
+[package]
+name = "convergio-default"
+version = "1.0.0"
+description = "Default Convergio organization with 69 agents across 9 categories"
+author = "Roberto D'Angelo"
+
+[categories]
+core_utility = { label = "Core Utility", agent_count = 20 }
+technical_development = { label = "Technical Development", agent_count = 10 }
+business_operations = { label = "Business Operations", agent_count = 10 }
+leadership_strategy = { label = "Leadership & Strategy", agent_count = 7 }
+compliance_legal = { label = "Compliance & Legal", agent_count = 5 }
+specialized_experts = { label = "Specialized Experts", agent_count = 7 }
+design_ux = { label = "Design & UX", agent_count = 4 }
+release_management = { label = "Release Management", agent_count = 5 }
+research_report = { label = "Research & Reports", agent_count = 1 }


### PR DESCRIPTION
## Summary
- Add `claude-config/orgs/convergio-default/manifest.toml` with org package metadata and category breakdown (9 categories, 69 agents)
- Add 10 core agent TOML definitions: ali-orchestrator, thor, baccio, elena, jony, ali-cos, convergio-pm, sara, rex, wanda
- All data sourced from existing Rust seed catalog (`convergio-agents/src/seed/`) — model tiers, roles, escalation targets match exactly

## Test plan
- [ ] Verify TOML files parse correctly (`toml` crate or any TOML validator)
- [ ] Cross-check agent attributes against `seed_core.rs`, `seed_tech.rs`, `seed_biz.rs`, `seed_rest.rs`
- [ ] Confirm manifest category counts match seed file totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)