### PR TITLE
feat: agent context API (Fase 32e)

### DIFF
--- a/daemon/crates/convergio-agent-runtime/src/context.rs
+++ b/daemon/crates/convergio-agent-runtime/src/context.rs
@@ -1,0 +1,219 @@
+//! Per-agent live context: CRUD operations on art_context.
+
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{RuntimeError, RuntimeResult};
+
+/// A single context key-value entry for an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextEntry {
+    pub agent_id: String,
+    pub key: String,
+    pub value: String,
+    pub version: i64,
+    pub set_by: String,
+    pub updated_at: String,
+}
+
+/// List all context entries for an agent.
+pub fn list(conn: &rusqlite::Connection, agent_id: &str) -> RuntimeResult<Vec<ContextEntry>> {
+    let mut stmt = conn.prepare(
+        "SELECT agent_id, key, value, version, set_by, updated_at \
+         FROM art_context WHERE agent_id = ?1 ORDER BY key",
+    )?;
+    let rows = stmt.query_map(params![agent_id], |r| {
+        Ok(ContextEntry {
+            agent_id: r.get(0)?,
+            key: r.get(1)?,
+            value: r.get(2)?,
+            version: r.get(3)?,
+            set_by: r.get(4)?,
+            updated_at: r.get(5)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// Get a single context entry.
+pub fn get(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    key: &str,
+) -> RuntimeResult<Option<ContextEntry>> {
+    let mut stmt = conn.prepare(
+        "SELECT agent_id, key, value, version, set_by, updated_at \
+         FROM art_context WHERE agent_id = ?1 AND key = ?2",
+    )?;
+    let mut rows = stmt.query_map(params![agent_id, key], |r| {
+        Ok(ContextEntry {
+            agent_id: r.get(0)?,
+            key: r.get(1)?,
+            value: r.get(2)?,
+            version: r.get(3)?,
+            set_by: r.get(4)?,
+            updated_at: r.get(5)?,
+        })
+    })?;
+    match rows.next() {
+        Some(row) => Ok(Some(row?)),
+        None => Ok(None),
+    }
+}
+
+/// Set a context entry (upsert with version increment).
+pub fn set(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    key: &str,
+    value: &str,
+    set_by: &str,
+) -> RuntimeResult<ContextEntry> {
+    conn.execute(
+        "INSERT INTO art_context (agent_id, key, value, version, set_by) \
+         VALUES (?1, ?2, ?3, 1, ?4) \
+         ON CONFLICT(agent_id, key) DO UPDATE SET \
+           value = excluded.value, \
+           version = art_context.version + 1, \
+           set_by = excluded.set_by, \
+           updated_at = datetime('now')",
+        params![agent_id, key, value, set_by],
+    )?;
+    get(conn, agent_id, key)?
+        .ok_or_else(|| RuntimeError::Internal("upsert succeeded but row missing".into()))
+}
+
+/// Delete a context entry. Returns true if a row was deleted.
+pub fn delete(conn: &rusqlite::Connection, agent_id: &str, key: &str) -> RuntimeResult<bool> {
+    let n = conn.execute(
+        "DELETE FROM art_context WHERE agent_id = ?1 AND key = ?2",
+        params![agent_id, key],
+    )?;
+    Ok(n > 0)
+}
+
+/// Seed initial context for a newly spawned agent.
+///
+/// Inserts org_id, and if task_id is present, also task_id,
+/// instructions, and plan_id from the tasks table.
+/// Uses INSERT OR IGNORE so repeated calls are safe.
+pub fn seed(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    task_id: Option<i64>,
+    org_id: &str,
+) -> RuntimeResult<usize> {
+    let mut count = 0usize;
+    count += conn.execute(
+        "INSERT OR IGNORE INTO art_context \
+         (agent_id, key, value, set_by) VALUES (?1, 'org_id', ?2, 'system')",
+        params![agent_id, org_id],
+    )?;
+    if let Some(tid) = task_id {
+        count += conn.execute(
+            "INSERT OR IGNORE INTO art_context \
+             (agent_id, key, value, set_by) VALUES (?1, 'task_id', ?2, 'system')",
+            params![agent_id, tid.to_string()],
+        )?;
+        // Pull instructions and plan_id from tasks table if it exists
+        let task_row: Option<(Option<String>, Option<i64>)> = conn
+            .query_row(
+                "SELECT instructions, plan_id FROM tasks WHERE id = ?1",
+                params![tid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .ok();
+        if let Some((instr, plan_id)) = task_row {
+            if let Some(i) = instr {
+                count += conn.execute(
+                    "INSERT OR IGNORE INTO art_context \
+                     (agent_id, key, value, set_by) \
+                     VALUES (?1, 'instructions', ?2, 'system')",
+                    params![agent_id, i],
+                )?;
+            }
+            if let Some(pid) = plan_id {
+                count += conn.execute(
+                    "INSERT OR IGNORE INTO art_context \
+                     (agent_id, key, value, set_by) \
+                     VALUES (?1, 'plan_id', ?2, 'system')",
+                    params![agent_id, pid.to_string()],
+                )?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        conn.execute(
+            "INSERT INTO art_agents (id, agent_name, org_id, node) \
+             VALUES ('a1', 'test-agent', 'org-1', 'localhost')",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_set_and_get() {
+        let conn = setup();
+        let entry = set(&conn, "a1", "model", "opus-4", "agent").unwrap();
+        assert_eq!(entry.key, "model");
+        assert_eq!(entry.value, "opus-4");
+        assert_eq!(entry.version, 1);
+        let got = get(&conn, "a1", "model").unwrap().unwrap();
+        assert_eq!(got.value, "opus-4");
+    }
+
+    #[test]
+    fn test_list() {
+        let conn = setup();
+        set(&conn, "a1", "alpha", "1", "agent").unwrap();
+        set(&conn, "a1", "beta", "2", "agent").unwrap();
+        let entries = list(&conn, "a1").unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key, "alpha");
+        assert_eq!(entries[1].key, "beta");
+    }
+
+    #[test]
+    fn test_delete() {
+        let conn = setup();
+        set(&conn, "a1", "tmp", "x", "agent").unwrap();
+        assert!(delete(&conn, "a1", "tmp").unwrap());
+        assert!(!delete(&conn, "a1", "tmp").unwrap());
+        assert!(get(&conn, "a1", "tmp").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_upsert_increments_version() {
+        let conn = setup();
+        let v1 = set(&conn, "a1", "k", "val1", "agent").unwrap();
+        assert_eq!(v1.version, 1);
+        let v2 = set(&conn, "a1", "k", "val2", "agent").unwrap();
+        assert_eq!(v2.version, 2);
+        assert_eq!(v2.value, "val2");
+    }
+
+    #[test]
+    fn test_seed_basic() {
+        let conn = setup();
+        let count = seed(&conn, "a1", None, "org-1").unwrap();
+        assert_eq!(count, 1);
+        let entry = get(&conn, "a1", "org_id").unwrap().unwrap();
+        assert_eq!(entry.value, "org-1");
+    }
+}

--- a/daemon/crates/convergio-agent-runtime/src/context_routes.rs
+++ b/daemon/crates/convergio-agent-runtime/src/context_routes.rs
@@ -1,0 +1,143 @@
+//! HTTP endpoints for per-agent context CRUD.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::response::Json;
+use axum::routing::{delete, get, post, put};
+use axum::Router;
+use convergio_db::pool::ConnPool;
+use rusqlite::params;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::context;
+
+/// Shared state for context routes.
+pub struct ContextState {
+    pub pool: ConnPool,
+}
+
+/// Build the context API router.
+pub fn context_routes(state: Arc<ContextState>) -> Router {
+    Router::new()
+        .route("/api/agents/:id/context", get(handle_list))
+        .route("/api/agents/:id/context/seed", post(handle_seed))
+        .route("/api/agents/:id/context/:key", get(handle_get))
+        .route("/api/agents/:id/context/:key", put(handle_set))
+        .route("/api/agents/:id/context/:key", delete(handle_delete))
+        .with_state(state)
+}
+
+async fn handle_list(
+    State(state): State<Arc<ContextState>>,
+    Path(agent_id): Path<String>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    match context::list(&conn, &agent_id) {
+        Ok(entries) => Json(json!({ "entries": entries })),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+async fn handle_get(
+    State(state): State<Arc<ContextState>>,
+    Path((agent_id, key)): Path<(String, String)>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    match context::get(&conn, &agent_id, &key) {
+        Ok(Some(entry)) => Json(json!(entry)),
+        Ok(None) => err_json("NOT_FOUND", "context key not found"),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+#[derive(Deserialize)]
+struct SetBody {
+    value: String,
+    #[serde(default = "default_set_by")]
+    set_by: String,
+}
+
+fn default_set_by() -> String {
+    "agent".into()
+}
+
+async fn handle_set(
+    State(state): State<Arc<ContextState>>,
+    Path((agent_id, key)): Path<(String, String)>,
+    Json(body): Json<SetBody>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    match context::set(&conn, &agent_id, &key, &body.value, &body.set_by) {
+        Ok(entry) => Json(json!(entry)),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+async fn handle_delete(
+    State(state): State<Arc<ContextState>>,
+    Path((agent_id, key)): Path<(String, String)>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    match context::delete(&conn, &agent_id, &key) {
+        Ok(true) => Json(json!({ "deleted": true })),
+        Ok(false) => err_json("NOT_FOUND", "context key not found"),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+async fn handle_seed(
+    State(state): State<Arc<ContextState>>,
+    Path(agent_id): Path<String>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    // Look up task_id and org_id from art_agents
+    let agent_row: Result<(Option<i64>, String), _> = conn.query_row(
+        "SELECT task_id, org_id FROM art_agents WHERE id = ?1",
+        params![agent_id],
+        |r| Ok((r.get(0)?, r.get(1)?)),
+    );
+    let (task_id, org_id) = match agent_row {
+        Ok(row) => row,
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            return err_json("NOT_FOUND", "agent not found");
+        }
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    match context::seed(&conn, &agent_id, task_id, &org_id) {
+        Ok(count) => Json(json!({ "seeded": count })),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+fn err_json(code: &str, message: &str) -> Json<Value> {
+    Json(json!({ "error": { "code": code, "message": message } }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_routes_builds() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let state = Arc::new(ContextState { pool });
+        let _router = context_routes(state);
+    }
+}

--- a/daemon/crates/convergio-agent-runtime/src/ext.rs
+++ b/daemon/crates/convergio-agent-runtime/src/ext.rs
@@ -75,6 +75,11 @@ impl Extension for AgentRuntimeExtension {
                     description: "GC for dead agents, orphan tasks, expired delegations"
                         .to_string(),
                 },
+                Capability {
+                    name: "agent-context".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Per-agent live context from DB".to_string(),
+                },
             ],
             requires: vec![],
             agent_tools: vec![],
@@ -97,8 +102,12 @@ impl Extension for AgentRuntimeExtension {
             repo_root,
             daemon_url,
         });
-        let router =
-            runtime_routes(self.state()).merge(crate::spawn_routes::spawn_routes(spawn_state));
+        let ctx_state = Arc::new(crate::context_routes::ContextState {
+            pool: self.pool.clone(),
+        });
+        let router = runtime_routes(self.state())
+            .merge(crate::spawn_routes::spawn_routes(spawn_state))
+            .merge(crate::context_routes::context_routes(ctx_state));
         Some(router)
     }
 
@@ -191,14 +200,14 @@ mod tests {
         let ext = AgentRuntimeExtension::default();
         let m = ext.manifest();
         assert_eq!(m.id, "convergio-agent-runtime");
-        assert_eq!(m.provides.len(), 5);
+        assert_eq!(m.provides.len(), 6);
     }
 
     #[test]
     fn migrations_are_returned() {
         let ext = AgentRuntimeExtension::default();
         let migs = ext.migrations();
-        assert_eq!(migs.len(), 3);
+        assert_eq!(migs.len(), 4);
     }
 
     #[test]

--- a/daemon/crates/convergio-agent-runtime/src/lib.rs
+++ b/daemon/crates/convergio-agent-runtime/src/lib.rs
@@ -9,6 +9,8 @@
 
 pub mod allocator;
 pub mod concurrency;
+pub mod context;
+pub mod context_routes;
 pub mod delegation;
 pub mod ext;
 pub mod heartbeat;

--- a/daemon/crates/convergio-agent-runtime/src/schema.rs
+++ b/daemon/crates/convergio-agent-runtime/src/schema.rs
@@ -1,7 +1,7 @@
 //! DB migrations for the agent runtime.
 //!
 //! Tables: art_agents, art_heartbeats, art_delegations, art_queue,
-//! art_scope_rules.
+//! art_scope_rules, art_context.
 
 use convergio_types::extension::Migration;
 
@@ -86,6 +86,23 @@ CREATE TABLE IF NOT EXISTS art_scope_rules (
 );
 CREATE INDEX IF NOT EXISTS idx_art_scope_agent ON art_scope_rules(agent_id);",
         },
+        Migration {
+            version: 4,
+            description: "per-agent live context",
+            up: "\
+CREATE TABLE IF NOT EXISTS art_context (
+    agent_id    TEXT NOT NULL,
+    key         TEXT NOT NULL,
+    value       TEXT NOT NULL,
+    version     INTEGER NOT NULL DEFAULT 1,
+    set_by      TEXT NOT NULL DEFAULT 'system',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (agent_id, key),
+    FOREIGN KEY (agent_id) REFERENCES art_agents(id)
+);
+CREATE INDEX IF NOT EXISTS idx_art_context_agent ON art_context(agent_id);",
+        },
     ]
 }
 
@@ -96,7 +113,7 @@ mod tests {
     #[test]
     fn migrations_have_sequential_versions() {
         let migs = migrations();
-        assert_eq!(migs.len(), 3);
+        assert_eq!(migs.len(), 4);
         for (i, m) in migs.iter().enumerate() {
             assert_eq!(m.version, (i + 1) as u32);
         }
@@ -116,6 +133,6 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(count, 5);
+        assert_eq!(count, 6);
     }
 }


### PR DESCRIPTION
## Summary

- **New `art_context` table** (migration v4): per-agent key-value context with versioning, authorship tracking, and timestamps
- **CRUD module `context.rs`**: `list`, `get`, `set` (upsert with version increment), `delete`, and `seed` (auto-populate from agent/task data)
- **HTTP endpoints `context_routes.rs`**: 5 routes under `/api/agents/:id/context` — list, get, put, delete, seed
- **Wired into extension**: new capability `agent-context v1.0`, routes merged in `ext.rs`

## Test plan

- [x] `cargo check --workspace` — clean (only pre-existing warning in convergio-orchestrator)
- [x] `cargo test -p convergio-agent-runtime` — all 49 tests pass (6 new: set_and_get, list, delete, upsert_increments_version, seed_basic, context_routes_builds)
- [x] `cargo fmt --all` — no changes needed
- [ ] Integration: spawn agent, call `POST /api/agents/:id/context/seed`, verify entries via `GET /api/agents/:id/context`
- [ ] Verify `PUT` upsert increments version via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)