### PR TITLE
feat: add artifact bundles and metadata enrichment (fase 41)

### DIFF
--- a/daemon/crates/convergio-orchestrator/src/artifact_bundle.rs
+++ b/daemon/crates/convergio-orchestrator/src/artifact_bundle.rs
@@ -1,0 +1,227 @@
+// Artifact bundle management — group artifacts into deliverables.
+// WHY: Production workflows need to package multiple artifacts into a single
+// reviewable unit (report pack, evidence bundle, deliverable set).
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactBundle {
+    pub id: i64,
+    pub plan_id: i64,
+    pub name: String,
+    pub bundle_type: String,
+    pub status: String,
+    pub created_at: String,
+    pub published_at: Option<String>,
+}
+
+/// Create a new bundle for a plan.
+pub fn create_bundle(
+    conn: &Connection,
+    plan_id: i64,
+    name: &str,
+    bundle_type: &str,
+) -> Result<i64, rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO artifact_bundles (plan_id, name, bundle_type) \
+         VALUES (?1, ?2, ?3)",
+        params![plan_id, name, bundle_type],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Add an artifact to a bundle (idempotent).
+pub fn add_to_bundle(
+    conn: &Connection,
+    bundle_id: i64,
+    artifact_id: i64,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT OR IGNORE INTO bundle_artifacts (bundle_id, artifact_id) \
+         VALUES (?1, ?2)",
+        params![bundle_id, artifact_id],
+    )?;
+    Ok(())
+}
+
+/// List bundles for a plan.
+pub fn list_bundles(conn: &Connection, plan_id: i64) -> Vec<ArtifactBundle> {
+    let mut stmt = match conn.prepare(
+        "SELECT id, plan_id, name, bundle_type, status, created_at, published_at \
+         FROM artifact_bundles WHERE plan_id = ?1 ORDER BY id",
+    ) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    stmt.query_map(params![plan_id], map_bundle)
+        .ok()
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default()
+}
+
+/// Get a bundle with its artifact IDs.
+pub fn get_bundle_with_artifacts(
+    conn: &Connection,
+    bundle_id: i64,
+) -> Option<(ArtifactBundle, Vec<i64>)> {
+    let bundle = conn
+        .query_row(
+            "SELECT id, plan_id, name, bundle_type, status, created_at, published_at \
+             FROM artifact_bundles WHERE id = ?1",
+            params![bundle_id],
+            map_bundle,
+        )
+        .ok()?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT artifact_id FROM bundle_artifacts \
+             WHERE bundle_id = ?1 ORDER BY artifact_id",
+        )
+        .ok()?;
+    let ids: Vec<i64> = stmt
+        .query_map(params![bundle_id], |r| r.get(0))
+        .ok()
+        .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default();
+    Some((bundle, ids))
+}
+
+/// Transition bundle status (draft -> reviewed -> published).
+pub fn update_bundle_status(
+    conn: &Connection,
+    bundle_id: i64,
+    status: &str,
+) -> Result<(), rusqlite::Error> {
+    let published_clause = if status == "published" {
+        ", published_at = datetime('now')"
+    } else {
+        ""
+    };
+    let sql = format!("UPDATE artifact_bundles SET status = ?1{published_clause} WHERE id = ?2");
+    conn.execute(&sql, params![status, bundle_id])?;
+    Ok(())
+}
+
+fn map_bundle(r: &rusqlite::Row) -> rusqlite::Result<ArtifactBundle> {
+    Ok(ArtifactBundle {
+        id: r.get(0)?,
+        plan_id: r.get(1)?,
+        name: r.get(2)?,
+        bundle_type: r.get(3)?,
+        status: r.get(4)?,
+        created_at: r.get(5)?,
+        published_at: r.get(6)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        for m in crate::schema_tracking::tracking_migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO plans(id, project_id, name) VALUES (1, 'proj-alpha', 'Report Plan')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tasks(id, plan_id, status) VALUES (10, 1, 'in_progress')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_create_and_list_bundles() {
+        let conn = setup();
+        let id1 = create_bundle(&conn, 1, "Q4 Deliverable", "deliverable").unwrap();
+        let id2 = create_bundle(&conn, 1, "Evidence Pack", "evidence-pack").unwrap();
+        assert!(id1 > 0);
+        assert!(id2 > id1);
+
+        let bundles = list_bundles(&conn, 1);
+        assert_eq!(bundles.len(), 2);
+        assert_eq!(bundles[0].name, "Q4 Deliverable");
+        assert_eq!(bundles[1].bundle_type, "evidence-pack");
+        assert_eq!(bundles[0].status, "draft");
+    }
+
+    #[test]
+    fn test_add_artifact_to_bundle() {
+        let conn = setup();
+        let bundle_id = create_bundle(&conn, 1, "Report Bundle", "deliverable").unwrap();
+        let art_id = crate::artifacts::record_artifact(
+            &conn,
+            10,
+            1,
+            "report.pdf",
+            "pdf",
+            "1/report.pdf",
+            4096,
+        )
+        .unwrap();
+        add_to_bundle(&conn, bundle_id, art_id).unwrap();
+        // Idempotent — second insert should not fail
+        add_to_bundle(&conn, bundle_id, art_id).unwrap();
+
+        let (_, ids) = get_bundle_with_artifacts(&conn, bundle_id).unwrap();
+        assert_eq!(ids, vec![art_id]);
+    }
+
+    #[test]
+    fn test_bundle_status_transition() {
+        let conn = setup();
+        let id = create_bundle(&conn, 1, "Final Report", "report").unwrap();
+        assert_eq!(list_bundles(&conn, 1)[0].status, "draft");
+
+        update_bundle_status(&conn, id, "reviewed").unwrap();
+        let (b, _) = get_bundle_with_artifacts(&conn, id).unwrap();
+        assert_eq!(b.status, "reviewed");
+        assert!(b.published_at.is_none());
+
+        update_bundle_status(&conn, id, "published").unwrap();
+        let (b, _) = get_bundle_with_artifacts(&conn, id).unwrap();
+        assert_eq!(b.status, "published");
+        assert!(b.published_at.is_some());
+    }
+
+    #[test]
+    fn test_get_bundle_with_artifacts() {
+        let conn = setup();
+        let bundle_id = create_bundle(&conn, 1, "Mixed Pack", "deliverable").unwrap();
+        let a1 =
+            crate::artifacts::record_artifact(&conn, 10, 1, "doc.pdf", "pdf", "1/doc.pdf", 1024)
+                .unwrap();
+        let a2 = crate::artifacts::record_artifact(
+            &conn,
+            10,
+            1,
+            "screenshot.png",
+            "image",
+            "1/screenshot.png",
+            2048,
+        )
+        .unwrap();
+        add_to_bundle(&conn, bundle_id, a1).unwrap();
+        add_to_bundle(&conn, bundle_id, a2).unwrap();
+
+        let (bundle, ids) = get_bundle_with_artifacts(&conn, bundle_id).unwrap();
+        assert_eq!(bundle.name, "Mixed Pack");
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&a1));
+        assert!(ids.contains(&a2));
+
+        // Non-existent bundle
+        assert!(get_bundle_with_artifacts(&conn, 9999).is_none());
+    }
+}

--- a/daemon/crates/convergio-orchestrator/src/artifacts.rs
+++ b/daemon/crates/convergio-orchestrator/src/artifacts.rs
@@ -14,6 +14,8 @@ pub struct Artifact {
     pub artifact_type: String,
     pub path: String,
     pub size_bytes: i64,
+    pub mime_type: Option<String>,
+    pub content_hash: Option<String>,
     pub created_at: String,
 }
 
@@ -27,11 +29,45 @@ pub fn record_artifact(
     path: &str,
     size_bytes: i64,
 ) -> Result<i64, rusqlite::Error> {
+    record_artifact_full(
+        conn,
+        task_id,
+        plan_id,
+        name,
+        artifact_type,
+        path,
+        size_bytes,
+        None,
+        None,
+    )
+}
+
+/// Record an artifact with optional mime_type and content_hash.
+pub fn record_artifact_full(
+    conn: &Connection,
+    task_id: i64,
+    plan_id: i64,
+    name: &str,
+    artifact_type: &str,
+    path: &str,
+    size_bytes: i64,
+    mime_type: Option<&str>,
+    content_hash: Option<&str>,
+) -> Result<i64, rusqlite::Error> {
     conn.execute(
         "INSERT INTO artifacts \
-         (task_id, plan_id, name, artifact_type, path, size_bytes) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![task_id, plan_id, name, artifact_type, path, size_bytes],
+         (task_id, plan_id, name, artifact_type, path, size_bytes, mime_type, content_hash) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            task_id,
+            plan_id,
+            name,
+            artifact_type,
+            path,
+            size_bytes,
+            mime_type,
+            content_hash
+        ],
     )?;
     Ok(conn.last_insert_rowid())
 }
@@ -40,7 +76,8 @@ pub fn record_artifact(
 pub fn list_artifacts(conn: &Connection, plan_id: i64) -> Vec<Artifact> {
     let mut stmt = match conn.prepare(
         "SELECT id, task_id, plan_id, name, artifact_type, path, \
-         size_bytes, created_at FROM artifacts WHERE plan_id = ?1 ORDER BY id",
+         size_bytes, mime_type, content_hash, created_at \
+         FROM artifacts WHERE plan_id = ?1 ORDER BY id",
     ) {
         Ok(s) => s,
         Err(_) => return vec![],
@@ -55,7 +92,8 @@ pub fn list_artifacts(conn: &Connection, plan_id: i64) -> Vec<Artifact> {
 pub fn get_artifact(conn: &Connection, id: i64) -> Option<Artifact> {
     conn.query_row(
         "SELECT id, task_id, plan_id, name, artifact_type, path, \
-         size_bytes, created_at FROM artifacts WHERE id = ?1",
+         size_bytes, mime_type, content_hash, created_at \
+         FROM artifacts WHERE id = ?1",
         params![id],
         map_artifact,
     )
@@ -66,7 +104,8 @@ pub fn get_artifact(conn: &Connection, id: i64) -> Option<Artifact> {
 pub fn list_task_artifacts(conn: &Connection, task_id: i64) -> Vec<Artifact> {
     let mut stmt = match conn.prepare(
         "SELECT id, task_id, plan_id, name, artifact_type, path, \
-         size_bytes, created_at FROM artifacts WHERE task_id = ?1 ORDER BY id",
+         size_bytes, mime_type, content_hash, created_at \
+         FROM artifacts WHERE task_id = ?1 ORDER BY id",
     ) {
         Ok(s) => s,
         Err(_) => return vec![],
@@ -86,7 +125,9 @@ fn map_artifact(r: &rusqlite::Row) -> rusqlite::Result<Artifact> {
         artifact_type: r.get(4)?,
         path: r.get(5)?,
         size_bytes: r.get(6)?,
-        created_at: r.get(7)?,
+        mime_type: r.get(7)?,
+        content_hash: r.get(8)?,
+        created_at: r.get(9)?,
     })
 }
 

--- a/daemon/crates/convergio-orchestrator/src/bundle_routes.rs
+++ b/daemon/crates/convergio-orchestrator/src/bundle_routes.rs
@@ -1,0 +1,125 @@
+// HTTP routes for artifact bundle management.
+// WHY: Bundles group artifacts into reviewable deliverables with lifecycle
+// tracking (draft -> reviewed -> published).
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_db::pool::ConnPool;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::artifact_bundle;
+
+pub fn bundle_routes(pool: ConnPool) -> Router {
+    Router::new()
+        .route("/api/bundles/create", post(handle_create))
+        .route("/api/bundles/:id/add", post(handle_add))
+        .route("/api/bundles/plan/:plan_id", get(handle_list))
+        .route("/api/bundles/:id", get(handle_get))
+        .route("/api/bundles/:id/publish", post(handle_publish))
+        .with_state(pool)
+}
+
+#[derive(Deserialize)]
+struct CreateReq {
+    plan_id: i64,
+    name: String,
+    bundle_type: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AddReq {
+    artifact_id: i64,
+}
+
+async fn handle_create(
+    State(pool): State<ConnPool>,
+    Json(req): Json<CreateReq>,
+) -> impl IntoResponse {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+    let btype = req.bundle_type.as_deref().unwrap_or("deliverable");
+    match artifact_bundle::create_bundle(&conn, req.plan_id, &req.name, btype) {
+        Ok(id) => (StatusCode::CREATED, Json(json!({"id": id}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}
+
+async fn handle_add(
+    State(pool): State<ConnPool>,
+    Path(id): Path<i64>,
+    Json(req): Json<AddReq>,
+) -> impl IntoResponse {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+    match artifact_bundle::add_to_bundle(&conn, id, req.artifact_id) {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}
+
+async fn handle_list(
+    State(pool): State<ConnPool>,
+    Path(plan_id): Path<i64>,
+) -> Json<serde_json::Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    Json(json!(artifact_bundle::list_bundles(&conn, plan_id)))
+}
+
+async fn handle_get(State(pool): State<ConnPool>, Path(id): Path<i64>) -> Json<serde_json::Value> {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(json!({"error": e.to_string()})),
+    };
+    match artifact_bundle::get_bundle_with_artifacts(&conn, id) {
+        Some((bundle, artifact_ids)) => {
+            Json(json!({"bundle": bundle, "artifact_ids": artifact_ids}))
+        }
+        None => Json(json!({"error": "bundle not found"})),
+    }
+}
+
+async fn handle_publish(State(pool): State<ConnPool>, Path(id): Path<i64>) -> impl IntoResponse {
+    let conn = match pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+        }
+    };
+    match artifact_bundle::update_bundle_status(&conn, id, "published") {
+        Ok(()) => (StatusCode::OK, Json(json!({"ok": true}))),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": e.to_string()})),
+        ),
+    }
+}

--- a/daemon/crates/convergio-orchestrator/src/ext.rs
+++ b/daemon/crates/convergio-orchestrator/src/ext.rs
@@ -77,7 +77,8 @@ impl Extension for OrchestratorExtension {
             .merge(crate::aggregation_routes::aggregation_routes(
                 self.pool.clone(),
             ))
-            .merge(crate::artifact_routes::artifact_routes(self.pool.clone()));
+            .merge(crate::artifact_routes::artifact_routes(self.pool.clone()))
+            .merge(crate::bundle_routes::bundle_routes(self.pool.clone()));
         Some(router)
     }
 

--- a/daemon/crates/convergio-orchestrator/src/lib.rs
+++ b/daemon/crates/convergio-orchestrator/src/lib.rs
@@ -5,8 +5,10 @@
 pub mod actions;
 pub mod aggregation_routes;
 pub mod approval;
+pub mod artifact_bundle;
 pub mod artifact_routes;
 pub mod artifacts;
+pub mod bundle_routes;
 pub mod executor;
 pub mod ext;
 pub mod gates;

--- a/daemon/crates/convergio-orchestrator/src/schema_tracking.rs
+++ b/daemon/crates/convergio-orchestrator/src/schema_tracking.rs
@@ -113,6 +113,36 @@ pub fn tracking_migrations() -> Vec<Migration> {
                  CREATE INDEX IF NOT EXISTS idx_artifacts_plan ON artifacts(plan_id);\
                  CREATE INDEX IF NOT EXISTS idx_artifacts_type ON artifacts(artifact_type);",
         },
+        Migration {
+            version: 9,
+            description: "artifact metadata: mime_type and content_hash",
+            up: "ALTER TABLE artifacts ADD COLUMN mime_type TEXT \
+                     DEFAULT 'application/octet-stream';\
+                 ALTER TABLE artifacts ADD COLUMN content_hash TEXT;",
+        },
+        Migration {
+            version: 10,
+            description: "artifact bundles for grouped deliverables",
+            up: "CREATE TABLE IF NOT EXISTS artifact_bundles (\
+                     id           INTEGER PRIMARY KEY AUTOINCREMENT,\
+                     plan_id      INTEGER NOT NULL,\
+                     name         TEXT NOT NULL,\
+                     bundle_type  TEXT NOT NULL DEFAULT 'deliverable',\
+                     status       TEXT NOT NULL DEFAULT 'draft',\
+                     created_at   TEXT NOT NULL DEFAULT (datetime('now')),\
+                     published_at TEXT\
+                 );\
+                 CREATE TABLE IF NOT EXISTS bundle_artifacts (\
+                     bundle_id   INTEGER NOT NULL,\
+                     artifact_id INTEGER NOT NULL,\
+                     added_at    TEXT NOT NULL DEFAULT (datetime('now')),\
+                     PRIMARY KEY (bundle_id, artifact_id)\
+                 );\
+                 CREATE INDEX IF NOT EXISTS idx_bundles_plan \
+                     ON artifact_bundles(plan_id);\
+                 CREATE INDEX IF NOT EXISTS idx_bundles_status \
+                     ON artifact_bundles(status);",
+        },
     ]
 }
 
@@ -132,6 +162,6 @@ mod tests {
         let tracking = tracking_migrations();
         let applied =
             convergio_db::migration::apply_migrations(&conn, "orchestrator", &tracking).unwrap();
-        assert_eq!(applied, 5);
+        assert_eq!(applied, 7);
     }
 }


### PR DESCRIPTION
## Summary
- **Artifact metadata enrichment**: Added `mime_type` and `content_hash` columns to the `artifacts` table (migration v9), with `record_artifact_full()` accepting the new fields while maintaining backward compatibility via the existing `record_artifact()` wrapper.
- **Artifact bundles**: New `artifact_bundles` and `bundle_artifacts` tables (migration v10) supporting grouped deliverables with lifecycle tracking (draft -> reviewed -> published).
- **Bundle HTTP routes**: 5 new endpoints — `POST /api/bundles/create`, `POST /api/bundles/:id/add`, `GET /api/bundles/plan/:plan_id`, `GET /api/bundles/:id`, `POST /api/bundles/:id/publish`.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test -p convergio-orchestrator` — all 61 tests pass (4 new bundle tests)
- [x] All files under 250-line limit
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)