### PR TITLE
feat: add delegation remote monitor (fase 34)

### DIFF
--- a/daemon/crates/convergio-delegation/src/ext.rs
+++ b/daemon/crates/convergio-delegation/src/ext.rs
@@ -1,8 +1,13 @@
 //! DelegationExtension — impl Extension for delegation orchestrator.
 
+use std::sync::Arc;
+
 use convergio_db::pool::ConnPool;
+use convergio_types::events::DomainEventSink;
 use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric, Migration};
 use convergio_types::manifest::{Capability, Dependency, Manifest, ModuleKind};
+
+use crate::routes::DelegationState;
 
 /// Extension entry point for the delegation orchestrator.
 pub struct DelegationExtension {
@@ -66,8 +71,15 @@ impl Extension for DelegationExtension {
         crate::schema::migrations()
     }
 
-    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
-        Some(crate::routes::delegation_routes(self.pool.clone()))
+    fn routes(&self, ctx: &AppContext) -> Option<axum::Router> {
+        let event_sink = ctx
+            .get_arc::<Arc<dyn DomainEventSink>>()
+            .map(|s| (*s).clone());
+        let state = DelegationState {
+            pool: self.pool.clone(),
+            event_sink,
+        };
+        Some(crate::routes::delegation_routes(state))
     }
 
     fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {

--- a/daemon/crates/convergio-delegation/src/lib.rs
+++ b/daemon/crates/convergio-delegation/src/lib.rs
@@ -4,6 +4,7 @@
 //! monitoring, and sync-back into a complete delegation pipeline.
 
 pub mod ext;
+pub mod monitor;
 pub mod pipeline;
 pub mod queries;
 pub mod remote_spawn;

--- a/daemon/crates/convergio-delegation/src/monitor.rs
+++ b/daemon/crates/convergio-delegation/src/monitor.rs
@@ -1,0 +1,173 @@
+//! Remote delegation monitor — polls tmux window on peer, syncs back on exit.
+
+use std::sync::Arc;
+
+use convergio_db::pool::ConnPool;
+use convergio_types::events::{make_event, DomainEventSink, EventContext, EventKind};
+use tokio::task::JoinHandle;
+
+use crate::queries;
+use crate::types::{DelegationStatus, DelegationStep, PipelineConfig};
+
+const POLL_INTERVAL_SECS: u64 = 30;
+
+/// Check if a tmux window is still alive on the remote peer via SSH.
+async fn is_tmux_window_alive(ssh_target: &str, tmux_session: &str, tmux_window: &str) -> bool {
+    let output = tokio::process::Command::new("ssh")
+        .args([
+            ssh_target,
+            "tmux",
+            "list-windows",
+            "-t",
+            tmux_session,
+            "-F",
+            "#{window_name}",
+        ])
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            stdout.lines().any(|line| line.trim() == tmux_window)
+        }
+        _ => false,
+    }
+}
+
+/// Spawn a background task that monitors a remote delegation.
+///
+/// Polls the remote tmux session every 30s. When the window disappears
+/// (agent exited), syncs results back and emits a `DelegationCompleted` event.
+#[allow(clippy::too_many_arguments)]
+pub fn monitor_remote_delegation(
+    pool: ConnPool,
+    delegation_id: String,
+    peer_name: String,
+    ssh_target: String,
+    tmux_session: String,
+    tmux_window: String,
+    config: PipelineConfig,
+    event_sink: Option<Arc<dyn DomainEventSink>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!(
+            delegation_id = delegation_id.as_str(),
+            peer_name = peer_name.as_str(),
+            "monitor started for remote delegation"
+        );
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(POLL_INTERVAL_SECS)).await;
+            let alive = is_tmux_window_alive(&ssh_target, &tmux_session, &tmux_window).await;
+            if alive {
+                continue;
+            }
+            tracing::info!(
+                delegation_id = delegation_id.as_str(),
+                "remote tmux window gone, starting sync_back"
+            );
+            break;
+        }
+        // Agent exited — sync back results
+        let result = crate::pipeline::sync_back(&pool, &delegation_id, &peer_name, &config).await;
+        match result {
+            Ok(()) => {
+                tracing::info!(delegation_id = delegation_id.as_str(), "sync_back complete");
+                emit_completed(&pool, &delegation_id, &peer_name, &event_sink);
+            }
+            Err(e) => {
+                tracing::error!(
+                    delegation_id = delegation_id.as_str(),
+                    error = %e,
+                    "sync_back failed"
+                );
+                let fail = DelegationStatus::Failed(format!("sync_back: {e}"));
+                let _ = queries::update_delegation_status(
+                    &pool,
+                    &delegation_id,
+                    &fail,
+                    &DelegationStep::SyncBack,
+                );
+            }
+        }
+    })
+}
+
+/// Emit a DelegationCompleted event if we have a sink and can read plan_id.
+fn emit_completed(
+    pool: &ConnPool,
+    delegation_id: &str,
+    peer_name: &str,
+    event_sink: &Option<Arc<dyn DomainEventSink>>,
+) {
+    let Some(sink) = event_sink else { return };
+    let plan_id = pool
+        .get()
+        .ok()
+        .and_then(|conn| queries::get_delegation(&conn, delegation_id))
+        .map(|rec| rec.plan_id)
+        .unwrap_or(0);
+    let event = make_event(
+        "delegation-monitor",
+        EventKind::DelegationCompleted {
+            delegation_id: delegation_id.to_string(),
+            plan_id,
+            peer_name: peer_name.to_string(),
+        },
+        EventContext {
+            plan_id: Some(plan_id),
+            ..Default::default()
+        },
+    );
+    sink.emit(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn tmux_check_builds_correct_command() {
+        // On CI/local without SSH, the command will fail — that means "not alive".
+        let alive = is_tmux_window_alive("nobody@127.0.0.1", "cvg-test-session", "plan-999").await;
+        assert!(!alive, "should be false when ssh fails");
+    }
+
+    #[tokio::test]
+    async fn monitor_handles_immediate_exit() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO delegations (delegation_id,plan_id,peer_name,source_path) \
+             VALUES('del-mon-1',1,'test-peer','/tmp')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        // Use a bogus ssh_target so tmux check fails immediately (not alive)
+        let handle = monitor_remote_delegation(
+            pool.clone(),
+            "del-mon-1".into(),
+            "test-peer".into(),
+            "nobody@127.0.0.1".into(),
+            "cvg-del-mon-1".into(),
+            "plan-1".into(),
+            PipelineConfig::default(),
+            None,
+        );
+        // The monitor will detect "not alive" on first poll, then sync_back
+        // will fail (no real peer), marking delegation as failed.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(35), handle).await;
+
+        let conn = pool.get().unwrap();
+        let rec = queries::get_delegation(&conn, "del-mon-1").unwrap();
+        assert!(
+            rec.status.starts_with("failed"),
+            "expected failed status, got: {}",
+            rec.status
+        );
+    }
+}

--- a/daemon/crates/convergio-delegation/src/pipeline.rs
+++ b/daemon/crates/convergio-delegation/src/pipeline.rs
@@ -10,6 +10,14 @@ use std::path::Path;
 
 type BoxErr = Box<dyn std::error::Error + Send + Sync>;
 
+/// Info returned by a successful pipeline run, used to start the monitor.
+pub struct PipelineResult {
+    pub ssh_target: String,
+    pub tmux_session: String,
+    pub tmux_window: String,
+    pub remote_path: String,
+}
+
 /// Resolve the SSH target string for a peer from the peers registry.
 fn resolve_ssh_target(peer_name: &str) -> Result<String, BoxErr> {
     let conf_path = peers_conf_path_from_env();
@@ -25,14 +33,15 @@ fn resolve_ssh_target(peer_name: &str) -> Result<String, BoxErr> {
     }
 }
 
-/// Run the full delegation pipeline: copy -> spawn -> monitor -> sync back.
+/// Run the full delegation pipeline: copy -> spawn -> set Running.
+/// Returns info needed to start the remote monitor.
 pub async fn run_delegation_pipeline(
     pool: &ConnPool,
     delegation_id: &str,
     plan_id: i64,
     peer_name: &str,
     config: &PipelineConfig,
-) -> Result<(), BoxErr> {
+) -> Result<PipelineResult, BoxErr> {
     let ssh_target = resolve_ssh_target(peer_name)?;
     let remote_path = format!("{}/{}", config.remote_base, delegation_id);
 
@@ -89,7 +98,12 @@ pub async fn run_delegation_pipeline(
     )?;
     update_remote_path(pool, delegation_id, &remote_path)?;
     tracing::info!(delegation_id, peer_name, "delegation running on peer");
-    Ok(())
+    Ok(PipelineResult {
+        ssh_target,
+        tmux_session,
+        tmux_window,
+        remote_path,
+    })
 }
 
 /// Sync results back from the remote peer after completion.

--- a/daemon/crates/convergio-delegation/src/routes.rs
+++ b/daemon/crates/convergio-delegation/src/routes.rs
@@ -1,14 +1,17 @@
 //! HTTP routes for the delegation API.
 
+use std::sync::Arc;
+
 use axum::extract::{Path, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use convergio_db::pool::ConnPool;
+use convergio_types::events::DomainEventSink;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::types::{DelegateMarkRequest, DelegateRequest, PipelineConfig};
-use crate::{pipeline, queries};
+use crate::{monitor, pipeline, queries};
 
 /// Query parameters for listing delegations.
 #[derive(Deserialize)]
@@ -17,23 +20,30 @@ pub struct ListParams {
     pub limit: Option<u32>,
 }
 
+/// Shared state for delegation routes.
+#[derive(Clone)]
+pub struct DelegationState {
+    pub pool: ConnPool,
+    pub event_sink: Option<Arc<dyn DomainEventSink>>,
+}
+
 /// Build the delegation router.
-pub fn delegation_routes(pool: ConnPool) -> Router {
+pub fn delegation_routes(state: DelegationState) -> Router {
     Router::new()
         .route("/api/mesh/delegate", post(mark_delegated))
         .route("/api/delegate/spawn", post(spawn_delegation))
         .route("/api/delegate/status/:delegation_id", get(get_status))
         .route("/api/delegate/list", get(list_delegations))
-        .with_state(pool)
+        .with_state(state)
 }
 
 /// POST /api/mesh/delegate — mark a plan as delegated to a peer.
 async fn mark_delegated(
-    State(pool): State<ConnPool>,
+    State(st): State<DelegationState>,
     Json(req): Json<DelegateMarkRequest>,
 ) -> Json<Value> {
     let delegation_id = uuid::Uuid::new_v4().to_string();
-    let conn = match pool.get() {
+    let conn = match st.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
     };
@@ -52,7 +62,7 @@ async fn mark_delegated(
 
 /// POST /api/delegate/spawn — create delegation record and launch pipeline.
 async fn spawn_delegation(
-    State(pool): State<ConnPool>,
+    State(st): State<DelegationState>,
     Json(req): Json<DelegateRequest>,
 ) -> Json<Value> {
     let delegation_id = uuid::Uuid::new_v4().to_string();
@@ -69,7 +79,7 @@ async fn spawn_delegation(
     };
 
     // Insert delegation record
-    let conn = match pool.get() {
+    let conn = match st.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
     };
@@ -82,18 +92,38 @@ async fn spawn_delegation(
     }
     drop(conn);
 
-    // Spawn pipeline in background
-    let pool_bg = pool.clone();
+    // Spawn pipeline + monitor in background
+    let pool_bg = st.pool.clone();
     let del_id = delegation_id.clone();
     let peer = req.peer.clone();
+    let sink = st.event_sink.clone();
     tokio::spawn(async move {
-        if let Err(e) =
-            pipeline::run_delegation_pipeline(&pool_bg, &del_id, req.plan_id, &peer, &config).await
+        match pipeline::run_delegation_pipeline(&pool_bg, &del_id, req.plan_id, &peer, &config)
+            .await
         {
-            tracing::error!(delegation_id = %del_id, error = %e, "delegation pipeline failed");
-            let fail = crate::types::DelegationStatus::Failed(e.to_string());
-            let step = crate::types::DelegationStep::Init;
-            let _ = queries::update_delegation_status(&pool_bg, &del_id, &fail, &step);
+            Ok(pr) => {
+                // Pipeline succeeded (status=Running) — start monitor
+                monitor::monitor_remote_delegation(
+                    pool_bg,
+                    del_id,
+                    peer,
+                    pr.ssh_target,
+                    pr.tmux_session,
+                    pr.tmux_window,
+                    config,
+                    sink,
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    delegation_id = %del_id,
+                    error = %e,
+                    "delegation pipeline failed"
+                );
+                let fail = crate::types::DelegationStatus::Failed(e.to_string());
+                let step = crate::types::DelegationStep::Init;
+                let _ = queries::update_delegation_status(&pool_bg, &del_id, &fail, &step);
+            }
         }
     });
 
@@ -106,10 +136,10 @@ async fn spawn_delegation(
 
 /// GET /api/delegate/status/:delegation_id
 async fn get_status(
-    State(pool): State<ConnPool>,
+    State(st): State<DelegationState>,
     Path(delegation_id): Path<String>,
 ) -> Json<Value> {
-    let conn = match pool.get() {
+    let conn = match st.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
     };
@@ -121,10 +151,10 @@ async fn get_status(
 
 /// GET /api/delegate/list?plan_id=N&limit=50
 async fn list_delegations(
-    State(pool): State<ConnPool>,
+    State(st): State<DelegationState>,
     Query(params): Query<ListParams>,
 ) -> Json<Value> {
-    let conn = match pool.get() {
+    let conn = match st.pool.get() {
         Ok(c) => c,
         Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
     };

--- a/daemon/crates/convergio-ipc/src/sse.rs
+++ b/daemon/crates/convergio-ipc/src/sse.rs
@@ -98,6 +98,9 @@ impl convergio_types::events::DomainEventSink for EventBus {
             convergio_types::events::EventKind::WaveCompleted { .. } => "wave_completed",
             convergio_types::events::EventKind::MessageSent { .. } => "message_sent",
             convergio_types::events::EventKind::DelegationStarted { .. } => "delegation_started",
+            convergio_types::events::EventKind::DelegationCompleted { .. } => {
+                "delegation_completed"
+            }
             convergio_types::events::EventKind::AgentOnline { .. } => "agent_online",
             convergio_types::events::EventKind::AgentOffline { .. } => "agent_offline",
             convergio_types::events::EventKind::HealthDegraded { .. } => "health_degraded",

--- a/daemon/crates/convergio-types/src/events.rs
+++ b/daemon/crates/convergio-types/src/events.rs
@@ -70,6 +70,11 @@ pub enum EventKind {
         to_org: String,
         task: String,
     },
+    DelegationCompleted {
+        delegation_id: String,
+        plan_id: i64,
+        peer_name: String,
+    },
 
     // Agent lifecycle
     AgentOnline {


### PR DESCRIPTION
## Summary
- Add `DelegationCompleted` event kind to `convergio-types` events enum
- Create `monitor.rs` in `convergio-delegation` — background task that polls remote tmux window via SSH every 30s, calls `sync_back()` when window disappears, emits domain event
- Change `run_delegation_pipeline` to return `PipelineResult` with SSH/tmux info needed by monitor
- Update `routes.rs` to use `DelegationState` (pool + optional event_sink), spawn monitor after successful pipeline
- Update `ext.rs` to extract `DomainEventSink` from `AppContext` and pass to routes
- Update `convergio-ipc` SSE match arm for the new event kind

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (all 20 delegation tests green, including 2 new monitor tests)
- [x] `cargo fmt --all` applied
- [ ] Manual: trigger delegation to real peer, verify monitor detects tmux exit and syncs back

🤖 Generated with [Claude Code](https://claude.com/claude-code)