### PR TITLE
fix: inference blocking_write panic (M1 Pro crash)

### DIFF
--- a/daemon/crates/convergio-inference/src/ext.rs
+++ b/daemon/crates/convergio-inference/src/ext.rs
@@ -92,7 +92,13 @@ impl Extension for InferenceExtension {
             .unwrap_or_else(|_| "config/inference-models.toml".to_string());
         let endpoints = crate::model_config::load_model_endpoints(Some(&config_path));
 
-        let mut router = self.router.blocking_write();
+        let mut router = match self.router.try_write() {
+            Ok(r) => r,
+            Err(_) => {
+                tracing::warn!("inference: could not acquire router lock on start");
+                return Ok(());
+            }
+        };
         for ep in endpoints {
             tracing::info!(
                 model = ep.name.as_str(),


### PR DESCRIPTION
blocking_write on tokio RwLock panics inside async runtime. 🤖