### PR TITLE
feat(spawn): support external repos and custom instruction files

### DIFF
--- a/daemon/crates/convergio-agent-runtime/src/spawn_routes.rs
+++ b/daemon/crates/convergio-agent-runtime/src/spawn_routes.rs
@@ -45,6 +45,10 @@ struct SpawnBody {
     timeout_secs: u64,
     #[serde(default)]
     priority: i32,
+    /// Override repo root for spawning in external repos.
+    repo_override: Option<String>,
+    /// Override the instruction file name (default: TASK.md).
+    instruction_file: Option<String>,
 }
 
 fn default_tier() -> String {
@@ -61,7 +65,8 @@ async fn handle_spawn(
     State(state): State<Arc<SpawnState>>,
     Json(body): Json<SpawnBody>,
 ) -> Json<Value> {
-    let repo_root = std::path::Path::new(&state.repo_root);
+    let repo_path = body.repo_override.as_deref().unwrap_or(&state.repo_root);
+    let repo_root = std::path::Path::new(repo_path);
     let wt_name = format!("agent-{}", &body.agent_name);
 
     // 1. Register in DB
@@ -92,9 +97,11 @@ async fn handle_spawn(
         Err(e) => return Json(json!({"error": format!("worktree: {e}"), "agent_id": agent_id})),
     };
 
-    // 3. Write instructions
-    if let Err(e) = spawner::write_instructions(&workspace, &body.instructions) {
-        return Json(json!({"error": format!("instructions: {e}"), "agent_id": agent_id}));
+    // 3. Write instructions (skip if using a pre-existing instruction file)
+    if body.instruction_file.is_none() {
+        if let Err(e) = spawner::write_instructions(&workspace, &body.instructions) {
+            return Json(json!({"error": format!("instructions: {e}"), "agent_id": agent_id}));
+        }
     }
 
     // 4. Choose backend via tier
@@ -111,7 +118,13 @@ async fn handle_spawn(
         ("CONVERGIO_DAEMON_URL", state.daemon_url.as_str()),
         ("CONVERGIO_AGENT_ID", agent_id.as_str()),
     ];
-    let result = spawner::spawn_process(&workspace, &backend, &env_vars, body.timeout_secs);
+    let result = spawner::spawn_process(
+        &workspace,
+        &backend,
+        &env_vars,
+        body.timeout_secs,
+        body.instruction_file.as_deref(),
+    );
 
     match result {
         Ok(spawned) => {

--- a/daemon/crates/convergio-agent-runtime/src/spawner.rs
+++ b/daemon/crates/convergio-agent-runtime/src/spawner.rs
@@ -61,12 +61,13 @@ pub fn write_instructions(workspace: &Path, instructions: &str) -> RuntimeResult
 }
 
 /// Spawn the agent process in the workspace.
-/// `timeout_secs` reserved for future use (reaper handles actual timeout).
+/// `instruction_file` overrides the default "TASK.md" prompt target.
 pub fn spawn_process(
     workspace: &Path,
     backend: &SpawnBackend,
     env_vars: &[(&str, &str)],
     _timeout_secs: u64,
+    instruction_file: Option<&str>,
 ) -> RuntimeResult<SpawnedProcess> {
     let child = match backend {
         SpawnBackend::ClaudeCli { model } => {
@@ -80,7 +81,9 @@ pub fn spawn_process(
             // Learning: claude -p sometimes hangs after completing its task.
             // --max-turns caps conversation turns so the process exits reliably.
             cmd.args(["--max-turns", "50"]);
-            cmd.args(["-p", "Leggi TASK.md per le istruzioni. Poi inizia."]);
+            let target = instruction_file.unwrap_or("TASK.md");
+            let prompt = format!("Leggi {target} per le istruzioni. Poi inizia.");
+            cmd.args(["-p", &prompt]);
             cmd.current_dir(workspace);
             for (k, v) in env_vars {
                 cmd.env(k, v);


### PR DESCRIPTION
## Summary
- `repo_override` field in spawn body: agents can now be spawned in any git repo, not just convergio
- `instruction_file` field: use pre-existing instruction files (e.g. AGENT-SARA-UX.md) instead of writing TASK.md
- Skip TASK.md write when instruction_file is set

Root cause analysis of spawn issues:
- nohup works fine when each agent runs in its own subshell `(cd dir && nohup claude ...)`
- Previous failure: all agents in same shell, only last `cd` took effect
- Old ConvergioPlatform used tmux sessions — not applicable for launchd daemon
- Zombie detection already fixed with waitpid (PR #46)

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p convergio-agent-runtime` — 43 tests pass
- [ ] Smoke: spawn agent with `repo_override` pointing to convergio-frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)