### PR TITLE
feat: artifact storage for non-code projects (fase 39b)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -791,6 +792,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1086,6 +1088,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -1815,6 +1826,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2558,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -85,9 +85,9 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.44", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.44", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "fs", "io-util"] }
 tracing = "0.1"
-axum = { version = "0.7", features = ["ws"] }
+axum = { version = "0.7", features = ["ws", "multipart"] }
 rusqlite = { version = "0.32", features = ["bundled", "functions"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.25"
@@ -97,6 +97,7 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.8"
 async-stream = "0.3"
+tokio-util = { version = "0.7", features = ["io"] }
 futures-core = "0.3"
 libc = "0.2"
 dirs = "6"

--- a/daemon/crates/convergio-evidence/src/types.rs
+++ b/daemon/crates/convergio-evidence/src/types.rs
@@ -12,6 +12,8 @@ pub enum EvidenceKind {
     CommitHash,
     Artifact,
     CurlOutput,
+    ReviewPass,
+    Document,
 }
 
 impl EvidenceKind {
@@ -23,6 +25,8 @@ impl EvidenceKind {
             Self::CommitHash => "commit_hash",
             Self::Artifact => "artifact",
             Self::CurlOutput => "curl_output",
+            Self::ReviewPass => "review_pass",
+            Self::Document => "document",
         }
     }
 
@@ -34,6 +38,8 @@ impl EvidenceKind {
             "commit_hash" => Some(Self::CommitHash),
             "artifact" => Some(Self::Artifact),
             "curl_output" => Some(Self::CurlOutput),
+            "review_pass" => Some(Self::ReviewPass),
+            "document" => Some(Self::Document),
             _ => None,
         }
     }
@@ -131,6 +137,8 @@ mod tests {
             EvidenceKind::CommitHash,
             EvidenceKind::Artifact,
             EvidenceKind::CurlOutput,
+            EvidenceKind::ReviewPass,
+            EvidenceKind::Document,
         ] {
             let s = kind.as_str();
             assert_eq!(EvidenceKind::parse(s), Some(kind));

--- a/daemon/crates/convergio-orchestrator/Cargo.toml
+++ b/daemon/crates/convergio-orchestrator/Cargo.toml
@@ -19,3 +19,4 @@ rusqlite = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
 libc = { workspace = true }
+tokio-util = { workspace = true }

--- a/daemon/crates/convergio-orchestrator/src/artifact_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/artifact_routes.rs
@@ -1,0 +1,217 @@
+// HTTP routes for artifact upload, listing, and download.
+// WHY: Non-code projects need file-based evidence (reports, PDFs, screenshots)
+// that cannot be represented as git commits.
+
+use std::path::PathBuf;
+
+use axum::body::Body;
+use axum::extract::{Multipart, Path, State};
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Json};
+use axum::routing::{get, post};
+use axum::Router;
+use convergio_db::pool::ConnPool;
+use serde_json::json;
+use tokio_util::io::ReaderStream;
+
+use crate::artifacts;
+
+/// Base directory for artifact file storage.
+fn artifacts_dir() -> PathBuf {
+    PathBuf::from(
+        std::env::var("CONVERGIO_ARTIFACTS_DIR")
+            .unwrap_or_else(|_| "/tmp/convergio-artifacts".to_string()),
+    )
+}
+
+pub fn artifact_routes(pool: ConnPool) -> Router {
+    Router::new()
+        .route("/api/artifacts/upload", post(handle_upload))
+        .route("/api/artifacts/plan/:plan_id", get(handle_list_plan))
+        .route("/api/artifacts/task/:task_id", get(handle_list_task))
+        .route("/api/artifacts/:id", get(handle_get))
+        .route("/api/artifacts/:id/download", get(handle_download))
+        .with_state(pool)
+}
+
+async fn handle_upload(
+    State(pool): State<ConnPool>,
+    mut multipart: Multipart,
+) -> impl IntoResponse {
+    let mut task_id: Option<i64> = None;
+    let mut plan_id: Option<i64> = None;
+    let mut name: Option<String> = None;
+    let mut artifact_type = "document".to_string();
+    let mut file_data: Option<Vec<u8>> = None;
+    let mut file_name: Option<String> = None;
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let field_name = field.name().unwrap_or("").to_string();
+        match field_name.as_str() {
+            "task_id" => {
+                let text = field.text().await.unwrap_or_default();
+                task_id = text.parse().ok();
+            }
+            "plan_id" => {
+                let text = field.text().await.unwrap_or_default();
+                plan_id = text.parse().ok();
+            }
+            "name" => name = Some(field.text().await.unwrap_or_default()),
+            "artifact_type" => {
+                artifact_type = field.text().await.unwrap_or_default();
+            }
+            "file" => {
+                file_name = field.file_name().map(|s| s.to_string());
+                file_data = field.bytes().await.ok().map(|b| b.to_vec());
+            }
+            _ => {}
+        }
+    }
+
+    let (Some(task_id), Some(plan_id), Some(data)) = (task_id, plan_id, file_data) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "missing required fields: task_id, plan_id, file"})),
+        );
+    };
+
+    let display_name =
+        name.unwrap_or_else(|| file_name.clone().unwrap_or_else(|| "unnamed".to_string()));
+    let safe_file = file_name.unwrap_or_else(|| display_name.clone());
+
+    // Write file to disk
+    let dir = artifacts_dir().join(plan_id.to_string());
+    if let Err(e) = tokio::fs::create_dir_all(&dir).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("mkdir failed: {e}")})),
+        );
+    }
+    let file_path = dir.join(&safe_file);
+    if let Err(e) = tokio::fs::write(&file_path, &data).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("write failed: {e}")})),
+        );
+    }
+
+    let relative = format!("{plan_id}/{safe_file}");
+    let size = data.len() as i64;
+
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+
+    match artifacts::record_artifact(
+        &conn,
+        task_id,
+        plan_id,
+        &display_name,
+        &artifact_type,
+        &relative,
+        size,
+    ) {
+        Ok(id) => {
+            // Also record as evidence in task_evidence
+            let _ = conn.execute(
+                "INSERT INTO task_evidence \
+                 (task_db_id, evidence_type, command, output_summary, exit_code) \
+                 VALUES (?1, 'artifact', ?2, ?3, 0)",
+                rusqlite::params![task_id, display_name, format!("artifact_id={id}")],
+            );
+            (
+                StatusCode::CREATED,
+                Json(json!({"id": id, "path": relative})),
+            )
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}
+
+async fn handle_list_plan(
+    State(pool): State<ConnPool>,
+    Path(plan_id): Path<i64>,
+) -> Json<serde_json::Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let arts = artifacts::list_artifacts(&conn, plan_id);
+    Json(json!(arts))
+}
+
+async fn handle_list_task(
+    State(pool): State<ConnPool>,
+    Path(task_id): Path<i64>,
+) -> Json<serde_json::Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    let arts = artifacts::list_task_artifacts(&conn, task_id);
+    Json(json!(arts))
+}
+
+async fn handle_get(State(pool): State<ConnPool>, Path(id): Path<i64>) -> Json<serde_json::Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match artifacts::get_artifact(&conn, id) {
+        Some(art) => Json(json!(art)),
+        None => Json(json!({"error": "artifact not found"})),
+    }
+}
+
+async fn handle_download(State(pool): State<ConnPool>, Path(id): Path<i64>) -> impl IntoResponse {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(header::CONTENT_TYPE, "application/json".to_string())],
+                Body::from(json!({"error": e.to_string()}).to_string()),
+            )
+        }
+    };
+    let art = match artifacts::get_artifact(&conn, id) {
+        Some(a) => a,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                [(header::CONTENT_TYPE, "application/json".to_string())],
+                Body::from(json!({"error": "not found"}).to_string()),
+            )
+        }
+    };
+    drop(conn);
+
+    let file_path = artifacts_dir().join(&art.path);
+    let file = match tokio::fs::File::open(&file_path).await {
+        Ok(f) => f,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                [(header::CONTENT_TYPE, "application/json".to_string())],
+                Body::from(json!({"error": format!("file: {e}")}).to_string()),
+            )
+        }
+    };
+
+    let stream = ReaderStream::new(file);
+    let body = Body::from_stream(stream);
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/octet-stream".to_string())],
+        body,
+    )
+}

--- a/daemon/crates/convergio-orchestrator/src/artifacts.rs
+++ b/daemon/crates/convergio-orchestrator/src/artifacts.rs
@@ -1,0 +1,175 @@
+// Artifact storage and retrieval for non-code project outputs.
+// WHY: Non-code projects (reports, analysis, documents) need artifact tracking
+// beyond git commits and test evidence.
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Artifact {
+    pub id: i64,
+    pub task_id: i64,
+    pub plan_id: i64,
+    pub name: String,
+    pub artifact_type: String,
+    pub path: String,
+    pub size_bytes: i64,
+    pub created_at: String,
+}
+
+/// Record a new artifact in the DB.
+pub fn record_artifact(
+    conn: &Connection,
+    task_id: i64,
+    plan_id: i64,
+    name: &str,
+    artifact_type: &str,
+    path: &str,
+    size_bytes: i64,
+) -> Result<i64, rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO artifacts \
+         (task_id, plan_id, name, artifact_type, path, size_bytes) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![task_id, plan_id, name, artifact_type, path, size_bytes],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// List artifacts for a plan.
+pub fn list_artifacts(conn: &Connection, plan_id: i64) -> Vec<Artifact> {
+    let mut stmt = match conn.prepare(
+        "SELECT id, task_id, plan_id, name, artifact_type, path, \
+         size_bytes, created_at FROM artifacts WHERE plan_id = ?1 ORDER BY id",
+    ) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    stmt.query_map(params![plan_id], map_artifact)
+        .ok()
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+}
+
+/// Get a single artifact by ID.
+pub fn get_artifact(conn: &Connection, id: i64) -> Option<Artifact> {
+    conn.query_row(
+        "SELECT id, task_id, plan_id, name, artifact_type, path, \
+         size_bytes, created_at FROM artifacts WHERE id = ?1",
+        params![id],
+        map_artifact,
+    )
+    .ok()
+}
+
+/// List artifacts for a specific task.
+pub fn list_task_artifacts(conn: &Connection, task_id: i64) -> Vec<Artifact> {
+    let mut stmt = match conn.prepare(
+        "SELECT id, task_id, plan_id, name, artifact_type, path, \
+         size_bytes, created_at FROM artifacts WHERE task_id = ?1 ORDER BY id",
+    ) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    stmt.query_map(params![task_id], map_artifact)
+        .ok()
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+}
+
+fn map_artifact(r: &rusqlite::Row) -> rusqlite::Result<Artifact> {
+    Ok(Artifact {
+        id: r.get(0)?,
+        task_id: r.get(1)?,
+        plan_id: r.get(2)?,
+        name: r.get(3)?,
+        artifact_type: r.get(4)?,
+        path: r.get(5)?,
+        size_bytes: r.get(6)?,
+        created_at: r.get(7)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        for m in crate::schema_tracking::tracking_migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        // Seed plan + task
+        conn.execute(
+            "INSERT INTO plans(id, project_id, name) VALUES (1, 'proj-alpha', 'Report Plan')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tasks(id, plan_id, status) VALUES (10, 1, 'in_progress')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_record_and_list_artifacts() {
+        let conn = setup();
+        let id1 = record_artifact(
+            &conn,
+            10,
+            1,
+            "quarterly.pdf",
+            "pdf",
+            "1/quarterly.pdf",
+            4096,
+        )
+        .unwrap();
+        let id2 =
+            record_artifact(&conn, 10, 1, "summary.md", "document", "1/summary.md", 1024).unwrap();
+        assert!(id1 > 0);
+        assert!(id2 > id1);
+
+        let arts = list_artifacts(&conn, 1);
+        assert_eq!(arts.len(), 2);
+        assert_eq!(arts[0].name, "quarterly.pdf");
+        assert_eq!(arts[1].name, "summary.md");
+    }
+
+    #[test]
+    fn test_list_task_artifacts() {
+        let conn = setup();
+        // Add a second task
+        conn.execute(
+            "INSERT INTO tasks(id, plan_id, status) VALUES (20, 1, 'pending')",
+            [],
+        )
+        .unwrap();
+        record_artifact(&conn, 10, 1, "report.pdf", "pdf", "1/report.pdf", 2048).unwrap();
+        record_artifact(&conn, 20, 1, "chart.png", "screenshot", "1/chart.png", 8192).unwrap();
+
+        let task10 = list_task_artifacts(&conn, 10);
+        assert_eq!(task10.len(), 1);
+        assert_eq!(task10[0].name, "report.pdf");
+
+        let task20 = list_task_artifacts(&conn, 20);
+        assert_eq!(task20.len(), 1);
+        assert_eq!(task20[0].name, "chart.png");
+    }
+
+    #[test]
+    fn test_get_artifact_by_id() {
+        let conn = setup();
+        let id =
+            record_artifact(&conn, 10, 1, "deck.pptx", "bundle", "1/deck.pptx", 51200).unwrap();
+        let art = get_artifact(&conn, id).unwrap();
+        assert_eq!(art.name, "deck.pptx");
+        assert_eq!(art.size_bytes, 51200);
+
+        assert!(get_artifact(&conn, 9999).is_none());
+    }
+}

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -76,7 +76,8 @@ impl Extension for OrchestratorExtension {
             .merge(crate::pm_routes::pm_routes(self.pool.clone()))
             .merge(crate::aggregation_routes::aggregation_routes(
                 self.pool.clone(),
-            ));
+            ))
+            .merge(crate::artifact_routes::artifact_routes(self.pool.clone()));
         Some(router)
     }
 

--- a/daemon/crates/convergio-orchestrator/src/lib.rs
+++ b/daemon/crates/convergio-orchestrator/src/lib.rs
@@ -5,6 +5,8 @@
 pub mod actions;
 pub mod aggregation_routes;
 pub mod approval;
+pub mod artifact_routes;
+pub mod artifacts;
 pub mod executor;
 pub mod ext;
 pub mod gates;

--- a/daemon/crates/convergio-orchestrator/src/schema_tracking.rs
+++ b/daemon/crates/convergio-orchestrator/src/schema_tracking.rs
@@ -96,6 +96,23 @@ pub fn tracking_migrations() -> Vec<Migration> {
                  ALTER TABLE waves ADD COLUMN completed_at TEXT;\
                  ALTER TABLE waves ADD COLUMN cancelled_at TEXT;",
         },
+        Migration {
+            version: 8,
+            description: "artifact storage for non-code projects",
+            up: "CREATE TABLE IF NOT EXISTS artifacts (\
+                     id            INTEGER PRIMARY KEY AUTOINCREMENT,\
+                     task_id       INTEGER NOT NULL,\
+                     plan_id       INTEGER NOT NULL,\
+                     name          TEXT NOT NULL,\
+                     artifact_type TEXT NOT NULL DEFAULT 'document',\
+                     path          TEXT NOT NULL,\
+                     size_bytes    INTEGER NOT NULL DEFAULT 0,\
+                     created_at    TEXT NOT NULL DEFAULT (datetime('now'))\
+                 );\
+                 CREATE INDEX IF NOT EXISTS idx_artifacts_task ON artifacts(task_id);\
+                 CREATE INDEX IF NOT EXISTS idx_artifacts_plan ON artifacts(plan_id);\
+                 CREATE INDEX IF NOT EXISTS idx_artifacts_type ON artifacts(artifact_type);",
+        },
     ]
 }
 
@@ -115,6 +132,6 @@ mod tests {
         let tracking = tracking_migrations();
         let applied =
             convergio_db::migration::apply_migrations(&conn, "orchestrator", &tracking).unwrap();
-        assert_eq!(applied, 4);
+        assert_eq!(applied, 5);
     }
 }


### PR DESCRIPTION
## Summary
- Add `artifacts` table (migration v8) for storing non-code project outputs (reports, PDFs, screenshots, documents)
- New `artifacts.rs` module with CRUD functions: `record_artifact`, `list_artifacts`, `get_artifact`, `list_task_artifacts`
- New `artifact_routes.rs` with endpoints: multipart upload, list by plan/task, get metadata, file download streaming
- Add `review_pass` and `document` evidence types to `convergio-evidence` EvidenceKind enum
- Upload endpoint auto-records artifact evidence in `task_evidence` table
- Add `tokio-util` workspace dep (for `ReaderStream`), enable `multipart` on axum, `fs`+`io-util` on tokio

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (0 failures)
- [x] `cargo fmt --all` clean
- [x] Unit tests: `test_record_and_list_artifacts`, `test_list_task_artifacts`, `test_get_artifact_by_id`
- [x] All files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)