### PR TITLE
fix: resolve 7 depgraph validation errors

### DIFF
--- a/daemon/crates/convergio-db/src/ext.rs
+++ b/daemon/crates/convergio-db/src/ext.rs
@@ -1,0 +1,46 @@
+//! DbExtension — provides the `db-pool` capability to the depgraph.
+//!
+//! The database pool is infrastructure, not a service with routes.
+//! This extension exists solely to declare the `db-pool` capability
+//! so that modules depending on it pass depgraph validation.
+
+use convergio_types::extension::{Extension, Health};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+/// Minimal extension that declares the `db-pool` capability.
+pub struct DbExtension;
+
+impl Extension for DbExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-db".into(),
+            description: "SQLite connection pool and migration runner".into(),
+            version: "1.0.0".into(),
+            kind: ModuleKind::Core,
+            provides: vec![Capability {
+                name: "db-pool".into(),
+                version: "1.0.0".into(),
+                description: "r2d2 SQLite connection pool".into(),
+            }],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn health(&self) -> Health {
+        Health::Ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_provides_db_pool() {
+        let ext = DbExtension;
+        let m = ext.manifest();
+        assert_eq!(m.id, "convergio-db");
+        assert!(m.provides.iter().any(|c| c.name == "db-pool"));
+    }
+}

--- a/daemon/crates/convergio-db/src/lib.rs
+++ b/daemon/crates/convergio-db/src/lib.rs
@@ -4,6 +4,9 @@
 //! tracks applied versions in `_schema_registry`.
 
 pub mod core_tables;
+pub mod ext;
 pub mod helpers;
 pub mod migration;
 pub mod pool;
+
+pub use ext::DbExtension;

--- a/daemon/crates/convergio-ipc/src/ext.rs
+++ b/daemon/crates/convergio-ipc/src/ext.rs
@@ -84,22 +84,22 @@ impl Extension for IpcExtension {
         Manifest {
             id: "convergio-ipc".into(),
             description: "Message bus, SSE streaming, agent registry".into(),
-            version: "0.1.0".into(),
+            version: "1.0.0".into(),
             kind: ModuleKind::Core,
             provides: vec![
                 Capability {
                     name: "ipc-bus".into(),
-                    version: "0.1.0".into(),
+                    version: "1.0.0".into(),
                     description: "Agent-to-agent messaging with channels".into(),
                 },
                 Capability {
                     name: "sse-events".into(),
-                    version: "0.1.0".into(),
+                    version: "1.0.0".into(),
                     description: "Real-time event streaming via SSE".into(),
                 },
                 Capability {
                     name: "agent-registry".into(),
-                    version: "0.1.0".into(),
+                    version: "1.0.0".into(),
                     description: "Agent registration and discovery".into(),
                 },
             ],

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -20,6 +20,7 @@ fn register_extensions(
 
     vec![
         // Infrastructure
+        Arc::new(convergio_db::DbExtension),
         Arc::new(convergio_ipc::IpcExtension::with_bus(
             pool.clone(),
             event_bus,
@@ -185,8 +186,7 @@ async fn main() {
         }
     }
 
-    // 9. Build router
-    // Dev mode: enable localhost bypass when no auth token is configured
+    // 9. Build router — dev mode when no auth token configured
     let dev_mode = std::env::var("CONVERGIO_AUTH_TOKEN")
         .map(|v| v.is_empty())
         .unwrap_or(true);


### PR DESCRIPTION
## Summary
- Add `DbExtension` in convergio-db to provide `db-pool` capability (v1.0.0)
- Bump convergio-ipc capabilities (`ipc-bus`, `sse-events`, `agent-registry`) from 0.1.0 to 1.0.0
- Register `DbExtension` in main.rs

Resolves all 7 depgraph validation errors (5 MissingDependency + 2 SemVerMismatch).

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test --workspace` — 851 tests, 0 failures
- [ ] Rebuild daemon, verify `/api/depgraph/validate` returns `valid: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)