### PR TITLE
feat: node capability registry (fase 37b)

### DIFF
--- a/daemon/crates/convergio-mesh/src/capability_registry.rs
+++ b/daemon/crates/convergio-mesh/src/capability_registry.rs
@@ -1,0 +1,237 @@
+//! Capability registry: CRUD and query operations on node_capabilities.
+
+use rusqlite::{params, Connection};
+use std::collections::HashMap;
+
+use crate::capability_types::{CapabilityMatch, CapabilityQuery, NodeCapabilities, NodeCapability};
+
+/// Upsert capabilities for a peer into the node_capabilities table.
+pub fn register_capabilities(
+    conn: &Connection,
+    peer_name: &str,
+    caps: &[NodeCapability],
+) -> Result<(), rusqlite::Error> {
+    for cap in caps {
+        let tags_json = serde_json::to_string(&cap.tags).unwrap_or_else(|_| "[]".into());
+        let meta_json = serde_json::to_string(&cap.metadata).unwrap_or_else(|_| "{}".into());
+        conn.execute(
+            "INSERT INTO node_capabilities \
+             (peer_name, capability_name, capability_version, tags_json, metadata_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5) \
+             ON CONFLICT(peer_name, capability_name) DO UPDATE SET \
+             capability_version = excluded.capability_version, \
+             tags_json = excluded.tags_json, \
+             metadata_json = excluded.metadata_json, \
+             updated_at = datetime('now')",
+            params![peer_name, cap.name, cap.version, tags_json, meta_json],
+        )?;
+    }
+    Ok(())
+}
+
+/// Find peers whose capabilities match the required tags, sorted by score.
+pub fn query_capable_peers(
+    conn: &Connection,
+    query: &CapabilityQuery,
+) -> Result<Vec<CapabilityMatch>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT peer_name, capability_name, tags_json, capability_version \
+         FROM node_capabilities",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+        ))
+    })?;
+
+    let required: Vec<String> = query.required_tags.iter().map(|t| t.to_string()).collect();
+    let total_required = required.len() as f64;
+    if total_required == 0.0 {
+        return Ok(vec![]);
+    }
+
+    let mut peer_matches: HashMap<String, (f64, Vec<String>)> = HashMap::new();
+    for row in rows {
+        let (peer, cap_name, tags_str, version) = row?;
+        if let Some(ref min_ver) = query.min_version {
+            if &version < min_ver {
+                continue;
+            }
+        }
+        let tags: Vec<String> = serde_json::from_str(&tags_str).unwrap_or_default();
+        let matched_tags: Vec<&String> = required.iter().filter(|rt| tags.contains(rt)).collect();
+        if !matched_tags.is_empty() {
+            let entry = peer_matches.entry(peer).or_insert((0.0, vec![]));
+            entry.0 += matched_tags.len() as f64;
+            entry.1.push(cap_name);
+        }
+    }
+
+    let mut results: Vec<CapabilityMatch> = peer_matches
+        .into_iter()
+        .map(|(peer, (score, caps))| CapabilityMatch {
+            peer_name: peer,
+            score: score / total_required,
+            matched_capabilities: caps,
+        })
+        .collect();
+    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    Ok(results)
+}
+
+/// Get all capabilities for a specific peer.
+pub fn get_peer_capabilities(
+    conn: &Connection,
+    peer_name: &str,
+) -> Result<Vec<NodeCapability>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT capability_name, capability_version, tags_json, metadata_json \
+         FROM node_capabilities WHERE peer_name = ?1",
+    )?;
+    let rows = stmt.query_map(params![peer_name], |row| {
+        let tags: Vec<String> = serde_json::from_str(&row.get::<_, String>(2)?).unwrap_or_default();
+        let metadata: serde_json::Value =
+            serde_json::from_str(&row.get::<_, String>(3)?).unwrap_or_default();
+        Ok(NodeCapability {
+            name: row.get(0)?,
+            version: row.get(1)?,
+            tags,
+            metadata,
+        })
+    })?;
+    rows.collect()
+}
+
+/// Remove all capabilities for a peer.
+pub fn remove_peer_capabilities(conn: &Connection, peer_name: &str) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "DELETE FROM node_capabilities WHERE peer_name = ?1",
+        params![peer_name],
+    )?;
+    Ok(())
+}
+
+/// List all capabilities grouped by peer.
+pub fn list_all_capabilities(conn: &Connection) -> Result<Vec<NodeCapabilities>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT peer_name, capability_name, capability_version, \
+         tags_json, metadata_json, updated_at \
+         FROM node_capabilities ORDER BY peer_name, capability_name",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let tags: Vec<String> = serde_json::from_str(&row.get::<_, String>(3)?).unwrap_or_default();
+        let metadata: serde_json::Value =
+            serde_json::from_str(&row.get::<_, String>(4)?).unwrap_or_default();
+        Ok((
+            row.get::<_, String>(0)?,
+            NodeCapability {
+                name: row.get(1)?,
+                version: row.get(2)?,
+                tags,
+                metadata,
+            },
+            row.get::<_, String>(5)?,
+        ))
+    })?;
+
+    let mut map: HashMap<String, (Vec<NodeCapability>, String)> = HashMap::new();
+    for row in rows {
+        let (peer, cap, updated) = row?;
+        let entry = map.entry(peer).or_insert((vec![], updated.clone()));
+        entry.0.push(cap);
+        if updated > entry.1 {
+            entry.1 = updated;
+        }
+    }
+
+    Ok(map
+        .into_iter()
+        .map(|(peer, (caps, updated))| NodeCapabilities {
+            peer_name: peer,
+            capabilities: caps,
+            last_updated: updated,
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability_types::CapabilityTag;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "mesh", &crate::schema::migrations())
+            .unwrap();
+        conn
+    }
+
+    fn sample_cap(name: &str, tags: Vec<&str>) -> NodeCapability {
+        NodeCapability {
+            name: name.into(),
+            version: "1.0.0".into(),
+            tags: tags.into_iter().map(String::from).collect(),
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[test]
+    fn register_and_get() {
+        let conn = setup_db();
+        let caps = vec![sample_cap("llm", vec!["gpu", "inference"])];
+        register_capabilities(&conn, "darwin-m4", &caps).unwrap();
+        let result = get_peer_capabilities(&conn, "darwin-m4").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "llm");
+    }
+
+    #[test]
+    fn upsert_overwrites() {
+        let conn = setup_db();
+        let v1 = vec![sample_cap("llm", vec!["gpu"])];
+        register_capabilities(&conn, "darwin-m4", &v1).unwrap();
+        let v2 = vec![NodeCapability {
+            name: "llm".into(),
+            version: "2.0.0".into(),
+            tags: vec!["gpu".into(), "inference".into()],
+            metadata: serde_json::json!({}),
+        }];
+        register_capabilities(&conn, "darwin-m4", &v2).unwrap();
+        let result = get_peer_capabilities(&conn, "darwin-m4").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].version, "2.0.0");
+    }
+
+    #[test]
+    fn query_matches() {
+        let conn = setup_db();
+        let caps_m4 = [sample_cap("llm", vec!["gpu", "inference"])];
+        let caps_a100 = [sample_cap("training", vec!["gpu", "compute"])];
+        register_capabilities(&conn, "darwin-m4", &caps_m4).unwrap();
+        register_capabilities(&conn, "linux-a100", &caps_a100).unwrap();
+        let query = CapabilityQuery {
+            required_tags: vec![CapabilityTag::Gpu, CapabilityTag::Inference],
+            min_version: None,
+        };
+        let matches = query_capable_peers(&conn, &query).unwrap();
+        assert_eq!(matches.len(), 2);
+        assert!(matches[0].score > matches[1].score);
+    }
+
+    #[test]
+    fn remove_and_list() {
+        let conn = setup_db();
+        register_capabilities(&conn, "darwin-m4", &[sample_cap("llm", vec!["gpu"])]).unwrap();
+        register_capabilities(&conn, "linux-a100", &[sample_cap("t", vec!["compute"])]).unwrap();
+        assert_eq!(list_all_capabilities(&conn).unwrap().len(), 2);
+        remove_peer_capabilities(&conn, "darwin-m4").unwrap();
+        assert!(get_peer_capabilities(&conn, "darwin-m4")
+            .unwrap()
+            .is_empty());
+        assert_eq!(list_all_capabilities(&conn).unwrap().len(), 1);
+    }
+}

--- a/daemon/crates/convergio-mesh/src/capability_routes.rs
+++ b/daemon/crates/convergio-mesh/src/capability_routes.rs
@@ -1,0 +1,106 @@
+//! HTTP API routes for the node capability registry.
+//!
+//! - POST   /api/mesh/capabilities/:peer_name  — register capabilities
+//! - GET    /api/mesh/capabilities              — list all capabilities
+//! - GET    /api/mesh/capabilities/:peer_name   — get peer capabilities
+//! - DELETE /api/mesh/capabilities/:peer_name   — remove peer capabilities
+//! - POST   /api/mesh/capabilities/query        — find capable peers
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use serde_json::json;
+
+use convergio_db::pool::ConnPool;
+
+use crate::capability_registry;
+use crate::capability_types::{CapabilityQuery, NodeCapability};
+
+struct CapState {
+    pool: ConnPool,
+}
+
+pub fn capability_routes(pool: ConnPool) -> Router {
+    let state = Arc::new(CapState { pool });
+    Router::new()
+        .route("/api/mesh/capabilities/query", post(handle_query))
+        .route(
+            "/api/mesh/capabilities/:peer_name",
+            post(handle_register)
+                .get(handle_get_peer)
+                .delete(handle_delete_peer),
+        )
+        .route("/api/mesh/capabilities", get(handle_list_all))
+        .with_state(state)
+}
+
+async fn handle_register(
+    State(state): State<Arc<CapState>>,
+    Path(peer_name): Path<String>,
+    Json(caps): Json<Vec<NodeCapability>>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match capability_registry::register_capabilities(&conn, &peer_name, &caps) {
+        Ok(()) => Json(json!({"status": "ok", "registered": caps.len()})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_list_all(State(state): State<Arc<CapState>>) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match capability_registry::list_all_capabilities(&conn) {
+        Ok(all) => Json(json!(all)),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_get_peer(
+    State(state): State<Arc<CapState>>,
+    Path(peer_name): Path<String>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match capability_registry::get_peer_capabilities(&conn, &peer_name) {
+        Ok(caps) => Json(json!(caps)),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_delete_peer(
+    State(state): State<Arc<CapState>>,
+    Path(peer_name): Path<String>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match capability_registry::remove_peer_capabilities(&conn, &peer_name) {
+        Ok(()) => Json(json!({"status": "ok"})),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn handle_query(
+    State(state): State<Arc<CapState>>,
+    Json(query): Json<CapabilityQuery>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match capability_registry::query_capable_peers(&conn, &query) {
+        Ok(matches) => Json(json!(matches)),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}

--- a/daemon/crates/convergio-mesh/src/capability_types.rs
+++ b/daemon/crates/convergio-mesh/src/capability_types.rs
@@ -1,0 +1,142 @@
+//! Types for the node capability registry.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// A single capability declared by a node.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NodeCapability {
+    pub name: String,
+    pub version: String,
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+/// Well-known capability tags for routing decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityTag {
+    Gpu,
+    Voice,
+    Compute,
+    Storage,
+    HighMemory,
+    LowLatency,
+    Inference,
+    CodeExecution,
+}
+
+impl fmt::Display for CapabilityTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Gpu => "gpu",
+            Self::Voice => "voice",
+            Self::Compute => "compute",
+            Self::Storage => "storage",
+            Self::HighMemory => "high_memory",
+            Self::LowLatency => "low_latency",
+            Self::Inference => "inference",
+            Self::CodeExecution => "code_execution",
+        };
+        f.write_str(s)
+    }
+}
+
+impl FromStr for CapabilityTag {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gpu" => Ok(Self::Gpu),
+            "voice" => Ok(Self::Voice),
+            "compute" => Ok(Self::Compute),
+            "storage" => Ok(Self::Storage),
+            "high_memory" => Ok(Self::HighMemory),
+            "low_latency" => Ok(Self::LowLatency),
+            "inference" => Ok(Self::Inference),
+            "code_execution" => Ok(Self::CodeExecution),
+            _ => Err(format!("unknown capability tag: {s}")),
+        }
+    }
+}
+
+/// All capabilities for a single peer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NodeCapabilities {
+    pub peer_name: String,
+    pub capabilities: Vec<NodeCapability>,
+    pub last_updated: String,
+}
+
+/// Query to find peers with specific capability tags.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityQuery {
+    pub required_tags: Vec<CapabilityTag>,
+    #[serde(default)]
+    pub min_version: Option<String>,
+}
+
+/// Result of a capability query: peer with match score.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityMatch {
+    pub peer_name: String,
+    pub score: f64,
+    pub matched_capabilities: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_tag_display_and_parse() {
+        let tags = [
+            CapabilityTag::Gpu,
+            CapabilityTag::Voice,
+            CapabilityTag::Compute,
+            CapabilityTag::Storage,
+            CapabilityTag::HighMemory,
+            CapabilityTag::LowLatency,
+            CapabilityTag::Inference,
+            CapabilityTag::CodeExecution,
+        ];
+        for tag in &tags {
+            let s = tag.to_string();
+            let parsed: CapabilityTag = s.parse().unwrap();
+            assert_eq!(*tag, parsed);
+        }
+    }
+
+    #[test]
+    fn capability_tag_unknown_fails() {
+        let result = "unknown_tag".parse::<CapabilityTag>();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn node_capability_serde_roundtrip() {
+        let cap = NodeCapability {
+            name: "llm-inference".into(),
+            version: "2.1.0".into(),
+            tags: vec!["gpu".into(), "inference".into()],
+            metadata: serde_json::json!({"model": "claude-opus"}),
+        };
+        let json = serde_json::to_string(&cap).unwrap();
+        let parsed: NodeCapability = serde_json::from_str(&json).unwrap();
+        assert_eq!(cap, parsed);
+    }
+
+    #[test]
+    fn capability_query_serde_roundtrip() {
+        let query = CapabilityQuery {
+            required_tags: vec![CapabilityTag::Gpu, CapabilityTag::Inference],
+            min_version: Some("1.0.0".into()),
+        };
+        let json = serde_json::to_string(&query).unwrap();
+        let parsed: CapabilityQuery = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.required_tags.len(), 2);
+        assert_eq!(parsed.min_version, Some("1.0.0".into()));
+    }
+}

--- a/daemon/crates/convergio-mesh/src/ext.rs
+++ b/daemon/crates/convergio-mesh/src/ext.rs
@@ -77,6 +77,11 @@ impl Extension for MeshExtension {
                     version: "0.1.0".into(),
                     description: "Remote task delegation progress".into(),
                 },
+                Capability {
+                    name: "node-capabilities".into(),
+                    version: "1.0.0".into(),
+                    description: "Node capability registry for routing".into(),
+                },
             ],
             requires: vec![Dependency {
                 capability: "db-pool".into(),
@@ -91,7 +96,9 @@ impl Extension for MeshExtension {
         let state = std::sync::Arc::new(crate::routes::MeshState {
             pool: self.pool.clone(),
         });
-        Some(crate::routes::mesh_routes(state))
+        let base = crate::routes::mesh_routes(state);
+        let cap_routes = crate::capability_routes::capability_routes(self.pool.clone());
+        Some(base.merge(cap_routes))
     }
 
     fn migrations(&self) -> Vec<Migration> {

--- a/daemon/crates/convergio-mesh/src/lib.rs
+++ b/daemon/crates/convergio-mesh/src/lib.rs
@@ -4,6 +4,9 @@
 //! host_heartbeats, mesh_peer_state, coordinator_events, delegation_progress.
 
 pub mod auth;
+pub mod capability_registry;
+pub mod capability_routes;
+pub mod capability_types;
 pub mod convergence;
 pub mod delegation;
 pub mod error;

--- a/daemon/crates/convergio-mesh/src/schema.rs
+++ b/daemon/crates/convergio-mesh/src/schema.rs
@@ -73,6 +73,26 @@ CREATE INDEX IF NOT EXISTS idx_delegation_id
     ON delegation_progress(delegation_id);
 ",
         },
+        Migration {
+            version: 3,
+            description: "node capability registry",
+            up: "
+CREATE TABLE IF NOT EXISTS node_capabilities (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    peer_name           TEXT NOT NULL,
+    capability_name     TEXT NOT NULL,
+    capability_version  TEXT NOT NULL DEFAULT '1.0.0',
+    tags_json           TEXT NOT NULL DEFAULT '[]',
+    metadata_json       TEXT NOT NULL DEFAULT '{}',
+    updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(peer_name, capability_name)
+);
+CREATE INDEX IF NOT EXISTS idx_node_cap_peer
+    ON node_capabilities(peer_name);
+CREATE INDEX IF NOT EXISTS idx_node_cap_name
+    ON node_capabilities(capability_name);
+",
+        },
     ]
 }
 
@@ -86,7 +106,7 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         convergio_db::migration::ensure_registry(&conn).unwrap();
         let applied = convergio_db::migration::apply_migrations(&conn, "mesh", &migrations());
-        assert_eq!(applied.unwrap(), 2);
+        assert_eq!(applied.unwrap(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `capability_types.rs`: NodeCapability, CapabilityTag enum (gpu, voice, compute, etc.)
- Add `capability_registry.rs`: register, query, get, remove, list capabilities per peer
- Add `capability_routes.rs`: 5 HTTP endpoints under `/api/mesh/capabilities`
- New migration v3: `node_capabilities` table with UNIQUE constraint
- 47 tests passing

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test --workspace` — all pass
- [ ] Smoke test: POST capabilities, GET, query by tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)