### PR TITLE
feat: add scheduler policy engine (fase 44)

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/convergio-observatory",
     "crates/convergio-file-transport",
     "crates/convergio-delegation",
+    "crates/convergio-scheduler",
 ]
 
 [package]
@@ -68,6 +69,7 @@ convergio-evidence = { path = "crates/convergio-evidence" }
 convergio-observatory = { path = "crates/convergio-observatory" }
 convergio-file-transport = { path = "crates/convergio-file-transport" }
 convergio-delegation = { path = "crates/convergio-delegation" }
+convergio-scheduler = { path = "crates/convergio-scheduler" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 dirs = { workspace = true }

--- a/daemon/crates/convergio-scheduler/Cargo.toml
+++ b/daemon/crates/convergio-scheduler/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "convergio-scheduler"
+description = "Policy-based task scheduling with capability matching, cost optimization, and load balancing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
+convergio-telemetry = { path = "../convergio-telemetry" }
+tracing = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+rusqlite = { workspace = true }
+axum = { workspace = true }

--- a/daemon/crates/convergio-scheduler/src/ext.rs
+++ b/daemon/crates/convergio-scheduler/src/ext.rs
@@ -1,0 +1,98 @@
+//! SchedulerExtension — impl Extension for the scheduler module.
+
+use std::sync::Arc;
+
+use convergio_db::pool::ConnPool;
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric, Migration};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+use crate::routes::SchedulerState;
+
+/// The scheduler extension — policy-based task assignment.
+pub struct SchedulerExtension {
+    pool: ConnPool,
+}
+
+impl SchedulerExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self { pool }
+    }
+
+    fn state(&self) -> Arc<SchedulerState> {
+        Arc::new(SchedulerState {
+            pool: self.pool.clone(),
+        })
+    }
+}
+
+impl Extension for SchedulerExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-scheduler".to_string(),
+            description: "Policy-based task scheduling with capability matching".into(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![Capability {
+                name: "scheduling-policy".to_string(),
+                version: "1.0".to_string(),
+                description: "Intelligent task assignment to mesh peers".into(),
+            }],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        Some(crate::routes::scheduler_routes(self.state()))
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("scheduler: extension started");
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match self.pool.get() {
+            Ok(conn) => {
+                let ok = conn
+                    .query_row("SELECT COUNT(*) FROM scheduler_policies", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
+                    .is_ok();
+                if ok {
+                    Health::Ok
+                } else {
+                    Health::Degraded {
+                        reason: "scheduler_policies table inaccessible".into(),
+                    }
+                }
+            }
+            Err(e) => Health::Down {
+                reason: format!("pool error: {e}"),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(_) => return vec![],
+        };
+
+        let mut out = Vec::new();
+        if let Ok(n) = conn.query_row("SELECT COUNT(*) FROM scheduling_decisions", [], |r| {
+            r.get::<_, f64>(0)
+        }) {
+            out.push(Metric {
+                name: "scheduler.decisions.total".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        out
+    }
+}

--- a/daemon/crates/convergio-scheduler/src/lib.rs
+++ b/daemon/crates/convergio-scheduler/src/lib.rs
@@ -1,0 +1,12 @@
+//! convergio-scheduler — Policy-based task scheduling.
+//!
+//! Scores mesh peers by capability match, cost, load, and locality,
+//! then assigns tasks to the best candidate using configurable weights.
+
+pub mod ext;
+pub mod policy;
+pub mod routes;
+pub mod schema;
+pub mod types;
+
+pub use ext::SchedulerExtension;

--- a/daemon/crates/convergio-scheduler/src/policy.rs
+++ b/daemon/crates/convergio-scheduler/src/policy.rs
@@ -1,0 +1,227 @@
+//! Policy engine — scoring, selection, and persistence of scheduler policies.
+
+use rusqlite::{params, Connection};
+
+use crate::types::{PeerCandidate, SchedulerPolicy, SchedulingRequest};
+
+/// Score a peer for a scheduling request using the given policy weights.
+pub fn score_peer(
+    peer_name: &str,
+    peer_caps: &[String],
+    peer_load: f64,
+    request: &SchedulingRequest,
+    policy: &SchedulerPolicy,
+) -> PeerCandidate {
+    let required = &request.required_capabilities;
+    let capabilities_match = if required.is_empty() {
+        1.0
+    } else {
+        let matched = required.iter().filter(|r| peer_caps.contains(r)).count();
+        matched as f64 / required.len() as f64
+    };
+
+    let cost_score = match request.max_cost_usd {
+        Some(max) if max > 0.0 => {
+            // Estimate cost based on tier hint; simple heuristic for MVP.
+            let estimated = estimate_tier_cost(request.tier_hint.as_deref());
+            (1.0 - (estimated / max)).max(0.0)
+        }
+        _ => 0.5,
+    };
+
+    let load_score = 1.0 - peer_load.clamp(0.0, 1.0);
+
+    let locality_bonus = match &request.preferred_locality {
+        Some(loc) if loc == peer_name => 1.0,
+        _ => 0.0,
+    };
+
+    let total = policy.weight_capability * capabilities_match
+        + policy.weight_cost * cost_score
+        + policy.weight_load * load_score
+        + policy.weight_locality * locality_bonus;
+
+    PeerCandidate {
+        peer_name: peer_name.to_string(),
+        score: total,
+        capabilities_match,
+        cost_score,
+        load_score,
+        locality_bonus,
+    }
+}
+
+/// Select the best peer from a list of scored candidates.
+pub fn select_best(candidates: Vec<PeerCandidate>) -> Option<PeerCandidate> {
+    candidates.into_iter().max_by(|a, b| {
+        a.score
+            .partial_cmp(&b.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    })
+}
+
+/// Return the default scheduling policy.
+pub fn default_policy() -> SchedulerPolicy {
+    SchedulerPolicy {
+        id: 0,
+        name: "default".to_string(),
+        weight_capability: 0.4,
+        weight_cost: 0.2,
+        weight_load: 0.2,
+        weight_locality: 0.2,
+        privacy_enforce: true,
+    }
+}
+
+/// Load a policy by name from DB, falling back to the default.
+pub fn load_policy(conn: &Connection, name: &str) -> SchedulerPolicy {
+    let result = conn.query_row(
+        "SELECT id, name, weight_capability, weight_cost, weight_load, \
+         weight_locality, privacy_enforce FROM scheduler_policies WHERE name = ?1",
+        params![name],
+        |row| {
+            Ok(SchedulerPolicy {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                weight_capability: row.get(2)?,
+                weight_cost: row.get(3)?,
+                weight_load: row.get(4)?,
+                weight_locality: row.get(5)?,
+                privacy_enforce: row.get::<_, i32>(6)? != 0,
+            })
+        },
+    );
+    result.unwrap_or_else(|_| default_policy())
+}
+
+/// Save or update a policy in the DB (upsert on name).
+pub fn save_policy(conn: &Connection, policy: &SchedulerPolicy) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO scheduler_policies \
+         (name, weight_capability, weight_cost, weight_load, weight_locality, privacy_enforce) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(name) DO UPDATE SET \
+         weight_capability = excluded.weight_capability, \
+         weight_cost = excluded.weight_cost, \
+         weight_load = excluded.weight_load, \
+         weight_locality = excluded.weight_locality, \
+         privacy_enforce = excluded.privacy_enforce",
+        params![
+            policy.name,
+            policy.weight_capability,
+            policy.weight_cost,
+            policy.weight_load,
+            policy.weight_locality,
+            policy.privacy_enforce as i32,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Estimate cost in USD based on tier hint (simple heuristic).
+fn estimate_tier_cost(tier: Option<&str>) -> f64 {
+    match tier {
+        Some("t1") => 0.01,
+        Some("t2") => 0.05,
+        Some("t3") => 0.20,
+        Some("t4") => 1.00,
+        _ => 0.10,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request() -> SchedulingRequest {
+        SchedulingRequest {
+            task_id: 1,
+            plan_id: 1,
+            required_capabilities: vec!["gpu".into(), "voice".into()],
+            preferred_locality: None,
+            privacy_level: "public".into(),
+            max_cost_usd: Some(1.0),
+            tier_hint: Some("t2".into()),
+        }
+    }
+
+    #[test]
+    fn test_score_peer_all_caps_match() {
+        let policy = default_policy();
+        let req = sample_request();
+        let caps = vec!["gpu".into(), "voice".into(), "compute".into()];
+        let c = score_peer("darwin-m4", &caps, 0.2, &req, &policy);
+        assert_eq!(c.capabilities_match, 1.0);
+        assert!(c.score > 0.7, "expected high score, got {}", c.score);
+    }
+
+    #[test]
+    fn test_score_peer_no_caps() {
+        let policy = default_policy();
+        let req = sample_request();
+        let caps: Vec<String> = vec![];
+        let c = score_peer("linux-a100", &caps, 0.5, &req, &policy);
+        assert_eq!(c.capabilities_match, 0.0);
+        assert!(c.score < 0.4, "expected low score, got {}", c.score);
+    }
+
+    #[test]
+    fn test_select_best() {
+        let candidates = vec![
+            PeerCandidate {
+                peer_name: "peer-a".into(),
+                score: 0.6,
+                capabilities_match: 1.0,
+                cost_score: 0.5,
+                load_score: 0.3,
+                locality_bonus: 0.0,
+            },
+            PeerCandidate {
+                peer_name: "peer-b".into(),
+                score: 0.9,
+                capabilities_match: 1.0,
+                cost_score: 0.8,
+                load_score: 0.8,
+                locality_bonus: 1.0,
+            },
+        ];
+        let best = select_best(candidates).unwrap();
+        assert_eq!(best.peer_name, "peer-b");
+    }
+
+    #[test]
+    fn test_default_policy_weights_sum_to_one() {
+        let p = default_policy();
+        let sum = p.weight_capability + p.weight_cost + p.weight_load + p.weight_locality;
+        assert!((sum - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_locality_bonus() {
+        let policy = default_policy();
+        let mut req = sample_request();
+        req.preferred_locality = Some("darwin-m4".into());
+        let caps = vec!["gpu".into(), "voice".into()];
+        let local = score_peer("darwin-m4", &caps, 0.2, &req, &policy);
+        let remote = score_peer("linux-a100", &caps, 0.2, &req, &policy);
+        assert!(local.locality_bonus > remote.locality_bonus);
+        assert!(local.score > remote.score);
+    }
+
+    #[test]
+    fn test_save_and_load_policy() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        convergio_db::migration::apply_migrations(&conn, "scheduler", &crate::schema::migrations())
+            .unwrap();
+        let mut policy = default_policy();
+        policy.weight_capability = 0.6;
+        policy.weight_cost = 0.1;
+        policy.weight_load = 0.2;
+        policy.weight_locality = 0.1;
+        save_policy(&conn, &policy).unwrap();
+        let loaded = load_policy(&conn, "default");
+        assert!((loaded.weight_capability - 0.6).abs() < f64::EPSILON);
+    }
+}

--- a/daemon/crates/convergio-scheduler/src/routes.rs
+++ b/daemon/crates/convergio-scheduler/src/routes.rs
@@ -1,0 +1,198 @@
+//! HTTP API routes for the scheduler.
+//!
+//! - POST /api/scheduler/decide   — make a scheduling decision
+//! - GET  /api/scheduler/policy   — get current policy
+//! - POST /api/scheduler/policy   — update policy weights
+//! - GET  /api/scheduler/history  — list recent decisions
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::response::Json;
+use axum::routing::{get, post};
+use axum::Router;
+use rusqlite::params;
+use serde::Deserialize;
+
+use convergio_db::pool::ConnPool;
+
+use crate::policy;
+use crate::types::{SchedulerPolicy, SchedulingDecision, SchedulingRequest};
+
+/// Shared state for scheduler routes.
+pub struct SchedulerState {
+    pub pool: ConnPool,
+}
+
+/// Build the scheduler API router.
+pub fn scheduler_routes(state: Arc<SchedulerState>) -> Router {
+    Router::new()
+        .route("/api/scheduler/decide", post(handle_decide))
+        .route(
+            "/api/scheduler/policy",
+            get(handle_get_policy).post(handle_set_policy),
+        )
+        .route("/api/scheduler/history", get(handle_history))
+        .with_state(state)
+}
+
+/// POST /api/scheduler/decide — score peers and assign best.
+async fn handle_decide(
+    State(state): State<Arc<SchedulerState>>,
+    Json(req): Json<SchedulingRequest>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return Json(serde_json::json!({
+                "error": {"code": "POOL_ERROR", "message": e.to_string()}
+            }))
+        }
+    };
+
+    let pol = policy::load_policy(&conn, "default");
+
+    // Query available peers from node_capabilities table.
+    let peers = load_peer_capabilities(&conn);
+    if peers.is_empty() {
+        return Json(serde_json::json!({
+            "error": {"code": "NO_PEERS", "message": "no peers with capabilities found"}
+        }));
+    }
+
+    let candidates: Vec<_> = peers
+        .iter()
+        .map(|(name, caps)| policy::score_peer(name, caps, 0.0, &req, &pol))
+        .collect();
+
+    let best = match policy::select_best(candidates.clone()) {
+        Some(b) => b,
+        None => {
+            return Json(serde_json::json!({
+                "error": {"code": "NO_MATCH", "message": "no suitable peer found"}
+            }))
+        }
+    };
+
+    let tier = req.tier_hint.clone().unwrap_or_else(|| "t2".into());
+    let decision = SchedulingDecision {
+        task_id: req.task_id,
+        assigned_peer: best.peer_name.clone(),
+        assigned_tier: tier.clone(),
+        estimated_cost: best.cost_score * req.max_cost_usd.unwrap_or(0.1),
+        reason: format!(
+            "score {:.3}, caps {:.0}%",
+            best.score,
+            best.capabilities_match * 100.0
+        ),
+        alternatives: candidates
+            .into_iter()
+            .filter(|c| c.peer_name != best.peer_name)
+            .collect(),
+    };
+
+    // Persist decision to history.
+    let _ = conn.execute(
+        "INSERT INTO scheduling_decisions (task_id, plan_id, assigned_peer, \
+         assigned_tier, estimated_cost, reason) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            decision.task_id,
+            req.plan_id,
+            decision.assigned_peer,
+            decision.assigned_tier,
+            decision.estimated_cost,
+            decision.reason,
+        ],
+    );
+
+    Json(serde_json::to_value(&decision).unwrap_or_default())
+}
+
+/// GET /api/scheduler/policy
+async fn handle_get_policy(State(state): State<Arc<SchedulerState>>) -> Json<SchedulerPolicy> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(_) => return Json(policy::default_policy()),
+    };
+    Json(policy::load_policy(&conn, "default"))
+}
+
+/// POST /api/scheduler/policy — update weights.
+async fn handle_set_policy(
+    State(state): State<Arc<SchedulerState>>,
+    Json(body): Json<SchedulerPolicy>,
+) -> Json<serde_json::Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => {
+            return Json(serde_json::json!({
+                "error": {"code": "POOL_ERROR", "message": e.to_string()}
+            }))
+        }
+    };
+    if let Err(e) = policy::save_policy(&conn, &body) {
+        return Json(serde_json::json!({
+            "error": {"code": "DB_ERROR", "message": e.to_string()}
+        }));
+    }
+    Json(serde_json::json!({"status": "updated", "name": body.name}))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HistoryQuery {
+    pub limit: Option<i64>,
+}
+
+/// GET /api/scheduler/history — recent scheduling decisions.
+async fn handle_history(
+    State(state): State<Arc<SchedulerState>>,
+    Query(params): Query<HistoryQuery>,
+) -> Json<Vec<SchedulingDecision>> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(_) => return Json(vec![]),
+    };
+    let limit = params.limit.unwrap_or(20).min(100);
+    let mut stmt = match conn.prepare(
+        "SELECT task_id, assigned_peer, assigned_tier, estimated_cost, reason \
+         FROM scheduling_decisions ORDER BY decided_at DESC LIMIT ?1",
+    ) {
+        Ok(s) => s,
+        Err(_) => return Json(vec![]),
+    };
+    let rows = match stmt.query_map(params![limit], |row| {
+        Ok(SchedulingDecision {
+            task_id: row.get(0)?,
+            assigned_peer: row.get(1)?,
+            assigned_tier: row.get(2)?,
+            estimated_cost: row.get(3)?,
+            reason: row.get(4)?,
+            alternatives: vec![],
+        })
+    }) {
+        Ok(r) => r.filter_map(|r| r.ok()).collect(),
+        Err(_) => vec![],
+    };
+    Json(rows)
+}
+
+/// Load peer names and their capability names from node_capabilities.
+fn load_peer_capabilities(conn: &rusqlite::Connection) -> Vec<(String, Vec<String>)> {
+    let mut stmt = match conn.prepare(
+        "SELECT peer_name, capability_name FROM node_capabilities \
+         ORDER BY peer_name",
+    ) {
+        Ok(s) => s,
+        Err(_) => return vec![],
+    };
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap_or_else(|_| panic!("query failed"))
+        .filter_map(|r| r.ok())
+        .collect();
+    let mut map: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+    for (peer, cap) in rows {
+        map.entry(peer).or_default().push(cap);
+    }
+    map.into_iter().collect()
+}

--- a/daemon/crates/convergio-scheduler/src/schema.rs
+++ b/daemon/crates/convergio-scheduler/src/schema.rs
@@ -1,0 +1,60 @@
+//! DB migrations for scheduler tables.
+
+use convergio_types::extension::Migration;
+
+pub fn migrations() -> Vec<Migration> {
+    vec![Migration {
+        version: 1,
+        description: "scheduler policies and decision history",
+        up: "
+            CREATE TABLE IF NOT EXISTS scheduler_policies (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                name             TEXT    NOT NULL UNIQUE,
+                weight_capability REAL   NOT NULL DEFAULT 0.4,
+                weight_cost      REAL    NOT NULL DEFAULT 0.2,
+                weight_load      REAL    NOT NULL DEFAULT 0.2,
+                weight_locality  REAL    NOT NULL DEFAULT 0.2,
+                privacy_enforce  INTEGER NOT NULL DEFAULT 1,
+                created_at       TEXT    NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS scheduling_decisions (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id        INTEGER NOT NULL,
+                plan_id        INTEGER NOT NULL,
+                assigned_peer  TEXT    NOT NULL,
+                assigned_tier  TEXT    NOT NULL,
+                estimated_cost REAL    NOT NULL DEFAULT 0,
+                reason         TEXT    NOT NULL DEFAULT '',
+                decided_at     TEXT    NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_sched_decisions_task
+                ON scheduling_decisions(task_id);
+            CREATE INDEX IF NOT EXISTS idx_sched_decisions_plan
+                ON scheduling_decisions(plan_id);
+        ",
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_are_ordered() {
+        let m = migrations();
+        for (i, mig) in m.iter().enumerate() {
+            assert_eq!(mig.version, (i + 1) as u32);
+        }
+    }
+
+    #[test]
+    fn migrations_apply_cleanly() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        convergio_db::migration::ensure_registry(&conn).unwrap();
+        let applied =
+            convergio_db::migration::apply_migrations(&conn, "scheduler", &migrations()).unwrap();
+        assert_eq!(applied, 1);
+    }
+}

--- a/daemon/crates/convergio-scheduler/src/types.rs
+++ b/daemon/crates/convergio-scheduler/src/types.rs
@@ -1,0 +1,59 @@
+//! Data types for the scheduler policy engine.
+
+use serde::{Deserialize, Serialize};
+
+/// A request to schedule a task on the best available peer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchedulingRequest {
+    pub task_id: i64,
+    pub plan_id: i64,
+    /// Required capabilities: "gpu", "voice", "compute", etc.
+    pub required_capabilities: Vec<String>,
+    /// Preferred locality: "local", "studio-mac", etc.
+    pub preferred_locality: Option<String>,
+    /// Privacy level: "public", "org", "private".
+    pub privacy_level: String,
+    /// Maximum cost budget in USD.
+    pub max_cost_usd: Option<f64>,
+    /// Tier hint: "t1", "t2", "t3", "t4".
+    pub tier_hint: Option<String>,
+}
+
+/// The result of scheduling: which peer was chosen and why.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchedulingDecision {
+    pub task_id: i64,
+    pub assigned_peer: String,
+    pub assigned_tier: String,
+    pub estimated_cost: f64,
+    pub reason: String,
+    pub alternatives: Vec<PeerCandidate>,
+}
+
+/// A scored candidate peer for a scheduling request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerCandidate {
+    pub peer_name: String,
+    pub score: f64,
+    pub capabilities_match: f64,
+    pub cost_score: f64,
+    pub load_score: f64,
+    pub locality_bonus: f64,
+}
+
+/// Configurable weights for the scoring formula.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchedulerPolicy {
+    pub id: i64,
+    pub name: String,
+    /// Weight for capability match (default 0.4).
+    pub weight_capability: f64,
+    /// Weight for cost score (default 0.2).
+    pub weight_cost: f64,
+    /// Weight for load score (default 0.2).
+    pub weight_load: f64,
+    /// Weight for locality bonus (default 0.2).
+    pub weight_locality: f64,
+    /// Whether to enforce privacy constraints.
+    pub privacy_enforce: bool,
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -59,6 +59,7 @@ fn register_extensions(
         Arc::new(convergio_observatory::ObservatoryExtension::new(
             pool.clone(),
         )),
+        Arc::new(convergio_scheduler::SchedulerExtension::new(pool.clone())),
     ]
 }
 
@@ -239,7 +240,6 @@ impl convergio_telemetry::health::HealthCheck for ExtHealthAdapter {
 
 /// Adapter: wraps an Extension as a MetricSource for the MetricsCollector.
 struct ExtMetricAdapter(String, Arc<dyn Extension>);
-
 impl convergio_telemetry::metrics::MetricSource for ExtMetricAdapter {
     fn name(&self) -> &str {
         &self.0


### PR DESCRIPTION
## Summary
- New crate `convergio-scheduler` with policy-based task scheduling
- Scores mesh peers by capability match (0.4), cost (0.2), load (0.2), and locality (0.2) using configurable weights
- HTTP API: POST /api/scheduler/decide, GET/POST /api/scheduler/policy, GET /api/scheduler/history
- Persists scheduling decisions for audit trail, policies are upsertable via DB
- Wired into daemon as Extension with migrations, health checks, and metrics

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test -p convergio-scheduler` — 8 tests pass (scoring, selection, policy persistence, migrations)
- [x] `cargo test --workspace` — all workspace tests pass
- [x] `cargo fmt --all` applied
- [x] All files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)