### PR TITLE
feat: close agent->plan lifecycle loop (fase 32b)

### DIFF
--- a/daemon/crates/convergio-ipc/src/sse.rs
+++ b/daemon/crates/convergio-ipc/src/sse.rs
@@ -94,6 +94,8 @@ impl convergio_types::events::DomainEventSink for EventBus {
             convergio_types::events::EventKind::PlanCreated { .. } => "plan_created",
             convergio_types::events::EventKind::TaskAssigned { .. } => "task_assigned",
             convergio_types::events::EventKind::TaskCompleted { .. } => "task_completed",
+            convergio_types::events::EventKind::PlanCompleted { .. } => "plan_completed",
+            convergio_types::events::EventKind::WaveCompleted { .. } => "wave_completed",
             convergio_types::events::EventKind::MessageSent { .. } => "message_sent",
             convergio_types::events::EventKind::DelegationStarted { .. } => "delegation_started",
             convergio_types::events::EventKind::AgentOnline { .. } => "agent_online",

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -78,14 +78,17 @@ impl Extension for OrchestratorExtension {
         Some(router)
     }
 
-    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+    fn on_start(&self, ctx: &AppContext) -> ExtResult<()> {
         tracing::info!("orchestrator: starting reactor, validator, reaper");
 
-        // Spawn Ali reactor
+        // Spawn Ali reactor with event sink for domain events
         let pool = self.pool.clone();
         let notify = self.notify.clone();
+        let sink = ctx
+            .get_arc::<Arc<dyn convergio_types::events::DomainEventSink>>()
+            .map(|s| (*s).clone());
         tokio::spawn(async move {
-            crate::reactor::run(pool, notify).await;
+            crate::reactor::run(pool, notify, sink).await;
         });
 
         // Spawn validator loop

--- a/daemon/crates/convergio-orchestrator/src/handlers.rs
+++ b/daemon/crates/convergio-orchestrator/src/handlers.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tokio::sync::Notify;
 
 use convergio_db::pool::ConnPool;
+use convergio_types::events::DomainEventSink;
 use rusqlite::params;
 
 use crate::actions;
@@ -56,9 +57,11 @@ pub fn on_task_done(
         return Ok(());
     };
 
+    // Count tasks not yet submitted/done — wave is ready for validation
+    // when all tasks reach at least "submitted"
     let pending: i64 = conn.query_row(
         "SELECT COUNT(*) FROM tasks WHERE plan_id = ?1 AND wave_id = ?2 \
-         AND status NOT IN ('done', 'cancelled', 'skipped')",
+         AND status NOT IN ('done', 'submitted', 'cancelled', 'skipped')",
         params![plan_id, wave_id],
         |row| row.get(0),
     )?;
@@ -95,10 +98,40 @@ pub fn on_wave_done(
 pub fn on_wave_validated(
     pool: &ConnPool,
     notify: &Arc<Notify>,
+    event_sink: &Option<Arc<dyn DomainEventSink>>,
     wave_id: i64,
     plan_id: i64,
 ) -> AliResult {
     let conn = pool.get()?;
+
+    // Promote submitted tasks to done (auto-validation until Thor is a service)
+    let promoted = conn.execute(
+        "UPDATE tasks SET status = 'done', completed_at = datetime('now') \
+         WHERE plan_id = ?1 AND wave_id = ?2 AND status = 'submitted'",
+        params![plan_id, wave_id],
+    )?;
+    if promoted > 0 {
+        tracing::info!("ali: promoted {promoted} submitted tasks to done in wave {wave_id}");
+    }
+
+    // Mark wave as done
+    conn.execute(
+        "UPDATE waves SET status = 'done', completed_at = datetime('now') \
+         WHERE id = ?1",
+        params![wave_id],
+    )?;
+
+    // Emit WaveCompleted domain event for SSE/UI
+    if let Some(ref sink) = event_sink {
+        sink.emit(convergio_types::events::make_event(
+            "orchestrator",
+            convergio_types::events::EventKind::WaveCompleted { wave_id, plan_id },
+            convergio_types::events::EventContext {
+                plan_id: Some(plan_id),
+                ..Default::default()
+            },
+        ));
+    }
 
     let next_wave: Option<i64> = match conn.query_row(
         "SELECT id FROM waves WHERE plan_id = ?1 AND id > ?2 AND status = 'pending' \
@@ -135,12 +168,18 @@ pub fn on_wave_validated(
     Ok(())
 }
 
-pub fn on_plan_done(pool: &ConnPool, notify: &Arc<Notify>, plan_id: i64) -> AliResult {
+pub fn on_plan_done(
+    pool: &ConnPool,
+    notify: &Arc<Notify>,
+    event_sink: &Option<Arc<dyn DomainEventSink>>,
+    plan_id: i64,
+) -> AliResult {
     let conn = pool.get()?;
 
     // Mark plan as done in DB
     conn.execute(
-        "UPDATE plans SET status = 'done', updated_at = datetime('now') WHERE id = ?1",
+        "UPDATE plans SET status = 'done', completed_at = datetime('now'), \
+         updated_at = datetime('now') WHERE id = ?1",
         params![plan_id],
     )?;
 
@@ -153,6 +192,21 @@ pub fn on_plan_done(pool: &ConnPool, notify: &Arc<Notify>, plan_id: i64) -> AliR
         .unwrap_or_else(|_| format!("Plan #{plan_id}"));
 
     tracing::info!("ali: plan {plan_id} ({plan_name}) marked done");
+
+    // Emit PlanCompleted domain event for SSE/UI
+    if let Some(ref sink) = event_sink {
+        sink.emit(convergio_types::events::make_event(
+            "orchestrator",
+            convergio_types::events::EventKind::PlanCompleted {
+                plan_id,
+                name: plan_name.clone(),
+            },
+            convergio_types::events::EventContext {
+                plan_id: Some(plan_id),
+                ..Default::default()
+            },
+        ));
+    }
 
     // Send Telegram notification (fire-and-forget)
     notify_plan_done(plan_id, &plan_name);
@@ -183,55 +237,6 @@ pub fn on_plan_done(pool: &ConnPool, notify: &Arc<Notify>, plan_id: i64) -> AliR
 mod notify;
 use notify::notify_plan_done;
 
-pub async fn on_wave_ready(
-    pool: &ConnPool,
-    notify: &Arc<Notify>,
-    wave_id: i64,
-    plan_id: i64,
-) -> AliResult {
-    let conn = pool.get()?;
-
-    conn.execute(
-        "UPDATE waves SET status='in_progress', started_at=datetime('now') WHERE id=?1",
-        params![wave_id],
-    )?;
-
-    let task_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM tasks WHERE plan_id=?1 AND wave_id=?2 AND status='pending'",
-        params![plan_id, wave_id],
-        |r| r.get(0),
-    )?;
-
-    tracing::info!(
-        "ali: wave {wave_id} starting with {task_count} pending tasks for plan {plan_id}"
-    );
-    actions::delegate_plan(pool, notify, plan_id).await
-}
-
-pub async fn on_delegation_failed(
-    pool: &ConnPool,
-    notify: &Arc<Notify>,
-    plan_id: i64,
-    failed_peer: &str,
-    reason: &str,
-) -> AliResult {
-    tracing::warn!("ali: delegation of plan {plan_id} to {failed_peer} failed: {reason}");
-
-    let alt_peer = actions::find_available_peer(Some(failed_peer)).await;
-
-    if let Some(peer) = alt_peer {
-        tracing::info!("ali: retrying plan {plan_id} on peer {peer}");
-        crate::executor::delegate_to_peer(pool, notify, plan_id, &peer).await
-    } else {
-        tracing::warn!("ali: no peers available for plan {plan_id}, requesting human");
-        actions::emit(
-            pool,
-            notify,
-            "need_human",
-            &serde_json::json!({
-                "plan_id": plan_id,
-                "reason": format!("delegation failed on {failed_peer}: {reason}, no alternative peers"),
-            }),
-        )
-    }
-}
+#[path = "handlers_delegation.rs"]
+mod delegation;
+pub use delegation::{on_delegation_failed, on_wave_ready};

--- a/daemon/crates/convergio-orchestrator/src/handlers_delegation.rs
+++ b/daemon/crates/convergio-orchestrator/src/handlers_delegation.rs
@@ -1,0 +1,64 @@
+// Handlers for wave execution and delegation.
+
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+use convergio_db::pool::ConnPool;
+use rusqlite::params;
+
+use crate::actions;
+
+type AliResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+pub async fn on_wave_ready(
+    pool: &ConnPool,
+    notify: &Arc<Notify>,
+    wave_id: i64,
+    plan_id: i64,
+) -> AliResult {
+    let conn = pool.get()?;
+
+    conn.execute(
+        "UPDATE waves SET status='in_progress', started_at=datetime('now') WHERE id=?1",
+        params![wave_id],
+    )?;
+
+    let task_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM tasks WHERE plan_id=?1 AND wave_id=?2 AND status='pending'",
+        params![plan_id, wave_id],
+        |r| r.get(0),
+    )?;
+
+    tracing::info!(
+        "ali: wave {wave_id} starting with {task_count} pending tasks for plan {plan_id}"
+    );
+    actions::delegate_plan(pool, notify, plan_id).await
+}
+
+pub async fn on_delegation_failed(
+    pool: &ConnPool,
+    notify: &Arc<Notify>,
+    plan_id: i64,
+    failed_peer: &str,
+    reason: &str,
+) -> AliResult {
+    tracing::warn!("ali: delegation of plan {plan_id} to {failed_peer} failed: {reason}");
+
+    let alt_peer = actions::find_available_peer(Some(failed_peer)).await;
+
+    if let Some(peer) = alt_peer {
+        tracing::info!("ali: retrying plan {plan_id} on peer {peer}");
+        crate::executor::delegate_to_peer(pool, notify, plan_id, &peer).await
+    } else {
+        tracing::warn!("ali: no peers available for plan {plan_id}, requesting human");
+        actions::emit(
+            pool,
+            notify,
+            "need_human",
+            &serde_json::json!({
+                "plan_id": plan_id,
+                "reason": format!("delegation failed on {failed_peer}: {reason}, no alternative peers"),
+            }),
+        )
+    }
+}

--- a/daemon/crates/convergio-orchestrator/src/reactor.rs
+++ b/daemon/crates/convergio-orchestrator/src/reactor.rs
@@ -5,13 +5,18 @@ use tokio::sync::Notify;
 
 use convergio_db::pool::ConnPool;
 use convergio_ipc::messaging;
+use convergio_types::events::DomainEventSink;
 
 use crate::handlers;
 
 pub const ALI_AGENT: &str = "ali-orchestrator";
 pub const CHANNEL: &str = "#orchestration";
 
-pub async fn run(pool: ConnPool, notify: Arc<Notify>) {
+pub async fn run(
+    pool: ConnPool,
+    notify: Arc<Notify>,
+    event_sink: Option<Arc<dyn DomainEventSink>>,
+) {
     loop {
         let msgs = messaging::receive_wait(
             &pool,
@@ -30,7 +35,7 @@ pub async fn run(pool: ConnPool, notify: Arc<Notify>) {
                     if msg.from_agent == ALI_AGENT {
                         continue;
                     }
-                    if let Err(e) = handle_message(&pool, &notify, msg).await {
+                    if let Err(e) = handle_message(&pool, &notify, &event_sink, msg).await {
                         tracing::error!("ali: handler error for msg {}: {e}", msg.id);
                         emit_error(&pool, &notify, &e.to_string());
                     }
@@ -47,6 +52,7 @@ pub async fn run(pool: ConnPool, notify: Arc<Notify>) {
 async fn handle_message(
     pool: &ConnPool,
     notify: &Arc<Notify>,
+    event_sink: &Option<Arc<dyn DomainEventSink>>,
     msg: &convergio_ipc::types::MessageInfo,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let payload: serde_json::Value = serde_json::from_str(&msg.content)?;
@@ -78,17 +84,17 @@ async fn handle_message(
                 handlers::on_wave_done(pool, notify, wave_id, plan_id)?;
             } else {
                 tracing::info!("ali: auto-validating wave {wave_id} (Thor not yet a service)");
-                handlers::on_wave_validated(pool, notify, wave_id, plan_id)?;
+                handlers::on_wave_validated(pool, notify, event_sink, wave_id, plan_id)?;
             }
         }
         "wave_validated" => {
             let wave_id = require_i64(&payload, "wave_id")?;
             let plan_id = require_i64(&payload, "plan_id")?;
-            handlers::on_wave_validated(pool, notify, wave_id, plan_id)?;
+            handlers::on_wave_validated(pool, notify, event_sink, wave_id, plan_id)?;
         }
         "plan_done" => {
             let plan_id = require_i64(&payload, "plan_id")?;
-            handlers::on_plan_done(pool, notify, plan_id)?;
+            handlers::on_plan_done(pool, notify, event_sink, plan_id)?;
         }
         "wave_ready" => {
             let wave_id = require_i64(&payload, "wave_id")?;

--- a/daemon/crates/convergio-types/src/events.rs
+++ b/daemon/crates/convergio-types/src/events.rs
@@ -50,6 +50,14 @@ pub enum EventKind {
     TaskCompleted {
         task_id: i64,
     },
+    PlanCompleted {
+        plan_id: i64,
+        name: String,
+    },
+    WaveCompleted {
+        wave_id: i64,
+        plan_id: i64,
+    },
 
     // Communication (visible in real-time UI)
     MessageSent {


### PR DESCRIPTION
## Summary
- **Root cause fix**: `on_task_done` SQL excluded `done/cancelled/skipped` but NOT `submitted` — wave never completed
- Auto-promote submitted tasks to done on wave validation (auto-validation until Thor is a service)
- Set wave/plan `completed_at` timestamps properly
- Add `PlanCompleted` and `WaveCompleted` domain events for SSE/UI visibility
- Thread event_sink through reactor -> handlers for domain event emission

## The bug
```
agent completes -> monitor sets task "submitted" -> reactor counts pending
-> "submitted" NOT IN ('done','cancelled','skipped') -> pending > 0 always
-> wave NEVER advances -> plan stays "todo" forever
```

## The fix
```
status NOT IN ('done', 'submitted', 'cancelled', 'skipped')
```

Plus: wave validation promotes submitted -> done, marks wave done, emits domain events.

## Files changed (6)
- `convergio-types/events.rs` — add PlanCompleted, WaveCompleted events
- `convergio-ipc/sse.rs` — map new events in EventBus
- `convergio-orchestrator/handlers.rs` — fix pending count, add event emission
- `convergio-orchestrator/handlers_delegation.rs` — extracted (250 line limit)
- `convergio-orchestrator/reactor.rs` — thread event_sink parameter
- `convergio-orchestrator/ext.rs` — pass event_sink to reactor on_start

## Test plan
- [x] `cargo check --workspace` — compiles
- [x] `cargo test --workspace` — 849 tests pass, 0 failures
- [x] `cargo fmt --all` — formatted
- [ ] Smoke test: spawn agent with task_id -> verify plan advances to done

🤖 Generated with [Claude Code](https://claude.com/claude-code)