### PR TITLE
feat: add remote execution security (fase 45)

### DIFF
--- a/daemon/crates/convergio-security/Cargo.toml
+++ b/daemon/crates/convergio-security/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
 tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -15,4 +16,6 @@ thiserror = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+rusqlite = { workspace = true }
+axum = { workspace = true }
 getrandom = "0.2"

--- a/daemon/crates/convergio-security/src/ext.rs
+++ b/daemon/crates/convergio-security/src/ext.rs
@@ -1,0 +1,91 @@
+//! SecurityExtension — impl Extension for remote execution security.
+
+use std::sync::Arc;
+
+use convergio_db::pool::ConnPool;
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Migration};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+use crate::trust_routes::SecurityState;
+
+/// Extension providing trust levels, secrets filtering, and sandbox policies.
+pub struct SecurityExtension {
+    pool: ConnPool,
+}
+
+impl SecurityExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self { pool }
+    }
+
+    fn state(&self) -> Arc<SecurityState> {
+        Arc::new(SecurityState {
+            pool: self.pool.clone(),
+        })
+    }
+}
+
+impl Extension for SecurityExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-security".to_string(),
+            description: "Auth, HMAC, crypto, audit, trust, sandbox".into(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![
+                Capability {
+                    name: "trust-levels".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Per-peer trust level management".into(),
+                },
+                Capability {
+                    name: "secrets-filtering".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Env var filtering by trust level".into(),
+                },
+                Capability {
+                    name: "sandbox-policy".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Resource limits for remote execution".into(),
+                },
+            ],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::trust_routes::security_routes(self.state()))
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("security: extension started (trust + sandbox)");
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match self.pool.get() {
+            Ok(conn) => {
+                let ok = conn
+                    .query_row("SELECT COUNT(*) FROM peer_trust", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
+                    .is_ok();
+                if ok {
+                    Health::Ok
+                } else {
+                    Health::Degraded {
+                        reason: "peer_trust table inaccessible".into(),
+                    }
+                }
+            }
+            Err(e) => Health::Down {
+                reason: format!("pool error: {e}"),
+            },
+        }
+    }
+}

--- a/daemon/crates/convergio-security/src/lib.rs
+++ b/daemon/crates/convergio-security/src/lib.rs
@@ -1,8 +1,14 @@
-//! convergio-security — Auth, HMAC, crypto, audit logging.
+//! convergio-security — Auth, HMAC, crypto, audit logging, trust, sandbox.
 //!
-//! Implements Extension: owns audit_log and ipc_auth_tokens tables.
+//! Implements Extension: owns audit_log, ipc_auth_tokens, peer_trust,
+//! secret_filters, and sandbox_overrides tables.
 
 pub mod audit;
+pub mod ext;
 pub mod jwt;
 pub mod rbac;
+pub mod sandbox;
+pub mod schema;
+pub mod trust;
+pub mod trust_routes;
 pub mod types;

--- a/daemon/crates/convergio-security/src/sandbox.rs
+++ b/daemon/crates/convergio-security/src/sandbox.rs
@@ -1,0 +1,176 @@
+//! Sandbox policies for remote peer execution.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::trust::TrustLevel;
+
+/// Resource limits and access rules for a sandboxed peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SandboxPolicy {
+    pub peer_name: String,
+    pub allow_network: bool,
+    pub allow_disk_write: bool,
+    pub max_cpu_seconds: u64,
+    pub max_memory_mb: u64,
+    pub allowed_commands: Vec<String>,
+    pub blocked_paths: Vec<String>,
+}
+
+/// Default sandbox policy based on trust level.
+pub fn sandbox_for_trust(peer_name: &str, trust: TrustLevel) -> SandboxPolicy {
+    match trust {
+        TrustLevel::Untrusted => SandboxPolicy {
+            peer_name: peer_name.to_string(),
+            allow_network: false,
+            allow_disk_write: false,
+            max_cpu_seconds: 60,
+            max_memory_mb: 512,
+            allowed_commands: vec![],
+            blocked_paths: vec!["/etc".into(), "/var".into(), "/root".into()],
+        },
+        TrustLevel::Basic => SandboxPolicy {
+            peer_name: peer_name.to_string(),
+            allow_network: false,
+            allow_disk_write: true,
+            max_cpu_seconds: 300,
+            max_memory_mb: 1024,
+            allowed_commands: vec![
+                "cargo".into(),
+                "npm".into(),
+                "git".into(),
+                "ls".into(),
+                "cat".into(),
+            ],
+            blocked_paths: vec!["/etc".into(), "/root".into()],
+        },
+        TrustLevel::Standard => SandboxPolicy {
+            peer_name: peer_name.to_string(),
+            allow_network: true,
+            allow_disk_write: true,
+            max_cpu_seconds: 3600,
+            max_memory_mb: 4096,
+            allowed_commands: vec![],
+            blocked_paths: vec![],
+        },
+        TrustLevel::Elevated | TrustLevel::Owner => SandboxPolicy {
+            peer_name: peer_name.to_string(),
+            allow_network: true,
+            allow_disk_write: true,
+            max_cpu_seconds: 0,
+            max_memory_mb: 0,
+            allowed_commands: vec![],
+            blocked_paths: vec![],
+        },
+    }
+}
+
+/// Get custom sandbox override for a peer (if any).
+pub fn get_custom_sandbox(conn: &Connection, peer: &str) -> Option<SandboxPolicy> {
+    conn.query_row(
+        "SELECT peer_name, allow_network, allow_disk_write, max_cpu_seconds,
+                max_memory_mb, allowed_commands, blocked_paths
+         FROM sandbox_overrides WHERE peer_name = ?1",
+        [peer],
+        |row| {
+            let cmds_json: String = row.get(5)?;
+            let paths_json: String = row.get(6)?;
+            Ok(SandboxPolicy {
+                peer_name: row.get(0)?,
+                allow_network: row.get::<_, i64>(1)? != 0,
+                allow_disk_write: row.get::<_, i64>(2)? != 0,
+                max_cpu_seconds: row.get::<_, i64>(3)? as u64,
+                max_memory_mb: row.get::<_, i64>(4)? as u64,
+                allowed_commands: serde_json::from_str(&cmds_json).unwrap_or_default(),
+                blocked_paths: serde_json::from_str(&paths_json).unwrap_or_default(),
+            })
+        },
+    )
+    .ok()
+}
+
+/// Set custom sandbox override for a peer.
+pub fn set_custom_sandbox(
+    conn: &Connection,
+    policy: &SandboxPolicy,
+) -> Result<(), rusqlite::Error> {
+    let cmds = serde_json::to_string(&policy.allowed_commands).unwrap_or_default();
+    let paths = serde_json::to_string(&policy.blocked_paths).unwrap_or_default();
+    conn.execute(
+        "INSERT INTO sandbox_overrides
+           (peer_name, allow_network, allow_disk_write, max_cpu_seconds,
+            max_memory_mb, allowed_commands, blocked_paths)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(peer_name) DO UPDATE SET
+           allow_network    = excluded.allow_network,
+           allow_disk_write = excluded.allow_disk_write,
+           max_cpu_seconds  = excluded.max_cpu_seconds,
+           max_memory_mb    = excluded.max_memory_mb,
+           allowed_commands = excluded.allowed_commands,
+           blocked_paths    = excluded.blocked_paths",
+        rusqlite::params![
+            policy.peer_name,
+            policy.allow_network as i64,
+            policy.allow_disk_write as i64,
+            policy.max_cpu_seconds as i64,
+            policy.max_memory_mb as i64,
+            cmds,
+            paths,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Resolve effective sandbox: custom override if present, else trust-based default.
+pub fn resolve_sandbox(conn: &Connection, peer: &str, trust: TrustLevel) -> SandboxPolicy {
+    get_custom_sandbox(conn, peer).unwrap_or_else(|| sandbox_for_trust(peer, trust))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(crate::schema::ALL_TABLES).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_sandbox_for_trust_untrusted() {
+        let policy = sandbox_for_trust("rogue-peer", TrustLevel::Untrusted);
+        assert!(!policy.allow_network);
+        assert!(!policy.allow_disk_write);
+        assert_eq!(policy.max_cpu_seconds, 60);
+        assert_eq!(policy.max_memory_mb, 512);
+        assert!(policy.allowed_commands.is_empty());
+    }
+
+    #[test]
+    fn test_sandbox_for_trust_owner() {
+        let policy = sandbox_for_trust("owner-node", TrustLevel::Owner);
+        assert!(policy.allow_network);
+        assert!(policy.allow_disk_write);
+        assert_eq!(policy.max_cpu_seconds, 0);
+        assert_eq!(policy.max_memory_mb, 0);
+    }
+
+    #[test]
+    fn test_custom_sandbox_roundtrip() {
+        let conn = setup_db();
+        let policy = SandboxPolicy {
+            peer_name: "custom-peer".into(),
+            allow_network: true,
+            allow_disk_write: false,
+            max_cpu_seconds: 120,
+            max_memory_mb: 2048,
+            allowed_commands: vec!["cargo".into()],
+            blocked_paths: vec!["/tmp/forbidden".into()],
+        };
+        set_custom_sandbox(&conn, &policy).unwrap();
+        let loaded = get_custom_sandbox(&conn, "custom-peer").unwrap();
+        assert_eq!(loaded.max_cpu_seconds, 120);
+        assert!(loaded.allow_network);
+        assert!(!loaded.allow_disk_write);
+    }
+}

--- a/daemon/crates/convergio-security/src/schema.rs
+++ b/daemon/crates/convergio-security/src/schema.rs
@@ -1,0 +1,62 @@
+//! DB migrations for security tables (trust, secrets, sandbox).
+
+use convergio_types::extension::Migration;
+
+/// Raw SQL for all tables — used by in-memory test helpers.
+pub const ALL_TABLES: &str = "
+    CREATE TABLE IF NOT EXISTS peer_trust (
+        peer_name   TEXT PRIMARY KEY,
+        trust_level INTEGER NOT NULL DEFAULT 0,
+        granted_by  TEXT NOT NULL,
+        reason      TEXT NOT NULL DEFAULT '',
+        granted_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        expires_at  TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS secret_filters (
+        env_var         TEXT PRIMARY KEY,
+        min_trust_level INTEGER NOT NULL DEFAULT 2,
+        description     TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS sandbox_overrides (
+        peer_name        TEXT PRIMARY KEY,
+        allow_network    INTEGER NOT NULL DEFAULT 0,
+        allow_disk_write INTEGER NOT NULL DEFAULT 0,
+        max_cpu_seconds  INTEGER NOT NULL DEFAULT 60,
+        max_memory_mb    INTEGER NOT NULL DEFAULT 512,
+        allowed_commands TEXT NOT NULL DEFAULT '[]',
+        blocked_paths    TEXT NOT NULL DEFAULT '[]'
+    );
+";
+
+pub fn migrations() -> Vec<Migration> {
+    vec![Migration {
+        version: 1,
+        description: "peer trust, secret filters, sandbox overrides",
+        up: ALL_TABLES,
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_are_ordered() {
+        let m = migrations();
+        for (i, mig) in m.iter().enumerate() {
+            assert_eq!(mig.version, (i + 1) as u32);
+        }
+    }
+
+    #[test]
+    fn migrations_apply_cleanly() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        let applied =
+            convergio_db::migration::apply_migrations(&conn, "security", &migrations()).unwrap();
+        assert_eq!(applied, 1);
+    }
+}

--- a/daemon/crates/convergio-security/src/trust.rs
+++ b/daemon/crates/convergio-security/src/trust.rs
@@ -1,0 +1,218 @@
+//! Trust levels and secrets filtering for remote peer execution.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+/// Trust level assigned to a remote peer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum TrustLevel {
+    Untrusted = 0,
+    Basic = 1,
+    Standard = 2,
+    Elevated = 3,
+    Owner = 4,
+}
+
+impl TrustLevel {
+    pub fn from_i64(v: i64) -> Self {
+        match v {
+            1 => Self::Basic,
+            2 => Self::Standard,
+            3 => Self::Elevated,
+            4 => Self::Owner,
+            _ => Self::Untrusted,
+        }
+    }
+}
+
+/// Record of trust granted to a peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerTrustRecord {
+    pub peer_name: String,
+    pub trust_level: TrustLevel,
+    pub granted_by: String,
+    pub reason: String,
+    pub granted_at: String,
+    pub expires_at: Option<String>,
+}
+
+/// Rule controlling which env vars require which trust level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecretFilter {
+    pub env_var: String,
+    pub min_trust_level: TrustLevel,
+    pub description: String,
+}
+
+/// Set trust level for a peer.
+pub fn set_trust(
+    conn: &Connection,
+    peer: &str,
+    level: TrustLevel,
+    granted_by: &str,
+    reason: &str,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO peer_trust (peer_name, trust_level, granted_by, reason)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(peer_name) DO UPDATE SET
+           trust_level = excluded.trust_level,
+           granted_by  = excluded.granted_by,
+           reason      = excluded.reason,
+           granted_at  = datetime('now')",
+        rusqlite::params![peer, level as i64, granted_by, reason],
+    )?;
+    Ok(())
+}
+
+/// Get trust level for a peer (default: Untrusted).
+pub fn get_trust(conn: &Connection, peer: &str) -> TrustLevel {
+    conn.query_row(
+        "SELECT trust_level FROM peer_trust WHERE peer_name = ?1",
+        [peer],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(TrustLevel::from_i64)
+    .unwrap_or(TrustLevel::Untrusted)
+}
+
+/// List all trust records.
+pub fn list_trust(conn: &Connection) -> Vec<PeerTrustRecord> {
+    let mut stmt = match conn.prepare(
+        "SELECT peer_name, trust_level, granted_by, reason, granted_at, expires_at
+         FROM peer_trust ORDER BY peer_name",
+    ) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    stmt.query_map([], |row| {
+        Ok(PeerTrustRecord {
+            peer_name: row.get(0)?,
+            trust_level: TrustLevel::from_i64(row.get(1)?),
+            granted_by: row.get(2)?,
+            reason: row.get(3)?,
+            granted_at: row.get(4)?,
+            expires_at: row.get(5)?,
+        })
+    })
+    .map(|rows| rows.filter_map(|r| r.ok()).collect())
+    .unwrap_or_default()
+}
+
+/// Check if a peer can access a specific secret.
+pub fn can_access_secret(conn: &Connection, peer: &str, env_var: &str) -> bool {
+    let peer_level = get_trust(conn, peer);
+    let min_level: TrustLevel = conn
+        .query_row(
+            "SELECT min_trust_level FROM secret_filters WHERE env_var = ?1",
+            [env_var],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(TrustLevel::from_i64)
+        .unwrap_or(TrustLevel::Standard);
+    peer_level >= min_level
+}
+
+/// Filter env vars for a peer based on trust level.
+pub fn filter_env_for_peer(
+    conn: &Connection,
+    peer: &str,
+    env: &[(String, String)],
+) -> Vec<(String, String)> {
+    env.iter()
+        .filter(|(k, _)| can_access_secret(conn, peer, k))
+        .cloned()
+        .collect()
+}
+
+/// Register a secret filter rule.
+pub fn register_secret_filter(
+    conn: &Connection,
+    env_var: &str,
+    min_level: TrustLevel,
+    description: &str,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO secret_filters (env_var, min_trust_level, description)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(env_var) DO UPDATE SET
+           min_trust_level = excluded.min_trust_level,
+           description     = excluded.description",
+        rusqlite::params![env_var, min_level as i64, description],
+    )?;
+    Ok(())
+}
+
+/// List all secret filter rules.
+pub fn list_secret_filters(conn: &Connection) -> Vec<SecretFilter> {
+    let mut stmt = match conn.prepare(
+        "SELECT env_var, min_trust_level, description FROM secret_filters ORDER BY env_var",
+    ) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    stmt.query_map([], |row| {
+        Ok(SecretFilter {
+            env_var: row.get(0)?,
+            min_trust_level: TrustLevel::from_i64(row.get(1)?),
+            description: row.get(2)?,
+        })
+    })
+    .map(|rows| rows.filter_map(|r| r.ok()).collect())
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(crate::schema::ALL_TABLES).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_set_and_get_trust() {
+        let conn = setup_db();
+        set_trust(
+            &conn,
+            "node-eu-1",
+            TrustLevel::Standard,
+            "admin",
+            "verified org",
+        )
+        .unwrap();
+        assert_eq!(get_trust(&conn, "node-eu-1"), TrustLevel::Standard);
+    }
+
+    #[test]
+    fn test_default_untrusted() {
+        let conn = setup_db();
+        assert_eq!(get_trust(&conn, "unknown-peer"), TrustLevel::Untrusted);
+    }
+
+    #[test]
+    fn test_filter_env_vars() {
+        let conn = setup_db();
+        set_trust(&conn, "peer-a", TrustLevel::Basic, "admin", "low trust").unwrap();
+        register_secret_filter(&conn, "API_KEY", TrustLevel::Elevated, "production key").unwrap();
+        register_secret_filter(&conn, "LOG_LEVEL", TrustLevel::Untrusted, "safe").unwrap();
+
+        let env = vec![
+            ("API_KEY".into(), "secret123".into()),
+            ("LOG_LEVEL".into(), "debug".into()),
+        ];
+        let filtered = filter_env_for_peer(&conn, "peer-a", &env);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].0, "LOG_LEVEL");
+    }
+
+    #[test]
+    fn test_trust_levels_ordered() {
+        assert!(TrustLevel::Untrusted < TrustLevel::Basic);
+        assert!(TrustLevel::Basic < TrustLevel::Standard);
+        assert!(TrustLevel::Standard < TrustLevel::Elevated);
+        assert!(TrustLevel::Elevated < TrustLevel::Owner);
+    }
+}

--- a/daemon/crates/convergio-security/src/trust_routes.rs
+++ b/daemon/crates/convergio-security/src/trust_routes.rs
@@ -1,0 +1,144 @@
+//! HTTP API routes for trust, secrets filtering, and sandbox policies.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use serde::Deserialize;
+
+use convergio_db::pool::ConnPool;
+
+use crate::sandbox::{self, SandboxPolicy};
+use crate::trust::{self, PeerTrustRecord, SecretFilter, TrustLevel};
+
+/// Shared state for security routes.
+pub struct SecurityState {
+    pub pool: ConnPool,
+}
+
+/// Build the security trust/sandbox API router.
+pub fn security_routes(state: Arc<SecurityState>) -> Router {
+    Router::new()
+        .route("/api/security/trust", post(handle_set_trust))
+        .route("/api/security/trust", get(handle_list_trust))
+        .route("/api/security/trust/:peer", get(handle_get_trust))
+        .route("/api/security/secrets/filter", post(handle_register_filter))
+        .route("/api/security/secrets/filter", get(handle_list_filters))
+        .route("/api/security/sandbox/:peer", get(handle_get_sandbox))
+        .route("/api/security/sandbox/:peer", post(handle_set_sandbox))
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetTrustRequest {
+    pub peer: String,
+    pub level: i64,
+    pub granted_by: String,
+    pub reason: String,
+}
+
+async fn handle_set_trust(
+    State(state): State<Arc<SecurityState>>,
+    Json(body): Json<SetTrustRequest>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(err_json("POOL_ERROR", &e.to_string())),
+    };
+    let level = TrustLevel::from_i64(body.level);
+    if let Err(e) = trust::set_trust(&conn, &body.peer, level, &body.granted_by, &body.reason) {
+        return Json(err_json("DB_ERROR", &e.to_string()));
+    }
+    Json(serde_json::json!({
+        "status": "ok",
+        "peer": body.peer,
+        "trust_level": level as i64,
+    }))
+}
+
+async fn handle_get_trust(
+    State(state): State<Arc<SecurityState>>,
+    Path(peer): Path<String>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(err_json("POOL_ERROR", &e.to_string())),
+    };
+    let level = trust::get_trust(&conn, &peer);
+    Json(serde_json::json!({
+        "peer": peer,
+        "trust_level": level as i64,
+    }))
+}
+
+async fn handle_list_trust(State(state): State<Arc<SecurityState>>) -> Json<Vec<PeerTrustRecord>> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(_) => return Json(vec![]),
+    };
+    Json(trust::list_trust(&conn))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterFilterRequest {
+    pub env_var: String,
+    pub min_trust_level: i64,
+    pub description: String,
+}
+
+async fn handle_register_filter(
+    State(state): State<Arc<SecurityState>>,
+    Json(body): Json<RegisterFilterRequest>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(err_json("POOL_ERROR", &e.to_string())),
+    };
+    let level = TrustLevel::from_i64(body.min_trust_level);
+    if let Err(e) = trust::register_secret_filter(&conn, &body.env_var, level, &body.description) {
+        return Json(err_json("DB_ERROR", &e.to_string()));
+    }
+    Json(serde_json::json!({"status": "ok", "env_var": body.env_var}))
+}
+
+async fn handle_list_filters(State(state): State<Arc<SecurityState>>) -> Json<Vec<SecretFilter>> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(_) => return Json(vec![]),
+    };
+    Json(trust::list_secret_filters(&conn))
+}
+
+async fn handle_get_sandbox(
+    State(state): State<Arc<SecurityState>>,
+    Path(peer): Path<String>,
+) -> Json<SandboxPolicy> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(_) => return Json(sandbox::sandbox_for_trust(&peer, TrustLevel::Untrusted)),
+    };
+    let trust_level = trust::get_trust(&conn, &peer);
+    Json(sandbox::resolve_sandbox(&conn, &peer, trust_level))
+}
+
+async fn handle_set_sandbox(
+    State(state): State<Arc<SecurityState>>,
+    Path(peer): Path<String>,
+    Json(mut body): Json<SandboxPolicy>,
+) -> Json<serde_json::Value> {
+    body.peer_name = peer.clone();
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return Json(err_json("POOL_ERROR", &e.to_string())),
+    };
+    if let Err(e) = sandbox::set_custom_sandbox(&conn, &body) {
+        return Json(err_json("DB_ERROR", &e.to_string()));
+    }
+    Json(serde_json::json!({"status": "ok", "peer": peer}))
+}
+
+fn err_json(code: &str, message: &str) -> serde_json::Value {
+    serde_json::json!({"error": {"code": code, "message": message}})
+}


### PR DESCRIPTION
## Summary
- Add `TrustLevel` enum (Untrusted/Basic/Standard/Elevated/Owner) with peer trust management via SQLite
- Add secrets filtering: env vars are filtered per-peer based on trust level and configurable filter rules
- Add `SandboxPolicy` with trust-based defaults (CPU/memory/network/disk limits) and custom overrides
- Wire `SecurityExtension` (impl Extension) with migrations, health check, and 7 HTTP routes under `/api/security/`

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test -p convergio-security` — 17 tests pass (trust, sandbox, schema, audit, jwt, rbac)
- [x] `cargo fmt --all` clean
- [x] All files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)