### PR TITLE
feat: daemon auto-start + launchd + firewall (fase 38c)

### DIFF
--- a/scripts/add-mesh-node.sh
+++ b/scripts/add-mesh-node.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOSTNAME="${1:-}"
+
+if [[ -z "${HOSTNAME}" ]]; then
+    echo "Usage: $0 <hostname>" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BINARY="/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio"
+PLIST_SRC="${SCRIPT_DIR}/com.convergio.daemon.plist"
+PLIST_NAME="com.convergio.daemon.plist"
+REMOTE_BINARY_DIR="/usr/local/bin"
+REMOTE_LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+REMOTE_BINARY="${REMOTE_BINARY_DIR}/convergio"
+
+# Verify local binary exists
+if [[ ! -f "${BINARY}" ]]; then
+    echo "ERROR: binary not found at ${BINARY}" >&2
+    echo "Run 'cargo build --release' first." >&2
+    exit 1
+fi
+
+# Verify SSH connectivity
+echo "Checking SSH connectivity to ${HOSTNAME}..."
+if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "${HOSTNAME}" "echo ok" &>/dev/null; then
+    echo "ERROR: cannot connect to ${HOSTNAME} via SSH." >&2
+    echo "Ensure SSH keys are configured and the host is reachable." >&2
+    exit 1
+fi
+echo "SSH OK."
+
+# Copy binary
+echo "Copying binary to ${HOSTNAME}:${REMOTE_BINARY}..."
+scp "${BINARY}" "${HOSTNAME}:${REMOTE_BINARY}"
+ssh "${HOSTNAME}" "chmod +x ${REMOTE_BINARY}"
+
+# Copy plist
+echo "Copying plist to ${HOSTNAME}:${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME}..."
+ssh "${HOSTNAME}" "mkdir -p ${REMOTE_LAUNCH_AGENTS}"
+scp "${PLIST_SRC}" "${HOSTNAME}:${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME}"
+
+# Install service on remote
+echo "Installing service on ${HOSTNAME}..."
+ssh "${HOSTNAME}" "launchctl unload ${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME} 2>/dev/null || true"
+ssh "${HOSTNAME}" "launchctl load ${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME}"
+
+echo "Mesh node ${HOSTNAME} configured and service started."

--- a/scripts/com.convergio.daemon.plist
+++ b/scripts/com.convergio.daemon.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.convergio.daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/Roberdan/GitHub/convergio/daemon</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/convergio-daemon.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/convergio-daemon.err</string>
+</dict>
+</plist>

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLIST_NAME="com.convergio.daemon.plist"
+PLIST_SRC="$(cd "$(dirname "$0")" && pwd)/${PLIST_NAME}"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+PLIST_DEST="${LAUNCH_AGENTS_DIR}/${PLIST_NAME}"
+BINARY="/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio"
+FIREWALL="/usr/libexec/ApplicationFirewall/socketfilterfw"
+
+# Verify binary exists
+if [[ ! -f "${BINARY}" ]]; then
+    echo "ERROR: binary not found at ${BINARY}" >&2
+    echo "Run 'cargo build --release' first." >&2
+    exit 1
+fi
+
+# Ensure LaunchAgents directory exists
+mkdir -p "${LAUNCH_AGENTS_DIR}"
+
+# Install plist
+echo "Installing ${PLIST_NAME} to ${LAUNCH_AGENTS_DIR}..."
+cp "${PLIST_SRC}" "${PLIST_DEST}"
+
+# Unload if already loaded (ignore errors if not loaded)
+launchctl unload "${PLIST_DEST}" 2>/dev/null || true
+
+# Load service
+echo "Loading service..."
+launchctl load "${PLIST_DEST}"
+
+# Add binary to macOS Application Firewall
+if [[ -x "${FIREWALL}" ]]; then
+    echo "Adding binary to firewall allowlist..."
+    sudo "${FIREWALL}" --add "${BINARY}"
+    sudo "${FIREWALL}" --unblockapp "${BINARY}"
+else
+    echo "WARNING: socketfilterfw not found, skipping firewall registration." >&2
+fi
+
+echo "Service installed and started."
+echo "Logs: /tmp/convergio-daemon.log"
+echo "Errors: /tmp/convergio-daemon.err"


### PR DESCRIPTION
## Summary

- `scripts/com.convergio.daemon.plist`: launchd agent plist con Label, ProgramArguments, WorkingDirectory, RunAtLoad, KeepAlive, stdout/stderr log paths
- `scripts/install-service.sh`: installa il plist in `~/Library/LaunchAgents/`, esegue `launchctl load`, registra il binary nel firewall macOS via `socketfilterfw --add`
- `scripts/add-mesh-node.sh <hostname>`: verifica SSH connectivity, copia binary via `scp`, copia plist, installa e avvia il service sul nodo remoto

## Test plan

- [ ] `cargo build --release` genera il binary
- [ ] `./scripts/install-service.sh` copia il plist e carica il service localmente
- [ ] `launchctl list | grep com.convergio.daemon` mostra il service attivo
- [ ] `/tmp/convergio-daemon.log` e `/tmp/convergio-daemon.err` vengono creati
- [ ] `./scripts/add-mesh-node.sh <host>` installa correttamente su un host remoto con SSH configurato

🤖 Generated with [Claude Code](https://claude.com/claude-code)