### PR TITLE
fix(inference): clippy double_ended_iterator_last + unused imports

### DIFF
--- a/daemon/crates/convergio-inference/src/backend.rs
+++ b/daemon/crates/convergio-inference/src/backend.rs
@@ -58,7 +58,11 @@ pub async fn call_model(
         .map_err(|e| format!("http client: {e}"))?;
 
     // Ollama model name: strip provider prefix if present
-    let model_name = endpoint.name.split('/').next_back().unwrap_or(&endpoint.name);
+    let model_name = endpoint
+        .name
+        .split('/')
+        .next_back()
+        .unwrap_or(&endpoint.name);
 
     let url = format!("{}/v1/chat/completions", endpoint.url.trim_end_matches('/'));
 

--- a/daemon/crates/convergio-inference/src/backend.rs
+++ b/daemon/crates/convergio-inference/src/backend.rs
@@ -58,7 +58,7 @@ pub async fn call_model(
         .map_err(|e| format!("http client: {e}"))?;
 
     // Ollama model name: strip provider prefix if present
-    let model_name = endpoint.name.split('/').last().unwrap_or(&endpoint.name);
+    let model_name = endpoint.name.split('/').next_back().unwrap_or(&endpoint.name);
 
     let url = format!("{}/v1/chat/completions", endpoint.url.trim_end_matches('/'));
 
@@ -123,8 +123,8 @@ pub async fn call_model(
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
-    use crate::types::{InferenceTier, ModelProvider};
 
     #[test]
     fn model_name_strips_prefix() {

--- a/daemon/crates/convergio-server/src/config.rs
+++ b/daemon/crates/convergio-server/src/config.rs
@@ -67,9 +67,14 @@ pub fn write_default_config(path: &Path) -> io::Result<()> {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::sync::Mutex;
+
+    // Tests share CONVERGIO_CONFIG env var — must run sequentially.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn load_from_custom_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let dir = std::env::temp_dir().join("cvg-cfg-test");
         let _ = std::fs::create_dir_all(&dir);
         let path = dir.join("test.toml");
@@ -77,16 +82,17 @@ mod tests {
         writeln!(f, "[daemon]\nport = 9999").unwrap();
         std::env::set_var("CONVERGIO_CONFIG", path.to_str().unwrap());
         let cfg = load_config();
-        assert_eq!(cfg.daemon.port, 9999);
         std::env::remove_var("CONVERGIO_CONFIG");
         let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(cfg.daemon.port, 9999);
     }
 
     #[test]
     fn missing_file_returns_defaults() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("CONVERGIO_CONFIG", "/tmp/nonexistent.toml");
         let cfg = load_config();
-        assert_eq!(cfg.daemon.port, 8420);
         std::env::remove_var("CONVERGIO_CONFIG");
+        assert_eq!(cfg.daemon.port, 8420);
     }
 }


### PR DESCRIPTION
## Summary

- Use `next_back()` instead of `last()` on `Split` iterator (clippy 1.94 lint `double_ended_iterator_last`)
- Remove unused test imports (`InferenceTier`, `ModelProvider`)

Fixes CI failure on main after Rust 1.94 clippy update.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)