### PR TITLE
feat(orchestrator): agent→plan lifecycle wiring (Fase 32b)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "hostname",
  "libc",
  "r2d2",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/daemon/crates/convergio-agent-runtime/Cargo.toml
+++ b/daemon/crates/convergio-agent-runtime/Cargo.toml
@@ -23,6 +23,7 @@ axum = { workspace = true }
 hostname = "0.4"
 dirs = { workspace = true }
 libc = "0.2"
+reqwest = { workspace = true }
 tempfile = { version = "3", optional = true }
 
 [dev-dependencies]

--- a/daemon/crates/convergio-agent-runtime/src/plan_task_update.rs
+++ b/daemon/crates/convergio-agent-runtime/src/plan_task_update.rs
@@ -1,0 +1,47 @@
+/// Update plan task status after agent completion.
+/// Reads task_id from art_agents, then calls the plan-db task/update API.
+pub fn update_plan_task(pool: &convergio_db::pool::ConnPool, agent_id: &str, status: &str) {
+    let task_id: Option<i64> = pool
+        .get()
+        .ok()
+        .and_then(|conn| {
+            conn.query_row(
+                "SELECT task_id FROM art_agents WHERE id = ?1",
+                rusqlite::params![agent_id],
+                |row| row.get(0),
+            )
+            .ok()
+        })
+        .flatten();
+
+    let Some(task_id) = task_id else {
+        tracing::debug!(agent_id, "no task_id linked — skipping plan update");
+        return;
+    };
+
+    tracing::info!(agent_id, task_id, status, "updating plan task status");
+
+    let body = serde_json::json!({
+        "task_id": task_id,
+        "status": status,
+        "executor_agent": agent_id,
+    });
+
+    let status_owned = status.to_string();
+    let url = "http://localhost:8420/api/plan-db/task/update";
+    tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        match client.post(url).json(&body).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!(task_id, status = status_owned.as_str(), "plan task updated");
+            }
+            Ok(resp) => {
+                let text = resp.text().await.unwrap_or_default();
+                tracing::warn!(task_id, "plan task update failed: {text}");
+            }
+            Err(e) => {
+                tracing::warn!(task_id, "plan task update HTTP error: {e}");
+            }
+        }
+    });
+}

--- a/daemon/crates/convergio-agent-runtime/src/spawn_monitor.rs
+++ b/daemon/crates/convergio-agent-runtime/src/spawn_monitor.rs
@@ -64,6 +64,11 @@ pub fn monitor_agent(
                     );
                 }
             }
+            // Update plan task status if agent was working on a plan task
+            update_plan_task(&pool, &agent_id, "submitted");
+        } else {
+            // Agent failed — mark task as failed too
+            update_plan_task(&pool, &agent_id, "failed");
         }
 
         // Log summary
@@ -212,3 +217,7 @@ fn resolve_gh_path() -> String {
     }
     "gh".into()
 }
+
+#[path = "plan_task_update.rs"]
+mod plan_task_update;
+use plan_task_update::update_plan_task;

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -64,6 +64,7 @@ impl Extension for OrchestratorExtension {
         let state = Arc::new(crate::plan_routes::PlanState {
             pool: self.pool.clone(),
             event_sink: sink.map(|s| (*s).clone()),
+            notify: self.notify.clone(),
         });
         let router = crate::scaffold::scaffold_routes()
             .merge(crate::plan_routes::plan_routes(Arc::clone(&state)))

--- a/daemon/crates/convergio-orchestrator/src/handlers.rs
+++ b/daemon/crates/convergio-orchestrator/src/handlers.rs
@@ -138,6 +138,25 @@ pub fn on_wave_validated(
 pub fn on_plan_done(pool: &ConnPool, notify: &Arc<Notify>, plan_id: i64) -> AliResult {
     let conn = pool.get()?;
 
+    // Mark plan as done in DB
+    conn.execute(
+        "UPDATE plans SET status = 'done', updated_at = datetime('now') WHERE id = ?1",
+        params![plan_id],
+    )?;
+
+    let plan_name: String = conn
+        .query_row(
+            "SELECT name FROM plans WHERE id = ?1",
+            params![plan_id],
+            |r| r.get(0),
+        )
+        .unwrap_or_else(|_| format!("Plan #{plan_id}"));
+
+    tracing::info!("ali: plan {plan_id} ({plan_name}) marked done");
+
+    // Send Telegram notification (fire-and-forget)
+    notify_plan_done(plan_id, &plan_name);
+
     let parent_id: Option<i64> = match conn.query_row(
         "SELECT parent_plan_id FROM plans WHERE id = ?1",
         params![plan_id],
@@ -159,6 +178,10 @@ pub fn on_plan_done(pool: &ConnPool, notify: &Arc<Notify>, plan_id: i64) -> AliR
 
     Ok(())
 }
+
+#[path = "handlers_notify.rs"]
+mod notify;
+use notify::notify_plan_done;
 
 pub async fn on_wave_ready(
     pool: &ConnPool,

--- a/daemon/crates/convergio-orchestrator/src/handlers_notify.rs
+++ b/daemon/crates/convergio-orchestrator/src/handlers_notify.rs
@@ -1,0 +1,35 @@
+/// Send Telegram notification when plan completes. Non-blocking, fire-and-forget.
+pub fn notify_plan_done(plan_id: i64, plan_name: &str) {
+    let token = match std::env::var("CONVERGIO_TELEGRAM_BOT_TOKEN") {
+        Ok(t) => t,
+        Err(_) => return, // Telegram not configured — skip silently
+    };
+    let chat_id = match std::env::var("CONVERGIO_TELEGRAM_CHAT_ID") {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let text = format!(
+        "\u{1f7e2} <b>Plan completed</b>\n\n{}\n\n<code>Plan #{}</code>",
+        html_escape(plan_name),
+        plan_id
+    );
+    tokio::spawn(async move {
+        let url = format!("https://api.telegram.org/bot{token}/sendMessage");
+        let payload = serde_json::json!({
+            "chat_id": chat_id,
+            "text": text,
+            "parse_mode": "HTML",
+        });
+        let client = reqwest::Client::new();
+        if let Err(e) = client.post(&url).json(&payload).send().await {
+            tracing::warn!("telegram notify failed for plan {plan_id}: {e}");
+        }
+    });
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}

--- a/daemon/crates/convergio-orchestrator/src/plan_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/plan_routes.rs
@@ -24,6 +24,7 @@ use convergio_types::events::DomainEventSink;
 pub struct PlanState {
     pub pool: ConnPool,
     pub event_sink: Option<Arc<dyn DomainEventSink>>,
+    pub notify: Arc<tokio::sync::Notify>,
 }
 
 pub fn plan_routes(state: Arc<PlanState>) -> Router {

--- a/daemon/crates/convergio-orchestrator/src/task_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/task_routes.rs
@@ -95,7 +95,83 @@ async fn handle_task_update(
     let refs: Vec<&dyn rusqlite::types::ToSql> = p.iter().map(|v| v.as_ref()).collect();
     match conn.execute(&sql, refs.as_slice()) {
         Ok(0) => Json(json!({"error": "task not found"})),
-        Ok(_) => Json(json!({"task_id": body.task_id, "updated": true})),
+        Ok(_) => {
+            // Emit lifecycle events when task reaches a terminal status
+            if let Some(ref new_status) = body.status {
+                if new_status == "done" || new_status == "submitted" {
+                    drop(conn);
+                    emit_task_lifecycle(&state, body.task_id);
+                }
+            }
+            Json(json!({"task_id": body.task_id, "updated": true}))
+        }
         Err(e) => Json(json!({"error": e.to_string()})),
     }
 }
+
+/// Emit IPC task_done (for reactor) and DomainEvent TaskCompleted (for SSE/UI).
+/// Handles its own DB connection to avoid holding the pool during IPC emit.
+fn emit_task_lifecycle(state: &PlanState, task_id: i64) {
+    let plan_id = {
+        let conn = match state.pool.get() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(task_id, "pool error in emit_task_lifecycle: {e}");
+                return;
+            }
+        };
+
+        // Look up plan_id for this task
+        let plan_id: Option<i64> = conn
+            .query_row(
+                "SELECT plan_id FROM tasks WHERE id = ?1",
+                rusqlite::params![task_id],
+                |row| row.get(0),
+            )
+            .ok();
+
+        let Some(plan_id) = plan_id else {
+            tracing::warn!(task_id, "task has no plan_id — skipping lifecycle emit");
+            return;
+        };
+
+        // Increment tasks_done counter on plan
+        let _ = conn.execute(
+            "UPDATE plans SET tasks_done = tasks_done + 1, updated_at = datetime('now') \
+             WHERE id = ?1",
+            rusqlite::params![plan_id],
+        );
+
+        plan_id
+        // conn dropped here — pool slot freed for IPC emit
+    };
+
+    // Emit IPC message to #orchestration → triggers reactor chain
+    if let Err(e) = crate::actions::emit(
+        &state.pool,
+        &state.notify,
+        "task_done",
+        &json!({"task_id": task_id.to_string(), "plan_id": plan_id}),
+    ) {
+        tracing::warn!(task_id, "failed to emit task_done IPC: {e}");
+    }
+
+    // Emit DomainEvent for SSE → UI
+    if let Some(ref sink) = state.event_sink {
+        sink.emit(convergio_types::events::make_event(
+            "orchestrator",
+            convergio_types::events::EventKind::TaskCompleted { task_id },
+            convergio_types::events::EventContext {
+                plan_id: Some(plan_id),
+                task_id: Some(task_id),
+                ..Default::default()
+            },
+        ));
+    }
+
+    tracing::info!(task_id, plan_id, "task lifecycle events emitted");
+}
+
+#[cfg(test)]
+#[path = "task_routes_tests.rs"]
+mod tests;

--- a/daemon/crates/convergio-orchestrator/src/task_routes_tests.rs
+++ b/daemon/crates/convergio-orchestrator/src/task_routes_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+fn setup() -> PlanState {
+    let pool = convergio_db::pool::create_memory_pool().unwrap();
+    let conn = pool.get().unwrap();
+    convergio_db::migration::ensure_registry(&conn).unwrap();
+    convergio_db::migration::apply_migrations(&conn, "ipc", &convergio_ipc::schema::migrations())
+        .unwrap();
+    convergio_db::migration::apply_migrations(&conn, "orchestrator", &crate::schema::migrations())
+        .unwrap();
+    drop(conn);
+    PlanState {
+        pool,
+        event_sink: None,
+        notify: Arc::new(Notify::new()),
+    }
+}
+
+fn seed_plan_and_task(state: &PlanState) {
+    let conn = state.pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO plans (id, project_id, name, tasks_done, tasks_total) \
+         VALUES (1, 'test', 'Test Plan', 0, 2)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO waves (id, wave_id, plan_id, name, status) \
+         VALUES (1, 1, 1, 'wave-1', 'in_progress')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO tasks (id, task_id, plan_id, wave_id, title, status) \
+         VALUES (1, 1, 1, 1, 'Task A', 'submitted')",
+        [],
+    )
+    .unwrap();
+}
+
+#[test]
+fn emit_task_lifecycle_increments_tasks_done() {
+    let state = setup();
+    seed_plan_and_task(&state);
+
+    emit_task_lifecycle(&state, 1);
+
+    let conn = state.pool.get().unwrap();
+    let tasks_done: i64 = conn
+        .query_row("SELECT tasks_done FROM plans WHERE id = 1", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(tasks_done, 1);
+}
+
+#[test]
+fn emit_task_lifecycle_emits_ipc_event() {
+    let state = setup();
+    seed_plan_and_task(&state);
+
+    emit_task_lifecycle(&state, 1);
+
+    let history = convergio_ipc::messaging::history(
+        &state.pool,
+        None,
+        Some(crate::reactor::CHANNEL),
+        10,
+        None,
+    )
+    .unwrap();
+    assert!(!history.is_empty(), "IPC message should be emitted");
+    assert!(
+        history[0].content.contains("task_done"),
+        "event type should be task_done"
+    );
+    assert!(
+        history[0].content.contains("\"plan_id\":1"),
+        "should include plan_id"
+    );
+}
+
+#[test]
+fn emit_task_lifecycle_skips_if_no_plan() {
+    let state = setup();
+    // No plan or task exists — should not panic
+    emit_task_lifecycle(&state, 999);
+}


### PR DESCRIPTION
## Summary

- **spawn_monitor.rs**: after push+PR, calls `POST /api/plan-db/task/update` with `status=submitted` (reads `task_id` from `art_agents`)
- **task_routes.rs**: when task status changes to `submitted`/`done`, emits IPC `task_done` to `#orchestration` channel (triggers reactor) + DomainEvent `TaskCompleted` (SSE → UI). Also increments `plans.tasks_done` counter.
- **handlers.rs**: `on_plan_done()` now marks plan as `done` in DB and sends Telegram notification (fire-and-forget) if `CONVERGIO_TELEGRAM_BOT_TOKEN` is configured.
- **PlanState**: gains `notify` field so task_routes can emit IPC events.
- New files: `plan_task_update.rs`, `handlers_notify.rs`, `task_routes_tests.rs` (split for 250-line limit)

### The loop that now closes

```
agent exits → monitor pushes + creates PR → monitor calls task/update
  → task_routes updates DB + emits IPC task_done
  → reactor: on_task_done() → wave_done → wave_validated → plan_done
  → on_plan_done() marks plan done + Telegram notify
  → DomainEvent TaskCompleted → SSE → UI updates in real-time
```

## Test plan

- [x] `cargo check --workspace` — compiles
- [x] `cargo test --workspace` — 839 tests pass, 0 failures
- [x] `cargo fmt --all` — formatted
- [x] 3 new tests: `emit_task_lifecycle_increments_tasks_done`, `emit_task_lifecycle_emits_ipc_event`, `emit_task_lifecycle_skips_if_no_plan`
- [ ] E2E smoke test: spawn agent with `task_id`, verify plan status updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)