### PR TITLE
feat: add convergio-file-transport crate (fase 31)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "convergio-db",
  "convergio-depgraph",
  "convergio-evidence",
+ "convergio-file-transport",
  "convergio-http-bridge",
  "convergio-inference",
  "convergio-ipc",
@@ -554,6 +555,22 @@ dependencies = [
  "chrono",
  "convergio-db",
  "convergio-orchestrator",
+ "convergio-telemetry",
+ "convergio-types",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "convergio-file-transport"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "convergio-db",
  "convergio-telemetry",
  "convergio-types",
  "rusqlite",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/convergio-multitenancy",
     "crates/convergio-evidence",
     "crates/convergio-observatory",
+    "crates/convergio-file-transport",
 ]
 
 [package]
@@ -64,6 +65,7 @@ convergio-backup = { path = "crates/convergio-backup" }
 convergio-multitenancy = { path = "crates/convergio-multitenancy" }
 convergio-evidence = { path = "crates/convergio-evidence" }
 convergio-observatory = { path = "crates/convergio-observatory" }
+convergio-file-transport = { path = "crates/convergio-file-transport" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 dirs = { workspace = true }

--- a/daemon/crates/convergio-file-transport/Cargo.toml
+++ b/daemon/crates/convergio-file-transport/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "convergio-file-transport"
+description = "Rsync-based file transport between mesh nodes"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
+convergio-telemetry = { path = "../convergio-telemetry" }
+tracing = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+axum = { workspace = true }
+rusqlite = { workspace = true }
+chrono = { workspace = true }

--- a/daemon/crates/convergio-file-transport/src/ext.rs
+++ b/daemon/crates/convergio-file-transport/src/ext.rs
@@ -1,0 +1,145 @@
+//! FileTransportExtension — impl Extension for file transport.
+
+use convergio_db::pool::ConnPool;
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric, Migration};
+use convergio_types::manifest::{Capability, Dependency, Manifest, ModuleKind};
+
+/// Extension entry point for rsync-based file transport.
+pub struct FileTransportExtension {
+    pool: ConnPool,
+}
+
+impl FileTransportExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl Default for FileTransportExtension {
+    fn default() -> Self {
+        let pool = convergio_db::pool::create_memory_pool().expect("in-memory pool for default");
+        Self { pool }
+    }
+}
+
+impl Extension for FileTransportExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-file-transport".to_string(),
+            description: "Rsync-based file transport between mesh nodes".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![Capability {
+                name: "file-transport".to_string(),
+                version: "1.0.0".to_string(),
+                description: "Push/pull files between mesh peers via rsync".to_string(),
+            }],
+            requires: vec![Dependency {
+                capability: "db-pool".to_string(),
+                version_req: ">=1.0.0".to_string(),
+                required: true,
+            }],
+            agent_tools: vec![],
+        }
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::routes::file_transport_routes(self.pool.clone()))
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("file-transport: extension started");
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match self.pool.get() {
+            Ok(conn) => {
+                let ok = conn
+                    .query_row("SELECT COUNT(*) FROM file_transfers", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
+                    .is_ok();
+                if ok {
+                    Health::Ok
+                } else {
+                    Health::Degraded {
+                        reason: "file_transfers table inaccessible".into(),
+                    }
+                }
+            }
+            Err(e) => Health::Down {
+                reason: format!("pool error: {e}"),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(_) => return vec![],
+        };
+        let mut metrics = Vec::new();
+        if let Ok(n) = conn.query_row("SELECT COUNT(*) FROM file_transfers", [], |r| {
+            r.get::<_, f64>(0)
+        }) {
+            metrics.push(Metric {
+                name: "file_transport.transfers.total".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        metrics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_has_correct_id() {
+        let ext = FileTransportExtension::default();
+        let m = ext.manifest();
+        assert_eq!(m.id, "convergio-file-transport");
+        assert_eq!(m.provides.len(), 1);
+        assert_eq!(m.provides[0].name, "file-transport");
+    }
+
+    #[test]
+    fn migrations_are_returned() {
+        let ext = FileTransportExtension::default();
+        let migs = ext.migrations();
+        assert_eq!(migs.len(), 1);
+    }
+
+    #[test]
+    fn health_ok_with_memory_pool() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+        let ext = FileTransportExtension::new(pool);
+        assert!(matches!(ext.health(), Health::Ok));
+    }
+
+    #[test]
+    fn metrics_with_empty_db() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+        let ext = FileTransportExtension::new(pool);
+        let m = ext.metrics();
+        assert_eq!(m.len(), 1);
+        assert_eq!(m[0].value, 0.0);
+    }
+}

--- a/daemon/crates/convergio-file-transport/src/lib.rs
+++ b/daemon/crates/convergio-file-transport/src/lib.rs
@@ -1,0 +1,13 @@
+//! convergio-file-transport — Rsync-based file transport between mesh nodes.
+//!
+//! Provides rsync push/pull between peers, transfer tracking with audit
+//! trail, HTTP API for triggering and querying transfers.
+
+pub mod ext;
+pub mod routes;
+pub mod rsync;
+pub mod schema;
+pub mod transfer;
+pub mod types;
+
+pub use ext::FileTransportExtension;

--- a/daemon/crates/convergio-file-transport/src/routes.rs
+++ b/daemon/crates/convergio-file-transport/src/routes.rs
@@ -1,0 +1,100 @@
+//! HTTP routes for file transport operations.
+
+use axum::extract::{Path, Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_db::pool::ConnPool;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::types::{TransferDirection, TransferRequest};
+
+/// Query parameters for listing transfers.
+#[derive(Deserialize)]
+pub struct ListParams {
+    pub peer: Option<String>,
+    pub limit: Option<u32>,
+}
+
+/// Build the file-transport router.
+pub fn file_transport_routes(pool: ConnPool) -> Router {
+    Router::new()
+        .route("/api/file-transport/push", post(push_transfer))
+        .route("/api/file-transport/pull", post(pull_transfer))
+        .route("/api/file-transport/transfers", get(list_transfers))
+        .route("/api/file-transport/transfers/:id", get(get_transfer))
+        .with_state(pool)
+}
+
+async fn push_transfer(
+    State(pool): State<ConnPool>,
+    Json(mut req): Json<TransferRequest>,
+) -> Json<Value> {
+    req.direction = TransferDirection::Push;
+    execute_and_record(pool, req).await
+}
+
+async fn pull_transfer(
+    State(pool): State<ConnPool>,
+    Json(mut req): Json<TransferRequest>,
+) -> Json<Value> {
+    req.direction = TransferDirection::Pull;
+    execute_and_record(pool, req).await
+}
+
+async fn execute_and_record(pool: ConnPool, req: TransferRequest) -> Json<Value> {
+    let result = match crate::rsync::execute_rsync(&req, &req.ssh_target).await {
+        Ok(r) => r,
+        Err(e) => {
+            return Json(json!({"ok": false, "error": e.to_string()}));
+        }
+    };
+
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            // Transfer ran but we couldn't record it
+            return Json(json!({
+                "ok": true,
+                "result": result,
+                "warning": format!("transfer completed but recording failed: {e}"),
+            }));
+        }
+    };
+
+    match crate::transfer::record_transfer(&conn, &result, &req) {
+        Ok(id) => Json(json!({"ok": true, "id": id, "result": result})),
+        Err(e) => Json(json!({
+            "ok": true,
+            "result": result,
+            "warning": format!("transfer completed but recording failed: {e}"),
+        })),
+    }
+}
+
+async fn list_transfers(
+    State(pool): State<ConnPool>,
+    Query(params): Query<ListParams>,
+) -> Json<Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
+    };
+    let limit = params.limit.unwrap_or(50).min(100);
+    match crate::transfer::list_transfers(&conn, params.peer.as_deref(), limit) {
+        Ok(list) => Json(json!({"ok": true, "transfers": list})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+async fn get_transfer(State(pool): State<ConnPool>, Path(id): Path<i64>) -> Json<Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
+    };
+    match crate::transfer::get_transfer(&conn, id) {
+        Ok(Some(rec)) => Json(json!({"ok": true, "transfer": rec})),
+        Ok(None) => Json(json!({"ok": false, "error": "transfer not found"})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}

--- a/daemon/crates/convergio-file-transport/src/rsync.rs
+++ b/daemon/crates/convergio-file-transport/src/rsync.rs
@@ -1,0 +1,193 @@
+//! Rsync wrapper — builds and executes rsync commands for file transfer.
+
+use crate::types::{TransferDirection, TransferRequest, TransferResult, TransferStatus};
+use std::time::Instant;
+use tokio::process::Command;
+
+/// Build the rsync command for a given transfer request.
+///
+/// Push: `rsync -avz --delete -e ssh source user@host:dest`
+/// Pull: `rsync -avz --delete -e ssh user@host:source dest`
+pub fn build_rsync_command(req: &TransferRequest, ssh_target: &str) -> Command {
+    let mut cmd = Command::new("rsync");
+    cmd.args(["-avz", "--delete", "-e", "ssh"]);
+
+    for pattern in &req.exclude_patterns {
+        cmd.arg(format!("--exclude={pattern}"));
+    }
+
+    match req.direction {
+        TransferDirection::Push => {
+            cmd.arg(&req.source_path);
+            cmd.arg(format!("{ssh_target}:{}", req.dest_path));
+        }
+        TransferDirection::Pull => {
+            cmd.arg(format!("{ssh_target}:{}", req.source_path));
+            cmd.arg(&req.dest_path);
+        }
+    }
+
+    cmd
+}
+
+/// Execute rsync and parse the output for transfer statistics.
+pub async fn execute_rsync(
+    req: &TransferRequest,
+    ssh_target: &str,
+) -> Result<TransferResult, Box<dyn std::error::Error + Send + Sync>> {
+    let start = Instant::now();
+    let mut cmd = build_rsync_command(req, ssh_target);
+
+    let output = cmd.output().await?;
+    let duration_ms = start.elapsed().as_millis() as u64;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        let msg = if stderr.is_empty() {
+            format!("rsync exit code {}", output.status)
+        } else {
+            stderr.trim().to_string()
+        };
+        return Ok(TransferResult {
+            peer_name: req.peer_name.clone(),
+            bytes_transferred: 0,
+            files_count: 0,
+            duration_ms,
+            status: TransferStatus::Failed(msg),
+        });
+    }
+
+    let (bytes, files) = parse_rsync_output(&stdout);
+    Ok(TransferResult {
+        peer_name: req.peer_name.clone(),
+        bytes_transferred: bytes,
+        files_count: files,
+        duration_ms,
+        status: TransferStatus::Success,
+    })
+}
+
+/// Parse rsync summary output for bytes transferred and file count.
+///
+/// Rsync outputs lines like:
+///   "sent 1,234 bytes  received 56 bytes"
+///   "total size is 5,678  speedup is 1.23"
+/// and lists transferred files one per line before the summary.
+pub fn parse_rsync_output(output: &str) -> (u64, u64) {
+    let mut bytes: u64 = 0;
+    let mut files: u64 = 0;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("sent ") && trimmed.contains("bytes") {
+            // "sent 1,234 bytes  received 56 bytes  ..."
+            if let Some(val) = extract_number_after(trimmed, "sent ") {
+                bytes += val;
+            }
+        } else if trimmed.starts_with("total size is ") {
+            // Ignore — we use sent bytes as the metric
+        } else if !trimmed.is_empty()
+            && !trimmed.starts_with("receiving")
+            && !trimmed.starts_with("sending")
+            && !trimmed.starts_with("created directory")
+            && !trimmed.starts_with("./")
+            && !trimmed.contains("speedup is")
+            && !trimmed.contains("bytes/sec")
+        {
+            // Count non-header lines as transferred files
+            files += 1;
+        }
+    }
+
+    (bytes, files)
+}
+
+/// Extract a number (with commas stripped) following a prefix in a line.
+fn extract_number_after(line: &str, prefix: &str) -> Option<u64> {
+    let rest = line.strip_prefix(prefix)?;
+    let num_str: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == ',')
+        .collect();
+    num_str.replace(',', "").parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request(dir: TransferDirection) -> TransferRequest {
+        TransferRequest {
+            source_path: "/data/project/".into(),
+            dest_path: "/backup/project/".into(),
+            peer_name: "studio-mac".into(),
+            ssh_target: "rob@192.168.1.50".into(),
+            direction: dir,
+            exclude_patterns: vec![],
+        }
+    }
+
+    #[test]
+    fn build_rsync_command_push() {
+        let req = sample_request(TransferDirection::Push);
+        let cmd = build_rsync_command(&req, "rob@192.168.1.50");
+        let prog = cmd.as_std().get_program().to_str().unwrap();
+        assert_eq!(prog, "rsync");
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_str().unwrap())
+            .collect();
+        assert!(args.contains(&"-avz"));
+        assert!(args.contains(&"--delete"));
+        assert!(args.contains(&"/data/project/"));
+        assert!(args.contains(&"rob@192.168.1.50:/backup/project/"));
+    }
+
+    #[test]
+    fn build_rsync_command_pull() {
+        let req = sample_request(TransferDirection::Pull);
+        let cmd = build_rsync_command(&req, "rob@192.168.1.50");
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_str().unwrap())
+            .collect();
+        assert!(args.contains(&"rob@192.168.1.50:/data/project/"));
+        assert!(args.contains(&"/backup/project/"));
+    }
+
+    #[test]
+    fn build_rsync_with_excludes() {
+        let mut req = sample_request(TransferDirection::Push);
+        req.exclude_patterns = vec!["*.tmp".into(), ".git".into()];
+        let cmd = build_rsync_command(&req, "rob@192.168.1.50");
+        let args: Vec<_> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_str().unwrap())
+            .collect();
+        assert!(args.contains(&"--exclude=*.tmp"));
+        assert!(args.contains(&"--exclude=.git"));
+    }
+
+    #[test]
+    fn parse_rsync_output_extracts_stats() {
+        let output = "\
+file1.txt
+file2.txt
+sent 1,234 bytes  received 56 bytes  2,580.00 bytes/sec
+total size is 5,678  speedup is 4.40";
+        let (bytes, files) = parse_rsync_output(output);
+        assert_eq!(bytes, 1234);
+        assert_eq!(files, 2);
+    }
+
+    #[test]
+    fn parse_rsync_output_empty() {
+        let (bytes, files) = parse_rsync_output("");
+        assert_eq!(bytes, 0);
+        assert_eq!(files, 0);
+    }
+}

--- a/daemon/crates/convergio-file-transport/src/schema.rs
+++ b/daemon/crates/convergio-file-transport/src/schema.rs
@@ -1,0 +1,76 @@
+//! DB migrations for the file-transport module.
+
+use convergio_types::extension::Migration;
+
+pub fn migrations() -> Vec<Migration> {
+    vec![Migration {
+        version: 1,
+        description: "file_transfers tracking table",
+        up: "\
+CREATE TABLE IF NOT EXISTS file_transfers (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    peer_name          TEXT NOT NULL,
+    direction          TEXT NOT NULL,
+    source_path        TEXT NOT NULL,
+    dest_path          TEXT NOT NULL,
+    bytes_transferred  INTEGER DEFAULT 0,
+    files_count        INTEGER DEFAULT 0,
+    duration_ms        INTEGER DEFAULT 0,
+    status             TEXT NOT NULL DEFAULT 'pending',
+    error_message      TEXT,
+    created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_ft_peer_date
+    ON file_transfers(peer_name, created_at);",
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_are_ordered() {
+        let migs = migrations();
+        assert!(!migs.is_empty());
+        for (i, m) in migs.iter().enumerate() {
+            assert_eq!(m.version, (i + 1) as u32);
+        }
+    }
+
+    #[test]
+    fn migrations_apply_cleanly() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        // Verify table exists
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='file_transfers'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn index_exists_after_migration() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        for m in migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_ft_peer_date'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/daemon/crates/convergio-file-transport/src/transfer.rs
+++ b/daemon/crates/convergio-file-transport/src/transfer.rs
@@ -1,0 +1,182 @@
+//! High-level transfer operations — DB persistence and querying.
+
+use crate::types::{TransferRecord, TransferRequest, TransferResult, TransferStatus};
+use rusqlite::Connection;
+
+/// Insert a completed transfer into the file_transfers table.
+pub fn record_transfer(
+    conn: &Connection,
+    result: &TransferResult,
+    req: &TransferRequest,
+) -> Result<i64, rusqlite::Error> {
+    let (status_str, error_msg) = match &result.status {
+        TransferStatus::Success => ("success".to_string(), None),
+        TransferStatus::Failed(msg) => ("failed".to_string(), Some(msg.clone())),
+        TransferStatus::PartialSuccess(msg) => ("partial".to_string(), Some(msg.clone())),
+    };
+
+    conn.execute(
+        "INSERT INTO file_transfers \
+         (peer_name, direction, source_path, dest_path, \
+          bytes_transferred, files_count, duration_ms, status, error_message) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        rusqlite::params![
+            result.peer_name,
+            req.direction.to_string(),
+            req.source_path,
+            req.dest_path,
+            result.bytes_transferred as i64,
+            result.files_count as i64,
+            result.duration_ms as i64,
+            status_str,
+            error_msg,
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// List transfers with optional peer filter and limit.
+pub fn list_transfers(
+    conn: &Connection,
+    peer: Option<&str>,
+    limit: u32,
+) -> Result<Vec<TransferRecord>, rusqlite::Error> {
+    let sql = match peer {
+        Some(_) => {
+            "SELECT id, peer_name, direction, source_path, dest_path, \
+                    bytes_transferred, files_count, duration_ms, status, \
+                    error_message, created_at \
+             FROM file_transfers WHERE peer_name = ?1 \
+             ORDER BY created_at DESC LIMIT ?2"
+        }
+        None => {
+            "SELECT id, peer_name, direction, source_path, dest_path, \
+                    bytes_transferred, files_count, duration_ms, status, \
+                    error_message, created_at \
+             FROM file_transfers \
+             ORDER BY created_at DESC LIMIT ?1"
+        }
+    };
+
+    let mut stmt = conn.prepare(sql)?;
+    let rows = if let Some(p) = peer {
+        stmt.query_map(rusqlite::params![p, limit], map_row)?
+    } else {
+        stmt.query_map(rusqlite::params![limit], map_row)?
+    };
+    rows.collect()
+}
+
+/// Get a single transfer by ID.
+pub fn get_transfer(conn: &Connection, id: i64) -> Result<Option<TransferRecord>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT id, peer_name, direction, source_path, dest_path, \
+                bytes_transferred, files_count, duration_ms, status, \
+                error_message, created_at \
+         FROM file_transfers WHERE id = ?1",
+    )?;
+    let mut rows = stmt.query_map(rusqlite::params![id], map_row)?;
+    match rows.next() {
+        Some(Ok(rec)) => Ok(Some(rec)),
+        Some(Err(e)) => Err(e),
+        None => Ok(None),
+    }
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TransferRecord> {
+    Ok(TransferRecord {
+        id: row.get(0)?,
+        peer_name: row.get(1)?,
+        direction: row.get(2)?,
+        source_path: row.get(3)?,
+        dest_path: row.get(4)?,
+        bytes_transferred: row.get(5)?,
+        files_count: row.get(6)?,
+        duration_ms: row.get(7)?,
+        status: row.get(8)?,
+        error_message: row.get(9)?,
+        created_at: row.get(10)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{TransferDirection, TransferStatus};
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn
+    }
+
+    fn sample_req() -> TransferRequest {
+        TransferRequest {
+            source_path: "/data/project/".into(),
+            dest_path: "/backup/project/".into(),
+            peer_name: "studio-mac".into(),
+            ssh_target: "rob@192.168.1.50".into(),
+            direction: TransferDirection::Push,
+            exclude_patterns: vec![],
+        }
+    }
+
+    fn sample_result() -> TransferResult {
+        TransferResult {
+            peer_name: "studio-mac".into(),
+            bytes_transferred: 4096,
+            files_count: 12,
+            duration_ms: 350,
+            status: TransferStatus::Success,
+        }
+    }
+
+    #[test]
+    fn record_and_get_transfer() {
+        let conn = setup_db();
+        let id = record_transfer(&conn, &sample_result(), &sample_req()).unwrap();
+        assert!(id > 0);
+        let rec = get_transfer(&conn, id).unwrap().unwrap();
+        assert_eq!(rec.peer_name, "studio-mac");
+        assert_eq!(rec.bytes_transferred, 4096);
+        assert_eq!(rec.status, "success");
+    }
+
+    #[test]
+    fn list_transfers_all() {
+        let conn = setup_db();
+        record_transfer(&conn, &sample_result(), &sample_req()).unwrap();
+        let list = list_transfers(&conn, None, 50).unwrap();
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn list_transfers_by_peer() {
+        let conn = setup_db();
+        record_transfer(&conn, &sample_result(), &sample_req()).unwrap();
+        let found = list_transfers(&conn, Some("studio-mac"), 50).unwrap();
+        assert_eq!(found.len(), 1);
+        let empty = list_transfers(&conn, Some("unknown-peer"), 50).unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn get_transfer_not_found() {
+        let conn = setup_db();
+        let rec = get_transfer(&conn, 999).unwrap();
+        assert!(rec.is_none());
+    }
+
+    #[test]
+    fn record_failed_transfer() {
+        let conn = setup_db();
+        let mut res = sample_result();
+        res.status = TransferStatus::Failed("connection refused".into());
+        let id = record_transfer(&conn, &res, &sample_req()).unwrap();
+        let rec = get_transfer(&conn, id).unwrap().unwrap();
+        assert_eq!(rec.status, "failed");
+        assert_eq!(rec.error_message.as_deref(), Some("connection refused"));
+    }
+}

--- a/daemon/crates/convergio-file-transport/src/types.rs
+++ b/daemon/crates/convergio-file-transport/src/types.rs
@@ -1,0 +1,112 @@
+//! Domain types for file transport operations.
+
+use serde::{Deserialize, Serialize};
+
+/// Direction of a file transfer between mesh nodes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferDirection {
+    Push,
+    Pull,
+}
+
+impl std::fmt::Display for TransferDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Push => write!(f, "push"),
+            Self::Pull => write!(f, "pull"),
+        }
+    }
+}
+
+/// Request to initiate a file transfer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferRequest {
+    pub source_path: String,
+    pub dest_path: String,
+    pub peer_name: String,
+    /// SSH target string (e.g. "user@host" or SSH alias).
+    pub ssh_target: String,
+    pub direction: TransferDirection,
+    #[serde(default)]
+    pub exclude_patterns: Vec<String>,
+}
+
+/// Outcome of an individual transfer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferResult {
+    pub peer_name: String,
+    pub bytes_transferred: u64,
+    pub files_count: u64,
+    pub duration_ms: u64,
+    pub status: TransferStatus,
+}
+
+/// Status of a completed transfer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "message")]
+pub enum TransferStatus {
+    Success,
+    Failed(String),
+    PartialSuccess(String),
+}
+
+impl std::fmt::Display for TransferStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Success => write!(f, "success"),
+            Self::Failed(msg) => write!(f, "failed: {msg}"),
+            Self::PartialSuccess(msg) => write!(f, "partial: {msg}"),
+        }
+    }
+}
+
+/// Persisted record of a transfer in the DB.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferRecord {
+    pub id: i64,
+    pub peer_name: String,
+    pub direction: String,
+    pub source_path: String,
+    pub dest_path: String,
+    pub bytes_transferred: i64,
+    pub files_count: i64,
+    pub duration_ms: i64,
+    pub status: String,
+    pub error_message: Option<String>,
+    pub created_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direction_display() {
+        assert_eq!(TransferDirection::Push.to_string(), "push");
+        assert_eq!(TransferDirection::Pull.to_string(), "pull");
+    }
+
+    #[test]
+    fn status_display() {
+        assert_eq!(TransferStatus::Success.to_string(), "success");
+        let f = TransferStatus::Failed("timeout".into());
+        assert!(f.to_string().contains("timeout"));
+    }
+
+    #[test]
+    fn request_roundtrip_json() {
+        let req = TransferRequest {
+            source_path: "/data/project".into(),
+            dest_path: "/backup/project".into(),
+            peer_name: "studio-mac".into(),
+            ssh_target: "rob@studio-mac".into(),
+            direction: TransferDirection::Push,
+            exclude_patterns: vec!["*.tmp".into()],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let back: TransferRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.peer_name, "studio-mac");
+        assert_eq!(back.direction, TransferDirection::Push);
+    }
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,7 +1,4 @@
-//! Convergio daemon — collects extensions, starts the server.
-//!
-//! This binary wires all extensions together and launches the daemon.
-//! Business logic lives in the crates; this is just the entry point.
+//! Convergio daemon — wires extensions together and launches the server.
 
 use convergio_db::pool::{create_pool, ConnPool};
 use convergio_server::config_watcher::spawn_config_watcher;
@@ -47,6 +44,9 @@ fn register_extensions(
         )),
         Arc::new(convergio_http_bridge::HttpBridgeExtension::new()),
         // Platform tools
+        Arc::new(convergio_file_transport::FileTransportExtension::new(
+            pool.clone(),
+        )),
         Arc::new(convergio_longrunning::LongRunningExtension::new(
             pool.clone(),
         )),


### PR DESCRIPTION
## Summary
- New crate `convergio-file-transport` with rsync-based file transport between mesh nodes
- `rsync.rs`: command builder + async executor with output parsing
- `transfer.rs`: DB persistence for transfer audit trail
- `routes.rs`: 4 HTTP endpoints (push, pull, list transfers, get transfer)
- `ext.rs`: Extension impl with health, metrics, migrations
- 20 tests passing, all files under 250 lines

## Test plan
- [x] `cargo check` — clean
- [x] `cargo test --workspace` — all pass
- [ ] Smoke test: POST push/pull to localhost peer

🤖 Generated with [Claude Code](https://claude.com/claude-code)