### PR TITLE
docs: add ADR collection and guides (fase 47)

### DIFF
--- a/docs/adr/ADR-001-new-repo-over-refactoring.md
+++ b/docs/adr/ADR-001-new-repo-over-refactoring.md
@@ -1,0 +1,25 @@
+# ADR-001: New repository over refactoring
+
+## Status
+
+Accepted
+
+## Context
+
+The original Convergio repository had accumulated 845 commits, a 784 MB `.git`
+directory, and significant cruft across the codebase. Refactoring in-place would
+require untangling years of incremental decisions while preserving backward
+compatibility with every existing script and workflow.
+
+## Decision
+
+Start a fresh repository with a clean workspace layout. Migrate only the
+architecture decisions and proven patterns from the old codebase, not the code
+itself. Build each crate from scratch following the Extension trait contract.
+
+## Consequences
+
+- Clean dependency graph from day one — no hidden circular imports.
+- Full git history from the old repo is lost (archived separately).
+- Migration scripts needed for any data carried forward.
+- Every crate starts with proper tests and documentation.

--- a/docs/adr/ADR-002-extension-trait-single-contract.md
+++ b/docs/adr/ADR-002-extension-trait-single-contract.md
@@ -1,0 +1,25 @@
+# ADR-002: Extension trait as single contract
+
+## Status
+
+Accepted
+
+## Context
+
+The system needs pluggable modules (billing, observatory, voice, org management,
+etc.) that can be added or removed without changing the core daemon. Multiple
+contract styles were considered: service registries, plugin DLLs, microservices.
+
+## Decision
+
+Define one Rust trait `Extension` that every module must implement. The trait
+exposes: `manifest()`, `routes()`, `migrations()`, `health()`, and `metrics()`.
+The server collects all extensions at startup and wires them into the router.
+
+## Consequences
+
+- Zero alternative paths — every module follows the same lifecycle.
+- New extensions are trivial to add: implement the trait, register in `main.rs`.
+- All modules are equal citizens (no first-class vs second-class distinction).
+- Tight coupling to the trait signature; changes require updating all extensions.
+- HTTP bridge extensions wrap external services behind the same trait.

--- a/docs/adr/ADR-003-sqlite-wal-over-postgres.md
+++ b/docs/adr/ADR-003-sqlite-wal-over-postgres.md
@@ -1,0 +1,27 @@
+# ADR-003: SQLite + WAL over Postgres
+
+## Status
+
+Accepted
+
+## Context
+
+Convergio runs as a single-node daemon. It needs persistent storage for plans,
+tasks, agents, events, and configuration. Postgres would add operational
+complexity (separate process, connection management, backups) for a system that
+runs on one machine.
+
+## Decision
+
+Use SQLite with WAL (Write-Ahead Logging) mode as the sole database engine.
+Each extension owns its tables via `migrations()`. The daemon manages a single
+connection pool with r2d2.
+
+## Consequences
+
+- Zero external dependencies for storage — no database server to install.
+- Portable: the entire state is one file, easy to backup and restore.
+- WAL mode allows concurrent reads during writes.
+- Limited write concurrency (one writer at a time).
+- No network database access — CLI must go through the daemon HTTP API.
+- FTS5 available for full-text search (used by Observatory).

--- a/docs/adr/ADR-004-cli-pure-http-client.md
+++ b/docs/adr/ADR-004-cli-pure-http-client.md
@@ -1,0 +1,25 @@
+# ADR-004: CLI as pure HTTP client
+
+## Status
+
+Accepted
+
+## Context
+
+The CLI (`cvg`) needs to interact with the daemon for plan management, agent
+control, status queries, and configuration. Importing daemon internals would
+create tight coupling and make the CLI impossible to test independently.
+
+## Decision
+
+The CLI makes only HTTP calls to the daemon API. It has zero internal imports
+from any daemon crate. It depends only on `convergio-types` for shared data
+structures.
+
+## Consequences
+
+- Full decoupling: CLI and daemon can be versioned independently.
+- CLI is testable without running the daemon (mock HTTP responses).
+- Works across the network — CLI can target a remote daemon.
+- Every feature must be exposed as an HTTP endpoint before the CLI can use it.
+- 209 tests validate CLI behavior against expected HTTP contracts.

--- a/docs/adr/ADR-005-isolated-worktrees-per-task.md
+++ b/docs/adr/ADR-005-isolated-worktrees-per-task.md
@@ -1,0 +1,24 @@
+# ADR-005: Isolated worktrees per task
+
+## Status
+
+Accepted
+
+## Context
+
+Multiple AI agents working in parallel on the same repository caused file
+conflicts, uncommitted changes overwriting each other, and broken builds. The
+root cause was shared filesystem state (Learning #4 from project history).
+
+## Decision
+
+Every task gets its own git worktree under `.worktrees/`. One worktree equals
+one branch equals one PR. Agents never work in the main checkout.
+
+## Consequences
+
+- Complete filesystem isolation between parallel tasks.
+- No accidental file overwrites between agents.
+- Higher disk usage (each worktree is a partial clone).
+- Merge discipline required: worktrees must be cleaned up after merge.
+- Branch naming convention enforced: `worktree-agent-<id>`.

--- a/docs/adr/ADR-006-no-squash-merge.md
+++ b/docs/adr/ADR-006-no-squash-merge.md
@@ -1,0 +1,25 @@
+# ADR-006: No squash merge
+
+## Status
+
+Accepted
+
+## Context
+
+When multiple agents work in parallel, squash merging one branch can silently
+overwrite or lose commits from other branches that were based on the same parent.
+This caused lost work on at least one occasion (Learning #23).
+
+## Decision
+
+Disable squash merge and rebase merge at the GitHub repository level. Only merge
+commits are allowed.
+
+## Consequences
+
+- Full commit history preserved for every branch.
+- Parallel agents can merge safely without losing each other's work.
+- Git log is longer with merge commits.
+- Enforced at the repository settings level — cannot be bypassed per-PR.
+
+See also: [ADR-011](ADR-011-merge-commit-only.md) for enforcement details.

--- a/docs/adr/ADR-007-agents-md-universal.md
+++ b/docs/adr/ADR-007-agents-md-universal.md
@@ -1,0 +1,25 @@
+# ADR-007: AGENTS.md universal over CLAUDE.md
+
+## Status
+
+Accepted
+
+## Context
+
+The original `CLAUDE.md` configuration file was only read by Claude Code.
+Other LLM agents (Copilot, Codex, Gemini, local models) ignored it entirely,
+leading to inconsistent behavior across providers (Learning #20).
+
+## Decision
+
+Create a universal `AGENTS.md` at the repository root that contains all rules
+for any LLM agent. Keep `CLAUDE.md` as a thin pointer that says "read
+AGENTS.md" plus Claude-specific settings (language, model name).
+
+## Consequences
+
+- Provider-agnostic: any LLM agent can follow the same rules.
+- Single source of truth for code style, workflow, and constraints.
+- Claude-specific settings (Italian conversation, Co-Authored-By) stay in
+  `.claude/CLAUDE.md`.
+- New agent providers only need to be taught to read `AGENTS.md`.

--- a/docs/adr/ADR-008-domain-event-sink-via-appcontext.md
+++ b/docs/adr/ADR-008-domain-event-sink-via-appcontext.md
@@ -1,0 +1,25 @@
+# ADR-008: DomainEventSink via AppContext
+
+## Status
+
+Accepted
+
+## Context
+
+Extensions need to emit domain events (PlanCreated, TaskCompleted, etc.) without
+depending directly on the IPC crate. Circular dependencies between crates would
+break the clean dependency graph.
+
+## Decision
+
+Define a `DomainEventSink` trait in the `convergio-types` crate (which has zero
+dependencies). Inject an implementation via `AppContext` at startup. Any
+extension can call `ctx.event_sink().emit(event)` without importing IPC.
+
+## Consequences
+
+- Any extension can emit events with no direct dependency on IPC internals.
+- The types crate remains dependency-free.
+- Event routing is configured once at startup in `main.rs`.
+- Testing is easy: inject a mock sink that collects events.
+- SSE streaming consumes these events for real-time UI updates.

--- a/docs/adr/ADR-009-agent-spawning-real-processes.md
+++ b/docs/adr/ADR-009-agent-spawning-real-processes.md
@@ -1,0 +1,25 @@
+# ADR-009: Agent spawning with real processes
+
+## Status
+
+Accepted
+
+## Context
+
+AI agents need to execute code changes in isolated environments. Simulating
+execution or running agents in-process would limit isolation and make cleanup
+unreliable.
+
+## Decision
+
+Spawn agents as real OS processes via fork+exec. Each agent gets its own git
+worktree, runs its task, commits, pushes, and creates a PR. A monitor process
+tracks heartbeats and handles timeouts.
+
+## Consequences
+
+- True filesystem and process isolation per agent.
+- Automatic cleanup via process termination.
+- Push and PR creation happen from the agent's worktree.
+- Process management complexity: need to handle zombies, timeouts, crashes.
+- Monitor must use `waitpid(WNOHANG)` for proper detection (see ADR-014).

--- a/docs/adr/ADR-010-thor-pre-post-review.md
+++ b/docs/adr/ADR-010-thor-pre-post-review.md
@@ -1,0 +1,27 @@
+# ADR-010: Thor pre+post review
+
+## Status
+
+Accepted
+
+## Context
+
+Plans executed without review can waste resources on poorly defined objectives
+or produce low-quality results. A validation step is needed both before
+execution starts and after it completes.
+
+## Decision
+
+Thor acts as a challenger/reviewer with two gates:
+1. **Pre-review**: validates the plan before any task starts (objective clarity,
+   task decomposition, risk assessment).
+2. **Post-review**: validates completed work against the original objective
+   (evidence check, quality assessment).
+
+## Consequences
+
+- Quality gate prevents wasted execution on bad plans.
+- Post-review catches issues before results reach the user.
+- Thor can become a bottleneck if review is slow.
+- Review failures must be handled gracefully (retry, escalate, or reject).
+- Only Thor can promote task status from `submitted` to `done`.

--- a/docs/adr/ADR-011-merge-commit-only.md
+++ b/docs/adr/ADR-011-merge-commit-only.md
@@ -1,0 +1,32 @@
+# ADR-011: Merge commit only (enforced)
+
+## Status
+
+Accepted
+
+## Context
+
+With multiple parallel agents merging PRs, both squash merge and rebase merge
+cause problems: squash loses individual commits from other branches, rebase
+rewrites SHAs that other branches reference (Learnings #23-24).
+
+## Decision
+
+Disable squash merge and rebase merge at the GitHub repository level using:
+
+```bash
+gh api repos/OWNER/REPO -X PATCH \
+  -f allow_squash_merge=false \
+  -f allow_rebase_merge=false \
+  -f allow_merge_commit=true
+```
+
+## Consequences
+
+- Full history preserved for every branch and every commit.
+- Merge commits appear in the log (longer but accurate history).
+- Parallel agents can merge without invalidating each other's refs.
+- Cannot be overridden per-PR — repository-level enforcement.
+- New repositories must apply the same setting at creation time.
+
+See also: [ADR-006](ADR-006-no-squash-merge.md) for the rationale.

--- a/docs/adr/ADR-012-launchd-absolute-paths.md
+++ b/docs/adr/ADR-012-launchd-absolute-paths.md
@@ -1,0 +1,24 @@
+# ADR-012: launchd with absolute paths
+
+## Status
+
+Accepted
+
+## Context
+
+macOS `launchd` runs services with a minimal `PATH` that does not include
+Homebrew, Cargo, or user-installed binaries. Services that rely on `PATH`
+resolution fail silently or use wrong binary versions (Learnings #19-20).
+
+## Decision
+
+Use absolute paths for all binaries referenced in the launchd plist file.
+The plist sets a full `PATH` environment variable and references the daemon
+binary by its complete filesystem path.
+
+## Consequences
+
+- Daemon starts correctly as a launchd service regardless of shell config.
+- Binary paths must be updated in the plist when the install location changes.
+- The plist includes a rebuild step after PR merge to keep the binary current.
+- No dependency on the user's shell profile or PATH configuration.

--- a/docs/adr/ADR-013-inference-multi-tier-routing.md
+++ b/docs/adr/ADR-013-inference-multi-tier-routing.md
@@ -1,0 +1,35 @@
+# ADR-013: Inference multi-tier routing
+
+## Status
+
+Accepted
+
+## Context
+
+Different tasks require different model capabilities. A simple status check
+does not need the same model as a complex architectural review. Using a single
+expensive model for everything wastes budget; using only cheap models produces
+poor results on hard tasks.
+
+## Decision
+
+Implement a 4-tier inference routing system:
+
+| Tier | Use case | Examples |
+|------|----------|---------|
+| t1 | Trivial | Status formatting, template filling |
+| t2 | Standard | Code generation, test writing |
+| t3 | Complex | Architecture review, multi-file refactor |
+| t4 | Critical | Security audit, production decisions |
+
+A semantic classifier assigns tiers. Budget-aware downgrade falls back to a
+lower tier when budget is exhausted. Local models (Ollama) serve as the
+bottom-tier fallback.
+
+## Consequences
+
+- Cost optimization: most tasks use cheaper models.
+- Local-first: Ollama handles t1/t2 without API calls.
+- Graceful degradation when cloud APIs are unavailable or budget-limited.
+- Classification accuracy affects quality — misrouted tasks get wrong models.
+- Model configuration loaded from TOML at startup with cloud health checks.

--- a/docs/adr/ADR-014-monitor-waitpid.md
+++ b/docs/adr/ADR-014-monitor-waitpid.md
@@ -1,0 +1,24 @@
+# ADR-014: Monitor with waitpid
+
+## Status
+
+Accepted
+
+## Context
+
+The agent monitor needs to detect when spawned processes terminate. Using
+`kill(pid, 0)` only checks if the process exists but cannot distinguish between
+a running process and a zombie process. Zombies appear alive to `kill(0)` but
+are actually dead.
+
+## Decision
+
+Use `waitpid(pid, WNOHANG)` for process monitoring. This correctly detects
+terminated processes (including zombies) and reaps them in a single call.
+
+## Consequences
+
+- Proper zombie detection and reaping.
+- Non-blocking check via `WNOHANG` — monitor loop does not stall.
+- Unix-specific code (not portable to Windows without abstraction).
+- Monitor can retrieve exit status for logging and error reporting.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,42 @@
+# Architecture Decision Records
+
+This directory contains the ADRs for the Convergio project. Each record
+documents a significant architectural decision, its context, and consequences.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [001](ADR-001-new-repo-over-refactoring.md) | New repository over refactoring | Accepted |
+| [002](ADR-002-extension-trait-single-contract.md) | Extension trait as single contract | Accepted |
+| [003](ADR-003-sqlite-wal-over-postgres.md) | SQLite + WAL over Postgres | Accepted |
+| [004](ADR-004-cli-pure-http-client.md) | CLI as pure HTTP client | Accepted |
+| [005](ADR-005-isolated-worktrees-per-task.md) | Isolated worktrees per task | Accepted |
+| [006](ADR-006-no-squash-merge.md) | No squash merge | Accepted |
+| [007](ADR-007-agents-md-universal.md) | AGENTS.md universal over CLAUDE.md | Accepted |
+| [008](ADR-008-domain-event-sink-via-appcontext.md) | DomainEventSink via AppContext | Accepted |
+| [009](ADR-009-agent-spawning-real-processes.md) | Agent spawning with real processes | Accepted |
+| [010](ADR-010-thor-pre-post-review.md) | Thor pre+post review | Accepted |
+| [011](ADR-011-merge-commit-only.md) | Merge commit only (enforced) | Accepted |
+| [012](ADR-012-launchd-absolute-paths.md) | launchd with absolute paths | Accepted |
+| [013](ADR-013-inference-multi-tier-routing.md) | Inference multi-tier routing | Accepted |
+| [014](ADR-014-monitor-waitpid.md) | Monitor with waitpid | Accepted |
+
+## Format
+
+Each ADR follows a standard template:
+
+```
+# ADR-NNN: Title
+## Status    — Accepted | Deprecated | Superseded by ADR-XXX
+## Context   — Why this decision was needed
+## Decision  — What was decided
+## Consequences — What follows from this decision
+```
+
+## Adding a new ADR
+
+1. Copy the template above.
+2. Use the next available number.
+3. Name the file `ADR-NNN-short-slug.md`.
+4. Add an entry to this index.

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,126 @@
+# Architecture Overview
+
+Convergio is a modular daemon (26 Rust crates) that serves as invisible
+infrastructure for autonomous AI organizations.
+
+## Three layers
+
+```
+┌─────────────────────────────────────────────────────┐
+│  EXTENSIONS (pluggable, replaceable)                │
+│  kernel, org, voice, billing, backup, observatory,  │
+│  org-package, mcp, evidence, long-running, ...      │
+├─────────────────────────────────────────────────────┤
+│  PLATFORM (orchestration)                           │
+│  orchestrator, agent-runtime, inference, prompts    │
+├─────────────────────────────────────────────────────┤
+│  INFRASTRUCTURE (core — must be perfect)            │
+│  types, telemetry, db, security, ipc, mesh, server  │
+└─────────────────────────────────────────────────────┘
+```
+
+**Infrastructure** provides the foundation: database, networking, security,
+inter-process communication. It never contains business logic.
+
+**Platform** coordinates work: planning, task assignment, model selection,
+agent lifecycle. It depends on infrastructure but not on extensions.
+
+**Extensions** implement business capabilities. Each is a self-contained
+module that registers via the `Extension` trait. Extensions can be added
+or removed without changing the core.
+
+## Core loop
+
+```
+Goal → Org routing → Agent assignment → Model selection
+  → Execution → Evidence → Thor review → Sync
+```
+
+1. A **goal** arrives (API call or user request).
+2. The **orchestrator** creates a plan with waves and tasks.
+3. **Thor** pre-reviews the plan before execution starts ([ADR-010]).
+4. The **agent runtime** spawns agents in isolated worktrees ([ADR-005]).
+5. **Inference routing** selects the appropriate model tier ([ADR-013]).
+6. Agents execute, commit, push, and create PRs ([ADR-009]).
+7. The **evidence gate** validates results before promotion.
+8. **Thor** post-reviews completed work.
+9. **Mesh sync** propagates state to peer nodes.
+
+## Extension contract
+
+Every module implements one trait:
+
+```rust
+pub trait Extension: Send + Sync {
+    fn manifest(&self) -> ExtensionManifest;
+    fn routes(&self) -> Option<Router>;
+    fn migrations(&self) -> Vec<Migration>;
+    fn health(&self) -> HealthStatus;
+    fn metrics(&self) -> Vec<Metric>;
+}
+```
+
+See [ADR-002] for the rationale. The manifest declares `provides` (capabilities
+with SemVer), `requires` (dependencies), and `agent_tools` (tools callable by
+AI agents).
+
+## Dependency graph
+
+```
+types (zero deps)
+  ├── telemetry
+  ├── db
+  ├── security
+  ├── ipc ──→ db, telemetry
+  ├── mesh ──→ db, security, telemetry
+  ├── orchestrator ──→ db, ipc, telemetry
+  ├── server ──→ collects Extension from all crates
+  ├── cli ──→ types only (HTTP client, ADR-004)
+  └── extensions ──→ types, db, telemetry
+```
+
+The `types` crate is the root of the dependency tree. It contains shared
+data structures, the `Extension` trait, error types, and the
+`DomainEventSink` trait ([ADR-008]).
+
+## Database
+
+SQLite with WAL mode ([ADR-003]). Each extension owns its tables via
+`migrations()`. The daemon runs all migrations at startup. Current count:
+59+ tables across 19 extensions.
+
+## Key design decisions
+
+| Decision | ADR |
+|----------|-----|
+| Fresh repo instead of refactoring | [ADR-001] |
+| Single Extension trait | [ADR-002] |
+| SQLite + WAL | [ADR-003] |
+| CLI as HTTP client | [ADR-004] |
+| Worktree isolation | [ADR-005] |
+| No squash merge | [ADR-006] |
+| Universal AGENTS.md | [ADR-007] |
+| DomainEventSink via AppContext | [ADR-008] |
+| Real process spawning | [ADR-009] |
+| Thor pre+post review | [ADR-010] |
+| Merge commit only | [ADR-011] |
+| launchd absolute paths | [ADR-012] |
+| Multi-tier inference | [ADR-013] |
+| waitpid monitoring | [ADR-014] |
+
+Browse all records in the [ADR directory](../adr/README.md).
+
+[ADR-001]: ../adr/ADR-001-new-repo-over-refactoring.md
+[ADR-002]: ../adr/ADR-002-extension-trait-single-contract.md
+[ADR-003]: ../adr/ADR-003-sqlite-wal-over-postgres.md
+[ADR-004]: ../adr/ADR-004-cli-pure-http-client.md
+[ADR-005]: ../adr/ADR-005-isolated-worktrees-per-task.md
+[ADR-006]: ../adr/ADR-006-no-squash-merge.md
+[ADR-007]: ../adr/ADR-007-agents-md-universal.md
+[ADR-008]: ../adr/ADR-008-domain-event-sink-via-appcontext.md
+[ADR-009]: ../adr/ADR-009-agent-spawning-real-processes.md
+[ADR-010]: ../adr/ADR-010-thor-pre-post-review.md
+[ADR-011]: ../adr/ADR-011-merge-commit-only.md
+[ADR-012]: ../adr/ADR-012-launchd-absolute-paths.md
+[ADR-013]: ../adr/ADR-013-inference-multi-tier-routing.md
+[ADR-014]: ../adr/ADR-014-monitor-waitpid.md

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,115 @@
+# Getting Started
+
+This guide walks you through building and running the Convergio daemon locally.
+
+## Prerequisites
+
+| Tool | Minimum version | Install |
+|------|----------------|---------|
+| Rust | 1.75+ | [rustup.rs](https://rustup.rs) |
+| SQLite | 3.35+ (bundled) | Included via `rusqlite` with `bundled` feature |
+| Git | 2.40+ | System package manager |
+| curl | any | Usually pre-installed |
+
+## Clone and build
+
+```bash
+git clone https://github.com/Roberdan/convergio.git
+cd convergio/daemon
+cargo build --release
+```
+
+The release binary is at `./target/release/convergio`.
+
+## Run the daemon
+
+```bash
+./target/release/convergio
+```
+
+The daemon starts on port **8420** by default. It will:
+
+1. Create or open the SQLite database (`convergio.db`).
+2. Run all pending migrations (59+ tables across 19 extensions).
+3. Register all extensions and mount their routes.
+4. Start the HTTP server.
+
+## Health check
+
+```bash
+curl http://localhost:8420/api/health
+```
+
+Expected response:
+
+```json
+{"status": "ok"}
+```
+
+For a deep health check across all 19 components:
+
+```bash
+curl http://localhost:8420/api/health/deep
+```
+
+## CLI
+
+The `cvg` CLI communicates with the daemon via HTTP.
+
+```bash
+# Check daemon status
+cvg status
+
+# List all plans
+cvg plan list
+
+# Get details for a specific plan
+cvg plan get <plan-id>
+```
+
+## Create your first plan
+
+```bash
+curl -X POST http://localhost:8420/api/plans \
+  -H "Content-Type: application/json" \
+  -d '{
+    "objective": "Add user preferences endpoint",
+    "motivation": "Users need to save display settings",
+    "requester": "getting-started-guide"
+  }'
+```
+
+The response includes a `plan_id`. Use it to check status:
+
+```bash
+curl http://localhost:8420/api/plans/<plan-id>
+```
+
+## Configuration
+
+The daemon reads configuration from `convergio.toml` in the working directory.
+Key sections:
+
+| Section | Purpose |
+|---------|---------|
+| `[server]` | Host, port, auth mode |
+| `[database]` | Path, WAL settings, pool size |
+| `[inference]` | Model tiers, Ollama/OpenAI endpoints |
+| `[mesh]` | Node identity, peer list, sync interval |
+| `[telemetry]` | Log level, metrics export |
+
+## Running as a macOS service
+
+```bash
+# Install the launchd plist
+cp scripts/com.convergio.daemon.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.convergio.daemon.plist
+```
+
+The plist uses absolute paths (see [ADR-012](../adr/ADR-012-launchd-absolute-paths.md)).
+
+## Next steps
+
+- Read the [Architecture overview](architecture.md) for system design.
+- Browse the [ADR collection](../adr/README.md) for key decisions.
+- Check `AGENTS.md` in the repo root for contribution rules.


### PR DESCRIPTION
## Summary

- 14 Architecture Decision Records (ADR-001 through ADR-014) documenting key design choices: fresh repo, Extension trait, SQLite+WAL, CLI as HTTP client, worktree isolation, no squash merge, AGENTS.md, DomainEventSink, agent spawning, Thor review, merge commits, launchd paths, inference routing, waitpid monitoring
- Getting-started guide with build, run, health check, CLI usage, and first plan creation
- Architecture overview with three-layer diagram, core loop, Extension contract, dependency graph, and ADR cross-references
- ADR index README with links and template for future records

## Test plan

- [ ] Verify all 14 ADR files render correctly on GitHub
- [ ] Verify internal links between ADRs and guides resolve
- [ ] Confirm all files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)