### PR TITLE
fix: agent spawn fixes + health/metrics wiring (learning #18)

### DIFF
--- a/daemon/crates/convergio-agent-runtime/src/spawner.rs
+++ b/daemon/crates/convergio-agent-runtime/src/spawner.rs
@@ -34,8 +34,10 @@ pub fn create_worktree(repo_root: &Path, name: &str) -> RuntimeResult<PathBuf> {
             wt_path.display()
         )));
     }
+    // Create worktree WITH a branch (not detached) so agent can push + PR
+    let branch = format!("agent/{name}");
     let output = Command::new("git")
-        .args(["worktree", "add", "--detach"])
+        .args(["worktree", "add", "-b", &branch])
         .arg(&wt_path)
         .arg("HEAD")
         .current_dir(repo_root)
@@ -78,10 +80,14 @@ pub fn spawn_process(
             for (k, v) in env_vars {
                 cmd.env(k, v);
             }
-            // Detach: don't inherit stdin, capture nothing
+            // Log output to files in worktree (Learning #18: /dev/null hides errors)
+            let log_out = std::fs::File::create(workspace.join("agent.log"))
+                .map_err(|e| RuntimeError::Internal(format!("create log: {e}")))?;
+            let log_err = std::fs::File::create(workspace.join("agent.err"))
+                .map_err(|e| RuntimeError::Internal(format!("create err: {e}")))?;
             cmd.stdin(std::process::Stdio::null());
-            cmd.stdout(std::process::Stdio::null());
-            cmd.stderr(std::process::Stdio::null());
+            cmd.stdout(std::process::Stdio::from(log_out));
+            cmd.stderr(std::process::Stdio::from(log_err));
             cmd.spawn()
                 .map_err(|e| RuntimeError::Internal(format!("spawn claude: {e}")))?
         }
@@ -94,9 +100,13 @@ pub fn spawn_process(
             for (k, v) in env_vars {
                 cmd.env(k, v);
             }
+            let log_out = std::fs::File::create(workspace.join("agent.log"))
+                .map_err(|e| RuntimeError::Internal(format!("create log: {e}")))?;
+            let log_err = std::fs::File::create(workspace.join("agent.err"))
+                .map_err(|e| RuntimeError::Internal(format!("create err: {e}")))?;
             cmd.stdin(std::process::Stdio::null());
-            cmd.stdout(std::process::Stdio::null());
-            cmd.stderr(std::process::Stdio::null());
+            cmd.stdout(std::process::Stdio::from(log_out));
+            cmd.stderr(std::process::Stdio::from(log_err));
             cmd.spawn()
                 .map_err(|e| RuntimeError::Internal(format!("spawn script: {e}")))?
         }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -149,9 +149,22 @@ async fn main() {
         }
     }
 
-    // 7. Health + metrics
+    // 7. Health + metrics — register extensions as health/metric sources
     let health = Arc::new(HealthRegistry::new());
     let metrics = Arc::new(MetricsCollector::new());
+    for ext in &extensions {
+        let manifest = ext.manifest();
+        // Wrap each extension as a health check source
+        let ext_clone = Arc::clone(ext);
+        let name = manifest.id.clone();
+        health.register(Arc::new(ExtHealthAdapter(name, ext_clone)));
+    }
+    for ext in &extensions {
+        let manifest = ext.manifest();
+        let ext_clone = Arc::clone(ext);
+        let name = manifest.id.clone();
+        metrics.register(Arc::new(ExtMetricAdapter(name, ext_clone)));
+    }
 
     // 8. Start extensions
     for ext in &extensions {
@@ -197,4 +210,33 @@ async fn main() {
         let _ = ext.on_shutdown();
     }
     tracing::info!("daemon stopped");
+}
+
+/// Adapter: wraps an Extension as a HealthCheck for the HealthRegistry.
+struct ExtHealthAdapter(String, Arc<dyn Extension>);
+
+impl convergio_telemetry::health::HealthCheck for ExtHealthAdapter {
+    fn name(&self) -> &str {
+        &self.0
+    }
+    fn check(&self) -> convergio_telemetry::health::ComponentHealth {
+        let status = self.1.health();
+        convergio_telemetry::health::ComponentHealth {
+            name: self.0.clone(),
+            status,
+            message: None,
+        }
+    }
+}
+
+/// Adapter: wraps an Extension as a MetricSource for the MetricsCollector.
+struct ExtMetricAdapter(String, Arc<dyn Extension>);
+
+impl convergio_telemetry::metrics::MetricSource for ExtMetricAdapter {
+    fn name(&self) -> &str {
+        &self.0
+    }
+    fn collect(&self) -> Vec<convergio_types::extension::Metric> {
+        self.1.metrics()
+    }
 }

--- a/scripts/add-mesh-node.sh
+++ b/scripts/add-mesh-node.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOSTNAME="${1:-}"
+
+if [[ -z "${HOSTNAME}" ]]; then
+    echo "Usage: $0 <hostname>" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BINARY="/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio"
+PLIST_SRC="${SCRIPT_DIR}/com.convergio.daemon.plist"
+PLIST_NAME="com.convergio.daemon.plist"
+REMOTE_BINARY_DIR="/usr/local/bin"
+REMOTE_LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+REMOTE_BINARY="${REMOTE_BINARY_DIR}/convergio"
+
+# Verify local binary exists
+if [[ ! -f "${BINARY}" ]]; then
+    echo "ERROR: binary not found at ${BINARY}" >&2
+    echo "Run 'cargo build --release' first." >&2
+    exit 1
+fi
+
+# Verify SSH connectivity
+echo "Checking SSH connectivity to ${HOSTNAME}..."
+if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "${HOSTNAME}" "echo ok" &>/dev/null; then
+    echo "ERROR: cannot connect to ${HOSTNAME} via SSH." >&2
+    echo "Ensure SSH keys are configured and the host is reachable." >&2
+    exit 1
+fi
+echo "SSH OK."
+
+# Copy binary
+echo "Copying binary to ${HOSTNAME}:${REMOTE_BINARY}..."
+scp "${BINARY}" "${HOSTNAME}:${REMOTE_BINARY}"
+ssh "${HOSTNAME}" "chmod +x ${REMOTE_BINARY}"
+
+# Copy plist
+echo "Copying plist to ${HOSTNAME}:${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME}..."
+ssh "${HOSTNAME}" "mkdir -p ${REMOTE_LAUNCH_AGENTS}"
+scp "${PLIST_SRC}" "${HOSTNAME}:${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME}"
+
+# Install service on remote
+echo "Installing service on ${HOSTNAME}..."
+ssh "${HOSTNAME}" "launchctl unload ${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME} 2>/dev/null || true"
+ssh "${HOSTNAME}" "launchctl load ${REMOTE_LAUNCH_AGENTS}/${PLIST_NAME}"
+
+echo "Mesh node ${HOSTNAME} configured and service started."

--- a/scripts/com.convergio.daemon.plist
+++ b/scripts/com.convergio.daemon.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.convergio.daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/Roberdan/GitHub/convergio/daemon</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/convergio-daemon.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/convergio-daemon.err</string>
+</dict>
+</plist>

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLIST_NAME="com.convergio.daemon.plist"
+PLIST_SRC="$(cd "$(dirname "$0")" && pwd)/${PLIST_NAME}"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+PLIST_DEST="${LAUNCH_AGENTS_DIR}/${PLIST_NAME}"
+BINARY="/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio"
+FIREWALL="/usr/libexec/ApplicationFirewall/socketfilterfw"
+
+# Verify binary exists
+if [[ ! -f "${BINARY}" ]]; then
+    echo "ERROR: binary not found at ${BINARY}" >&2
+    echo "Run 'cargo build --release' first." >&2
+    exit 1
+fi
+
+# Ensure LaunchAgents directory exists
+mkdir -p "${LAUNCH_AGENTS_DIR}"
+
+# Install plist
+echo "Installing ${PLIST_NAME} to ${LAUNCH_AGENTS_DIR}..."
+cp "${PLIST_SRC}" "${PLIST_DEST}"
+
+# Unload if already loaded (ignore errors if not loaded)
+launchctl unload "${PLIST_DEST}" 2>/dev/null || true
+
+# Load service
+echo "Loading service..."
+launchctl load "${PLIST_DEST}"
+
+# Add binary to macOS Application Firewall
+if [[ -x "${FIREWALL}" ]]; then
+    echo "Adding binary to firewall allowlist..."
+    sudo "${FIREWALL}" --add "${BINARY}"
+    sudo "${FIREWALL}" --unblockapp "${BINARY}"
+else
+    echo "WARNING: socketfilterfw not found, skipping firewall registration." >&2
+fi
+
+echo "Service installed and started."
+echo "Logs: /tmp/convergio-daemon.log"
+echo "Errors: /tmp/convergio-daemon.err"


### PR DESCRIPTION
## Summary

Fixes 3 critical issues discovered during the FIRST REAL agent spawn test:

### 1. Agent worktree gets a branch (not detached HEAD)
Before: `git worktree add --detach` → agent can commit but can't push/PR
After: `git worktree add -b agent/<name>` → agent can push and create PR

### 2. Agent output logged to files (not /dev/null)  
Before: stdout/stderr → /dev/null → silent failures
After: stdout → `agent.log`, stderr → `agent.err` in worktree

### 3. Health/metrics wiring in main.rs
Before: HealthRegistry and MetricsCollector created but EMPTY — no extensions registered
After: All 18 extensions registered via ExtHealthAdapter/ExtMetricAdapter
- `/api/health/deep` → 18 components with real status
- `/api/metrics` → 33 real metrics

Also includes cherry-picked Fase 38c work (launchd plist, install-service.sh, add-mesh-node.sh) produced by the spawned agent.

## Test plan
- [x] `cargo test --workspace` — 833 tests pass
- [x] `/api/health/deep` shows 18 components
- [x] `/api/metrics` shows 33 metrics
- [x] Mesh correctly shows "Degraded: no peers online"

🤖 Generated with [Claude Code](https://claude.com/claude-code)