### PR TITLE
feat: agent live adaptation (Fase 32f)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "convergio-org",
  "convergio-org-package",
  "convergio-prompts",
+ "convergio-scheduler",
  "convergio-security",
  "convergio-server",
  "convergio-telemetry",
@@ -856,14 +857,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-scheduler"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "convergio-db",
+ "convergio-telemetry",
+ "convergio-types",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "convergio-security"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "base64",
  "chrono",
+ "convergio-db",
  "convergio-types",
  "getrandom 0.2.17",
  "hmac",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",

--- a/daemon/crates/convergio-agent-runtime/src/adaptation.rs
+++ b/daemon/crates/convergio-agent-runtime/src/adaptation.rs
@@ -1,0 +1,201 @@
+//! Agent live adaptation — poll for updates and sentinel files.
+//!
+//! Agents call `poll_updates` periodically to discover plan/task status
+//! changes, new context entries, pending IPC messages, and sentinel signals
+//! (STOP, PRIORITY_CHANGE, CHECKPOINT_READY).
+
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{RuntimeError, RuntimeResult};
+
+/// All updates available for an agent since a given timestamp.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AgentUpdates {
+    pub agent_id: String,
+    pub since: String,
+    pub plan_status: Option<String>,
+    pub task_status: Option<String>,
+    pub context_changes: Vec<ContextChange>,
+    pub pending_messages: i64,
+    pub sentinel: Option<String>,
+}
+
+/// A context entry that changed since the last poll.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContextChange {
+    pub key: String,
+    pub value: String,
+    pub version: i64,
+    pub updated_at: String,
+}
+
+/// Fetch all updates for an agent since a given timestamp.
+pub fn poll_updates(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    since: &str,
+) -> RuntimeResult<AgentUpdates> {
+    // 1. Get agent record
+    let row: (Option<i64>, Option<String>, String) = conn
+        .query_row(
+            "SELECT task_id, workspace_path, agent_name FROM art_agents WHERE id = ?1",
+            params![agent_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => RuntimeError::NotFound(agent_id.to_string()),
+            other => RuntimeError::Db(other),
+        })?;
+    let (task_id, workspace_path, agent_name) = row;
+
+    // 2. Plan + task status
+    let (plan_status, task_status) = query_plan_task(conn, task_id);
+
+    // 3. Context changes since timestamp
+    let context_changes = query_context_changes(conn, agent_id, since)?;
+
+    // 4. Pending IPC messages
+    let pending_messages: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM ipc_messages WHERE to_agent = ?1 AND read_at IS NULL",
+            params![agent_name],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // 5. Sentinel check
+    let sentinel = workspace_path.as_deref().and_then(check_sentinel);
+
+    Ok(AgentUpdates {
+        agent_id: agent_id.to_string(),
+        since: since.to_string(),
+        plan_status,
+        task_status,
+        context_changes,
+        pending_messages,
+        sentinel,
+    })
+}
+
+fn query_plan_task(
+    conn: &rusqlite::Connection,
+    task_id: Option<i64>,
+) -> (Option<String>, Option<String>) {
+    let Some(tid) = task_id else {
+        return (None, None);
+    };
+    let row: Option<(String, Option<i64>)> = conn
+        .query_row(
+            "SELECT status, plan_id FROM tasks WHERE id = ?1",
+            params![tid],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .ok();
+    let Some((task_status, plan_id)) = row else {
+        return (None, None);
+    };
+    let plan_status = plan_id.and_then(|pid| {
+        conn.query_row(
+            "SELECT status FROM plans WHERE id = ?1",
+            params![pid],
+            |r| r.get::<_, String>(0),
+        )
+        .ok()
+    });
+    (plan_status, Some(task_status))
+}
+
+fn query_context_changes(
+    conn: &rusqlite::Connection,
+    agent_id: &str,
+    since: &str,
+) -> RuntimeResult<Vec<ContextChange>> {
+    let mut stmt = conn.prepare(
+        "SELECT key, value, version, updated_at FROM art_context \
+         WHERE agent_id = ?1 AND updated_at > ?2 ORDER BY updated_at",
+    )?;
+    let rows = stmt.query_map(params![agent_id, since], |r| {
+        Ok(ContextChange {
+            key: r.get(0)?,
+            value: r.get(1)?,
+            version: r.get(2)?,
+            updated_at: r.get(3)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// Check for sentinel files in an agent workspace.
+pub fn check_sentinel(workspace: &str) -> Option<String> {
+    let sentinel_dir = std::path::Path::new(workspace).join(".convergio");
+    for name in ["STOP", "PRIORITY_CHANGE", "CHECKPOINT_READY"] {
+        if sentinel_dir.join(name).exists() {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+/// Write a sentinel file to an agent's workspace.
+pub fn write_sentinel(workspace: &str, sentinel: &str) -> RuntimeResult<()> {
+    let dir = std::path::Path::new(workspace).join(".convergio");
+    std::fs::create_dir_all(&dir).map_err(|e| RuntimeError::Internal(format!("mkdir: {e}")))?;
+    std::fs::write(dir.join(sentinel), "")
+        .map_err(|e| RuntimeError::Internal(format!("write sentinel: {e}")))?;
+    Ok(())
+}
+
+/// Clear a sentinel file after it has been processed.
+pub fn clear_sentinel(workspace: &str, sentinel: &str) -> RuntimeResult<()> {
+    let path = std::path::Path::new(workspace)
+        .join(".convergio")
+        .join(sentinel);
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .map_err(|e| RuntimeError::Internal(format!("rm sentinel: {e}")))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_sentinel_none() {
+        // Non-existent directory returns None
+        assert!(check_sentinel("/tmp/no-such-dir-convergio").is_none());
+    }
+
+    #[test]
+    fn test_write_and_check_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().to_str().unwrap();
+        write_sentinel(ws, "STOP").unwrap();
+        assert_eq!(check_sentinel(ws), Some("STOP".to_string()));
+    }
+
+    #[test]
+    fn test_clear_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().to_str().unwrap();
+        write_sentinel(ws, "STOP").unwrap();
+        clear_sentinel(ws, "STOP").unwrap();
+        assert!(check_sentinel(ws).is_none());
+    }
+
+    #[test]
+    fn test_poll_updates_no_agent() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        let err = poll_updates(&conn, "nonexistent", "1970-01-01").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+}

--- a/daemon/crates/convergio-agent-runtime/src/adaptation_routes.rs
+++ b/daemon/crates/convergio-agent-runtime/src/adaptation_routes.rs
@@ -1,0 +1,120 @@
+//! HTTP endpoints for agent live adaptation.
+//!
+//! - GET  /api/agents/:id/updates?since=...  — poll all updates
+//! - POST /api/agents/:id/sentinel/:name     — write sentinel
+//! - DELETE /api/agents/:id/sentinel/:name   — clear sentinel
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::response::Json;
+use axum::routing::{delete, get, post};
+use axum::Router;
+use convergio_db::pool::ConnPool;
+use rusqlite::params;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::adaptation;
+
+/// Shared state for adaptation routes.
+pub struct AdaptationState {
+    pub pool: ConnPool,
+}
+
+#[derive(Deserialize)]
+pub struct UpdatesQuery {
+    since: Option<String>,
+}
+
+/// Build the adaptation API router.
+pub fn adaptation_routes(state: Arc<AdaptationState>) -> Router {
+    Router::new()
+        .route("/api/agents/:id/updates", get(handle_poll_updates))
+        .route("/api/agents/:id/sentinel/:name", post(handle_write))
+        .route("/api/agents/:id/sentinel/:name", delete(handle_clear))
+        .with_state(state)
+}
+
+async fn handle_poll_updates(
+    State(state): State<Arc<AdaptationState>>,
+    Path(agent_id): Path<String>,
+    Query(q): Query<UpdatesQuery>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    let since = q.since.as_deref().unwrap_or("1970-01-01");
+    match adaptation::poll_updates(&conn, &agent_id, since) {
+        Ok(updates) => Json(json!(updates)),
+        Err(crate::types::RuntimeError::NotFound(_)) => err_json("NOT_FOUND", "agent not found"),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+async fn handle_write(
+    State(state): State<Arc<AdaptationState>>,
+    Path((agent_id, name)): Path<(String, String)>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    let ws = match lookup_workspace(&conn, &agent_id) {
+        Ok(w) => w,
+        Err(resp) => return resp,
+    };
+    match adaptation::write_sentinel(&ws, &name) {
+        Ok(()) => Json(json!({ "ok": true, "sentinel": name })),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+async fn handle_clear(
+    State(state): State<Arc<AdaptationState>>,
+    Path((agent_id, name)): Path<(String, String)>,
+) -> Json<Value> {
+    let conn = match state.pool.get() {
+        Ok(c) => c,
+        Err(e) => return err_json("INTERNAL", &e.to_string()),
+    };
+    let ws = match lookup_workspace(&conn, &agent_id) {
+        Ok(w) => w,
+        Err(resp) => return resp,
+    };
+    match adaptation::clear_sentinel(&ws, &name) {
+        Ok(()) => Json(json!({ "ok": true, "cleared": name })),
+        Err(e) => err_json("INTERNAL", &e.to_string()),
+    }
+}
+
+fn lookup_workspace(conn: &rusqlite::Connection, agent_id: &str) -> Result<String, Json<Value>> {
+    let row: Result<Option<String>, _> = conn.query_row(
+        "SELECT workspace_path FROM art_agents WHERE id = ?1",
+        params![agent_id],
+        |r| r.get(0),
+    );
+    match row {
+        Ok(Some(ws)) => Ok(ws),
+        Ok(None) => Err(err_json("BAD_REQUEST", "agent has no workspace")),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Err(err_json("NOT_FOUND", "agent not found")),
+        Err(e) => Err(err_json("INTERNAL", &e.to_string())),
+    }
+}
+
+fn err_json(code: &str, message: &str) -> Json<Value> {
+    Json(json!({ "error": { "code": code, "message": message } }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adaptation_routes_builds() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let state = Arc::new(AdaptationState { pool });
+        let _router = adaptation_routes(state);
+    }
+}

--- a/daemon/crates/convergio-agent-runtime/src/ext.rs
+++ b/daemon/crates/convergio-agent-runtime/src/ext.rs
@@ -80,6 +80,11 @@ impl Extension for AgentRuntimeExtension {
                     version: "1.0".to_string(),
                     description: "Per-agent live context from DB".to_string(),
                 },
+                Capability {
+                    name: "agent-adaptation".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Live adaptation: poll updates, sentinel files".to_string(),
+                },
             ],
             requires: vec![],
             agent_tools: vec![],
@@ -105,9 +110,13 @@ impl Extension for AgentRuntimeExtension {
         let ctx_state = Arc::new(crate::context_routes::ContextState {
             pool: self.pool.clone(),
         });
+        let adapt_state = Arc::new(crate::adaptation_routes::AdaptationState {
+            pool: self.pool.clone(),
+        });
         let router = runtime_routes(self.state())
             .merge(crate::spawn_routes::spawn_routes(spawn_state))
-            .merge(crate::context_routes::context_routes(ctx_state));
+            .merge(crate::context_routes::context_routes(ctx_state))
+            .merge(crate::adaptation_routes::adaptation_routes(adapt_state));
         Some(router)
     }
 
@@ -200,7 +209,7 @@ mod tests {
         let ext = AgentRuntimeExtension::default();
         let m = ext.manifest();
         assert_eq!(m.id, "convergio-agent-runtime");
-        assert_eq!(m.provides.len(), 6);
+        assert_eq!(m.provides.len(), 7);
     }
 
     #[test]

--- a/daemon/crates/convergio-agent-runtime/src/lib.rs
+++ b/daemon/crates/convergio-agent-runtime/src/lib.rs
@@ -7,6 +7,8 @@
 //! Implements Extension: provides scheduling, isolation, and lifecycle
 //! management for AI agents.
 
+pub mod adaptation;
+pub mod adaptation_routes;
 pub mod allocator;
 pub mod concurrency;
 pub mod context;

--- a/daemon/crates/convergio-agent-runtime/src/spawn_monitor.rs
+++ b/daemon/crates/convergio-agent-runtime/src/spawn_monitor.rs
@@ -22,8 +22,25 @@ pub fn monitor_agent(
     _repo_root: String,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        // Sentinel watcher: kill agent on STOP signal
+        let ws_clone = workspace.clone();
+        let sentinel_handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                if let Some(s) = crate::adaptation::check_sentinel(&ws_clone) {
+                    if s == "STOP" {
+                        tracing::info!(pid, "STOP sentinel detected, killing agent");
+                        unsafe {
+                            libc::kill(pid as i32, libc::SIGTERM);
+                        }
+                        break;
+                    }
+                }
+            }
+        });
         // Wait for process to exit (poll every 5s)
         let exited = wait_for_exit(pid).await;
+        sentinel_handle.abort();
         tracing::info!(
             agent_id = agent_id.as_str(),
             pid,


### PR DESCRIPTION
## Summary
- New `adaptation.rs`: `poll_updates()` aggregates plan/task status, context changes, pending IPC messages, and sentinel files into a single response for agents to poll
- New `adaptation_routes.rs`: three endpoints — `GET /api/agents/:id/updates`, `POST /api/agents/:id/sentinel/:name`, `DELETE /api/agents/:id/sentinel/:name`
- Sentinel file support: daemon writes STOP/PRIORITY_CHANGE/CHECKPOINT_READY files to agent workspace `.convergio/` dir; agents detect them on next poll
- Monitor loop in `spawn_monitor.rs` now spawns a sentinel watcher that kills the agent process (SIGTERM) when STOP sentinel is detected

## Test plan
- [x] `test_check_sentinel_none` — no sentinel dir returns None
- [x] `test_write_and_check_sentinel` — write STOP, check returns Some("STOP")
- [x] `test_clear_sentinel` — write, clear, check returns None
- [x] `test_poll_updates_no_agent` — nonexistent agent returns NotFound error
- [x] `test_adaptation_routes_builds` — router builds without panic
- [x] `cargo check --workspace` passes
- [x] `cargo test -p convergio-agent-runtime` — 54 tests pass
- [x] All files under 250 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)