### PR TITLE
feat: add plan lifecycle E2E HTTP tests (fase 40b)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "tower 0.5.3",
  "tracing",
 ]
 

--- a/daemon/crates/convergio-orchestrator/Cargo.toml
+++ b/daemon/crates/convergio-orchestrator/Cargo.toml
@@ -20,3 +20,7 @@ reqwest = { workspace = true }
 axum = { workspace = true }
 libc = { workspace = true }
 tokio-util = { workspace = true }
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+convergio-ipc = { path = "../convergio-ipc" }

--- a/daemon/crates/convergio-orchestrator/tests/helpers/mod.rs
+++ b/daemon/crates/convergio-orchestrator/tests/helpers/mod.rs
@@ -1,0 +1,60 @@
+//! Shared test helpers for plan lifecycle E2E tests.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::Request;
+use axum::Router;
+use convergio_db::pool::{create_memory_pool, ConnPool};
+use convergio_orchestrator::plan_routes::{plan_routes, PlanState};
+use convergio_orchestrator::plan_routes_ext::plan_routes_ext;
+use convergio_orchestrator::task_routes::task_routes;
+
+/// Create an in-memory database with all orchestrator migrations applied.
+pub fn setup() -> (ConnPool, Arc<PlanState>) {
+    let pool = create_memory_pool().unwrap();
+    let conn = pool.get().unwrap();
+    // Schema registry for migration tracking
+    convergio_db::migration::ensure_registry(&conn).unwrap();
+    // Core orchestrator tables (v1-v3)
+    let base = convergio_orchestrator::schema::migrations();
+    convergio_db::migration::apply_migrations(&conn, "orchestrator", &base).unwrap();
+    // Tracking tables (v4-v8): plan_metadata, token_usage, etc.
+    let tracking = convergio_orchestrator::schema_tracking::tracking_migrations();
+    convergio_db::migration::apply_migrations(&conn, "orchestrator", &tracking).unwrap();
+    // IPC tables needed by task lifecycle emit
+    let ipc = convergio_ipc::schema::migrations();
+    convergio_db::migration::apply_migrations(&conn, "ipc", &ipc).unwrap();
+    drop(conn);
+    let state = Arc::new(PlanState {
+        pool: pool.clone(),
+        event_sink: None,
+        notify: Arc::new(tokio::sync::Notify::new()),
+    });
+    (pool, state)
+}
+
+/// Build the test router merging plan, plan_ext and task routes.
+pub fn app(state: &Arc<PlanState>) -> Router {
+    plan_routes(state.clone())
+        .merge(plan_routes_ext(state.clone()))
+        .merge(task_routes(state.clone()))
+}
+
+/// Build a POST request with JSON body.
+pub fn post_json(uri: &str, body: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_owned()))
+        .unwrap()
+}
+
+/// Extract JSON from response body.
+pub async fn json_body(resp: axum::http::Response<Body>) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}

--- a/daemon/crates/convergio-orchestrator/tests/plan_lifecycle_e2e.rs
+++ b/daemon/crates/convergio-orchestrator/tests/plan_lifecycle_e2e.rs
@@ -1,0 +1,146 @@
+//! E2E HTTP integration tests for plan lifecycle endpoints.
+//!
+//! Tests the real axum routes via tower::ServiceExt::oneshot against
+//! an in-memory SQLite database with full orchestrator migrations.
+
+mod helpers;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use helpers::{app, json_body, post_json, setup};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_create_plan() {
+    let (_, state) = setup();
+    let resp = app(&state)
+        .oneshot(post_json(
+            "/api/plan-db/create",
+            r#"{"project_id":"proj-1","name":"widget-plan",
+                "objective":"Build widget","motivation":"Customer need",
+                "requester":"roberto"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = json_body(resp).await;
+    assert_eq!(json["status"], "created");
+    assert!(json["id"].as_i64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn test_list_plans() {
+    let (_, state) = setup();
+    // Create two plans
+    for name in ["alpha-plan", "beta-plan"] {
+        let body = format!(
+            r#"{{"project_id":"proj-1","name":"{name}",
+                "objective":"obj","motivation":"mot","requester":"rob"}}"#,
+        );
+        let resp = app(&state)
+            .oneshot(post_json("/api/plan-db/create", &body))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+    // List
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/plan-db/list")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = json_body(resp).await;
+    let plans = json.as_array().expect("list should be an array");
+    assert_eq!(plans.len(), 2);
+}
+
+#[tokio::test]
+async fn test_get_plan() {
+    let (_, state) = setup();
+    let resp = app(&state)
+        .oneshot(post_json(
+            "/api/plan-db/create",
+            r#"{"project_id":"proj-1","name":"detail-plan",
+                "objective":"obj","motivation":"mot","requester":"rob"}"#,
+        ))
+        .await
+        .unwrap();
+    let created = json_body(resp).await;
+    let plan_id = created["id"].as_i64().unwrap();
+
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/plan-db/json/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = json_body(resp).await;
+    assert_eq!(json["name"], "detail-plan");
+    assert_eq!(json["status"], "todo");
+}
+
+#[tokio::test]
+async fn test_cancel_plan() {
+    let (_, state) = setup();
+    let resp = app(&state)
+        .oneshot(post_json(
+            "/api/plan-db/create",
+            r#"{"project_id":"proj-1","name":"cancel-me",
+                "objective":"obj","motivation":"mot","requester":"rob"}"#,
+        ))
+        .await
+        .unwrap();
+    let created = json_body(resp).await;
+    let plan_id = created["id"].as_i64().unwrap();
+
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/cancel/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = json_body(resp).await;
+    assert_eq!(json["status"], "cancelled");
+}
+
+#[tokio::test]
+async fn test_complete_plan() {
+    let (_, state) = setup();
+    let resp = app(&state)
+        .oneshot(post_json(
+            "/api/plan-db/create",
+            r#"{"project_id":"proj-1","name":"finish-plan",
+                "objective":"obj","motivation":"mot","requester":"rob"}"#,
+        ))
+        .await
+        .unwrap();
+    let plan_id = json_body(resp).await["id"].as_i64().unwrap();
+
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/complete/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = json_body(resp).await;
+    assert_eq!(json["status"], "done");
+}

--- a/daemon/crates/convergio-orchestrator/tests/plan_task_e2e.rs
+++ b/daemon/crates/convergio-orchestrator/tests/plan_task_e2e.rs
@@ -1,0 +1,206 @@
+//! E2E HTTP integration tests for task creation and plan lifecycle
+//! transitions that require task + Thor pre-review setup.
+
+mod helpers;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use helpers::{app, json_body, post_json, setup};
+use rusqlite::params;
+use tower::ServiceExt;
+
+/// Helper: create a plan and return its id.
+async fn create_plan(
+    state: &std::sync::Arc<convergio_orchestrator::plan_routes::PlanState>,
+) -> i64 {
+    let resp = app(state)
+        .oneshot(post_json(
+            "/api/plan-db/create",
+            r#"{"project_id":"proj-1","name":"task-plan",
+                "objective":"obj","motivation":"mot","requester":"rob"}"#,
+        ))
+        .await
+        .unwrap();
+    json_body(resp).await["id"].as_i64().unwrap()
+}
+
+#[tokio::test]
+async fn test_task_create() {
+    let (_, state) = setup();
+    let plan_id = create_plan(&state).await;
+
+    // Create a wave first (tasks reference wave_id)
+    let wave_body = format!(r#"{{"plan_id":{plan_id},"wave_id":"W-1","name":"wave-alpha"}}"#,);
+    let resp = app(&state)
+        .oneshot(post_json("/api/plan-db/wave/create", &wave_body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let wave = json_body(resp).await;
+    let wave_db_id = wave["id"].as_i64().unwrap();
+
+    // Create a task
+    let task_body = format!(
+        r#"{{"plan_id":{plan_id},"wave_id":{wave_db_id},
+            "title":"Implement feature X","description":"Full impl"}}"#,
+    );
+    let resp = app(&state)
+        .oneshot(post_json("/api/plan-db/task/create", &task_body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let task = json_body(resp).await;
+    assert!(task["id"].as_i64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn test_plan_lifecycle_with_thor_review() {
+    let (pool, state) = setup();
+    let plan_id = create_plan(&state).await;
+
+    // Verify initial status is todo
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/plan-db/json/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(json_body(resp).await["status"], "todo");
+
+    // Create wave + task (StartGate requires >= 1 task)
+    let wave_body = format!(r#"{{"plan_id":{plan_id},"wave_id":"W-1","name":"wave-1"}}"#,);
+    let wave = json_body(
+        app(&state)
+            .oneshot(post_json("/api/plan-db/wave/create", &wave_body))
+            .await
+            .unwrap(),
+    )
+    .await;
+    let wid = wave["id"].as_i64().unwrap();
+
+    let task_body = format!(r#"{{"plan_id":{plan_id},"wave_id":{wid},"title":"Task 1"}}"#,);
+    app(&state)
+        .oneshot(post_json("/api/plan-db/task/create", &task_body))
+        .await
+        .unwrap();
+
+    // Start without Thor review should fail
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/start/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = json_body(resp).await;
+    assert_eq!(body["gate"], "ThorPreReview");
+
+    // Insert a passing Thor pre-review into plan_metadata
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "UPDATE plan_metadata SET report_json = ?1 WHERE plan_id = ?2",
+        params![
+            r#"{"pre_review":true,"verdict":"pass","notes":"ok"}"#,
+            plan_id
+        ],
+    )
+    .unwrap();
+    drop(conn);
+
+    // Now start should succeed
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/start/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json_body(resp).await;
+    assert_eq!(body["status"], "in_progress");
+
+    // Complete the plan
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/complete/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(json_body(resp).await["status"], "done");
+}
+
+#[tokio::test]
+async fn test_start_gate_blocks_without_tasks() {
+    let (pool, state) = setup();
+    let plan_id = create_plan(&state).await;
+
+    // Insert passing Thor review
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "UPDATE plan_metadata SET report_json = ?1 WHERE plan_id = ?2",
+        params![r#"{"pre_review":true,"verdict":"pass"}"#, plan_id],
+    )
+    .unwrap();
+    drop(conn);
+
+    // Start should fail: no tasks
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/start/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = json_body(resp).await;
+    assert_eq!(body["gate"], "StartGate");
+}
+
+#[tokio::test]
+async fn test_list_plans_filter_by_status() {
+    let (_, state) = setup();
+    // Create and cancel one plan
+    let plan_id = create_plan(&state).await;
+    app(&state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/plan-db/cancel/{plan_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Create another plan (stays todo)
+    create_plan(&state).await;
+
+    // Filter by cancelled
+    let resp = app(&state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/plan-db/list?status=cancelled")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let plans = json_body(resp).await;
+    let arr = plans.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["status"], "cancelled");
+}


### PR DESCRIPTION
## Summary
- Add 9 E2E HTTP integration tests for the orchestrator plan-db API endpoints
- Tests use `tower::ServiceExt::oneshot` against in-memory SQLite with full migrations
- Covers: plan CRUD (create, list, get, cancel, complete), task creation via wave, full lifecycle with Thor pre-review bypass, StartGate validation, and status filtering

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (921+ tests, 0 failures)
- [x] `cargo fmt --all` applied
- [x] All 9 new integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)