### PR TITLE
feat: Fase 26 — self-build extension (Convergio builds Convergio)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -466,6 +466,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "convergio-build"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "convergio-db",
+ "convergio-telemetry",
+ "convergio-types",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "convergio-cli"
 version = "0.1.0"
 dependencies = [
@@ -495,6 +515,7 @@ dependencies = [
  "convergio-agents",
  "convergio-backup",
  "convergio-billing",
+ "convergio-build",
  "convergio-db",
  "convergio-delegation",
  "convergio-depgraph",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/convergio-file-transport",
     "crates/convergio-delegation",
     "crates/convergio-scheduler",
+    "crates/convergio-build",
 ]
 
 [package]
@@ -70,6 +71,7 @@ convergio-observatory = { path = "crates/convergio-observatory" }
 convergio-file-transport = { path = "crates/convergio-file-transport" }
 convergio-delegation = { path = "crates/convergio-delegation" }
 convergio-scheduler = { path = "crates/convergio-scheduler" }
+convergio-build = { path = "crates/convergio-build" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 dirs = { workspace = true }

--- a/daemon/crates/convergio-build/Cargo.toml
+++ b/daemon/crates/convergio-build/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "convergio-build"
+description = "Self-build: the daemon builds, tests, and deploys itself"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+convergio-types = { path = "../convergio-types" }
+convergio-db = { path = "../convergio-db" }
+convergio-telemetry = { path = "../convergio-telemetry" }
+tracing = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+rusqlite = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+sha2 = { workspace = true }
+axum = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/daemon/crates/convergio-build/src/builder.rs
+++ b/daemon/crates/convergio-build/src/builder.rs
@@ -1,0 +1,292 @@
+//! Build logic — runs cargo check/test/build and tracks results.
+
+use crate::types::{BuildError, BuildRecord, BuildResult, BuildStatus};
+use convergio_db::pool::ConnPool;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tracing::info;
+
+/// Resolve the workspace root (where Cargo.toml lives).
+pub fn workspace_root() -> PathBuf {
+    // The binary runs from daemon/, so Cargo.toml is in the same dir
+    let exe = std::env::current_exe().unwrap_or_default();
+    // Walk up from binary location to find daemon/Cargo.toml
+    for ancestor in exe.ancestors() {
+        if ancestor.join("Cargo.toml").exists() && ancestor.join("crates").exists() {
+            return ancestor.to_path_buf();
+        }
+    }
+    // Fallback: assume CWD or known path
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// Get current git commit hash.
+pub fn current_commit() -> String {
+    Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Create a new build record in the database.
+pub fn create_build(pool: &ConnPool, commit: &str) -> BuildResult<String> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let conn = pool.get().map_err(|e| BuildError::Pool(e.to_string()))?;
+    conn.execute(
+        "INSERT INTO build_history (id, status, commit_hash) VALUES (?1, ?2, ?3)",
+        rusqlite::params![id, "queued", commit],
+    )?;
+    Ok(id)
+}
+
+/// Update build status.
+pub fn update_status(pool: &ConnPool, id: &str, status: BuildStatus) -> BuildResult<()> {
+    let conn = pool.get().map_err(|e| BuildError::Pool(e.to_string()))?;
+    conn.execute(
+        "UPDATE build_history SET status = ?1 WHERE id = ?2",
+        rusqlite::params![status.to_string(), id],
+    )?;
+    Ok(())
+}
+
+/// Mark build as completed (success or failure).
+pub fn complete_build(pool: &ConnPool, id: &str, record: &BuildRecord) -> BuildResult<()> {
+    let conn = pool.get().map_err(|e| BuildError::Pool(e.to_string()))?;
+    conn.execute(
+        "UPDATE build_history SET status=?1, test_count=?2, binary_hash=?3, \
+         binary_size=?4, completed_at=datetime('now'), error=?5, duration_secs=?6 \
+         WHERE id=?7",
+        rusqlite::params![
+            record.status.to_string(),
+            record.test_count,
+            record.binary_hash,
+            record.binary_size,
+            record.error,
+            record.duration_secs,
+            id,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Run the full build pipeline: check → test → build --release.
+pub fn run_build(workspace: &Path) -> BuildResult<(i64, String, i64)> {
+    info!(workspace = %workspace.display(), "starting self-build pipeline");
+
+    // Step 1: cargo check
+    let out = Command::new("cargo")
+        .args(["check", "--workspace"])
+        .current_dir(workspace)
+        .output()?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(BuildError::BuildFailed(format!("cargo check: {stderr}")));
+    }
+    info!("cargo check passed");
+
+    // Step 2: cargo test
+    let out = Command::new("cargo")
+        .args(["test", "--workspace"])
+        .current_dir(workspace)
+        .output()?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let test_count = parse_test_count(&stdout);
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(BuildError::BuildFailed(format!("cargo test: {stderr}")));
+    }
+    info!(tests = test_count, "cargo test passed");
+
+    // Step 3: cargo build --release
+    let out = Command::new("cargo")
+        .args(["build", "--release"])
+        .current_dir(workspace)
+        .output()?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(BuildError::BuildFailed(format!("cargo build: {stderr}")));
+    }
+
+    // Hash + size of produced binary
+    let binary = workspace.join("target/release/convergio");
+    let hash = hash_file(&binary)?;
+    let size = std::fs::metadata(&binary)
+        .map(|m| m.len() as i64)
+        .unwrap_or(0);
+    info!(hash = %hash, size, "release binary built");
+
+    Ok((test_count, hash, size))
+}
+
+/// Parse total test count from cargo test output.
+fn parse_test_count(output: &str) -> i64 {
+    let mut total: i64 = 0;
+    for line in output.lines() {
+        // Lines like: "test result: ok. 59 passed; 0 failed; ..."
+        if let Some(rest) = line.strip_prefix("test result:") {
+            for part in rest.split(';') {
+                let part = part.trim();
+                if part.ends_with("passed") {
+                    // Extract the number just before "passed"
+                    let words: Vec<&str> = part.split_whitespace().collect();
+                    if words.len() >= 2 {
+                        if let Ok(n) = words[words.len() - 2].parse::<i64>() {
+                            total += n;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    total
+}
+
+/// SHA-256 hash of a file.
+fn hash_file(path: &Path) -> BuildResult<String> {
+    let data = std::fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Get a build record by ID.
+pub fn get_build(pool: &ConnPool, id: &str) -> BuildResult<BuildRecord> {
+    let conn = pool.get().map_err(|e| BuildError::Pool(e.to_string()))?;
+    conn.query_row(
+        "SELECT id, status, commit_hash, test_count, binary_hash, binary_size, \
+         started_at, completed_at, error, duration_secs FROM build_history WHERE id=?1",
+        [id],
+        |row| {
+            Ok(BuildRecord {
+                id: row.get(0)?,
+                status: BuildStatus::from_str(&row.get::<_, String>(1)?),
+                commit_hash: row.get(2)?,
+                test_count: row.get(3)?,
+                binary_hash: row.get(4)?,
+                binary_size: row.get(5)?,
+                started_at: row.get(6)?,
+                completed_at: row.get(7)?,
+                error: row.get(8)?,
+                duration_secs: row.get(9)?,
+            })
+        },
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => BuildError::NotFound(format!("build {id}")),
+        other => BuildError::Db(other),
+    })
+}
+
+/// List recent builds.
+pub fn list_builds(pool: &ConnPool, limit: i64) -> BuildResult<Vec<BuildRecord>> {
+    let conn = pool.get().map_err(|e| BuildError::Pool(e.to_string()))?;
+    let mut stmt = conn.prepare(
+        "SELECT id, status, commit_hash, test_count, binary_hash, binary_size, \
+         started_at, completed_at, error, duration_secs \
+         FROM build_history ORDER BY started_at DESC LIMIT ?1",
+    )?;
+    let rows = stmt.query_map([limit], |row| {
+        Ok(BuildRecord {
+            id: row.get(0)?,
+            status: BuildStatus::from_str(&row.get::<_, String>(1)?),
+            commit_hash: row.get(2)?,
+            test_count: row.get(3)?,
+            binary_hash: row.get(4)?,
+            binary_size: row.get(5)?,
+            started_at: row.get(6)?,
+            completed_at: row.get(7)?,
+            error: row.get(8)?,
+            duration_secs: row.get(9)?,
+        })
+    })?;
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_test_count_from_output() {
+        let output = "test result: ok. 59 passed; 0 failed; 0 ignored;\n\
+                       test result: ok. 12 passed; 0 failed; 0 ignored;";
+        assert_eq!(parse_test_count(output), 71);
+    }
+
+    #[test]
+    fn parse_test_count_empty() {
+        assert_eq!(parse_test_count("no test output"), 0);
+    }
+
+    #[test]
+    fn current_commit_returns_something() {
+        let commit = current_commit();
+        assert!(!commit.is_empty());
+    }
+
+    #[test]
+    fn create_and_get_build() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+
+        let id = create_build(&pool, "abc123").unwrap();
+        let rec = get_build(&pool, &id).unwrap();
+        assert_eq!(rec.commit_hash, "abc123");
+        assert_eq!(rec.status, BuildStatus::Queued);
+    }
+
+    #[test]
+    fn list_builds_empty() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+
+        let builds = list_builds(&pool, 10).unwrap();
+        assert!(builds.is_empty());
+    }
+
+    #[test]
+    fn update_and_complete_build() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+
+        let id = create_build(&pool, "def456").unwrap();
+        update_status(&pool, &id, BuildStatus::Testing).unwrap();
+
+        let rec = get_build(&pool, &id).unwrap();
+        assert_eq!(rec.status, BuildStatus::Testing);
+
+        let completed = BuildRecord {
+            id: id.clone(),
+            status: BuildStatus::Succeeded,
+            commit_hash: "def456".into(),
+            test_count: Some(971),
+            binary_hash: Some("sha256abc".into()),
+            binary_size: Some(50_000_000),
+            started_at: rec.started_at,
+            completed_at: None,
+            error: None,
+            duration_secs: Some(120.5),
+        };
+        complete_build(&pool, &id, &completed).unwrap();
+
+        let rec = get_build(&pool, &id).unwrap();
+        assert_eq!(rec.status, BuildStatus::Succeeded);
+        assert_eq!(rec.test_count, Some(971));
+    }
+}

--- a/daemon/crates/convergio-build/src/deployer.rs
+++ b/daemon/crates/convergio-build/src/deployer.rs
@@ -1,0 +1,136 @@
+//! Deploy logic — binary swap + launchd restart.
+
+use crate::types::{BuildError, BuildResult};
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
+
+/// Resolve the path to the running daemon binary.
+pub fn running_binary_path() -> PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("/usr/local/bin/convergio"))
+}
+
+/// Resolve the newly-built release binary.
+pub fn release_binary_path(workspace: &Path) -> PathBuf {
+    workspace.join("target/release/convergio")
+}
+
+/// Deploy a new binary: backup old → copy new → verify → restart.
+/// Returns the backup path of the old binary.
+pub fn deploy(workspace: &Path) -> BuildResult<PathBuf> {
+    let current = running_binary_path();
+    let new_binary = release_binary_path(workspace);
+
+    if !new_binary.exists() {
+        return Err(BuildError::DeployFailed(
+            "release binary not found — run build first".into(),
+        ));
+    }
+
+    // 1. Backup current binary
+    let backup = current.with_extension("bak");
+    if current.exists() {
+        std::fs::copy(&current, &backup)?;
+        info!(backup = %backup.display(), "backed up current binary");
+    }
+
+    // 2. Copy new binary over current
+    std::fs::copy(&new_binary, &current)?;
+    info!(
+        from = %new_binary.display(),
+        to = %current.display(),
+        "deployed new binary"
+    );
+
+    // 3. Ensure executable permission
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&current)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&current, perms)?;
+    }
+
+    // 4. Restart via launchd
+    match restart_launchd() {
+        Ok(()) => info!("launchd service restarted"),
+        Err(e) => warn!("launchd restart failed (manual restart needed): {e}"),
+    }
+
+    Ok(backup)
+}
+
+/// Restart the convergio launchd service.
+fn restart_launchd() -> BuildResult<()> {
+    let label = "com.convergio.daemon";
+
+    // Stop
+    let stop = std::process::Command::new("launchctl")
+        .args(["stop", label])
+        .output()?;
+    if !stop.status.success() {
+        warn!("launchctl stop failed (service may not be running)");
+    }
+
+    // Start (launchd will pick up the new binary)
+    let start = std::process::Command::new("launchctl")
+        .args(["start", label])
+        .output()?;
+    if !start.status.success() {
+        let stderr = String::from_utf8_lossy(&start.stderr);
+        return Err(BuildError::DeployFailed(format!(
+            "launchctl start: {stderr}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Rollback to the backup binary.
+pub fn rollback(_workspace: &Path) -> BuildResult<()> {
+    let current = running_binary_path();
+    let backup = current.with_extension("bak");
+
+    if !backup.exists() {
+        return Err(BuildError::DeployFailed("no backup binary found".into()));
+    }
+
+    std::fs::copy(&backup, &current)?;
+    info!("rolled back to backup binary");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&current)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&current, perms)?;
+    }
+
+    restart_launchd()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_binary_returns_path() {
+        let path = running_binary_path();
+        // In test context this is the test binary, not convergio
+        assert!(!path.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn release_binary_path_correct() {
+        let ws = PathBuf::from("/tmp/daemon");
+        let p = release_binary_path(&ws);
+        assert_eq!(p, PathBuf::from("/tmp/daemon/target/release/convergio"));
+    }
+
+    #[test]
+    fn deploy_fails_without_binary() {
+        let ws = PathBuf::from("/tmp/nonexistent-workspace");
+        let result = deploy(&ws);
+        assert!(result.is_err());
+    }
+}

--- a/daemon/crates/convergio-build/src/ext.rs
+++ b/daemon/crates/convergio-build/src/ext.rs
@@ -1,0 +1,172 @@
+//! BuildExtension — impl Extension for the self-build module.
+
+use convergio_db::pool::ConnPool;
+use convergio_types::extension::{AppContext, ExtResult, Extension, Health, Metric, Migration};
+use convergio_types::manifest::{Capability, Manifest, ModuleKind};
+
+/// The Extension entry point for self-build.
+pub struct BuildExtension {
+    pool: ConnPool,
+}
+
+impl BuildExtension {
+    pub fn new(pool: ConnPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl Default for BuildExtension {
+    fn default() -> Self {
+        let pool = convergio_db::pool::create_memory_pool().expect("in-memory pool for default");
+        Self { pool }
+    }
+}
+
+impl Extension for BuildExtension {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            id: "convergio-build".to_string(),
+            description: "Self-build: the daemon builds, tests, and deploys itself".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            kind: ModuleKind::Platform,
+            provides: vec![
+                Capability {
+                    name: "self-build".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Build the daemon from source (check, test, release)".to_string(),
+                },
+                Capability {
+                    name: "self-deploy".to_string(),
+                    version: "1.0".to_string(),
+                    description: "Deploy new binary with launchd restart and rollback".to_string(),
+                },
+            ],
+            requires: vec![],
+            agent_tools: vec![],
+        }
+    }
+
+    fn routes(&self, _ctx: &AppContext) -> Option<axum::Router> {
+        let state = std::sync::Arc::new(crate::routes::BuildState {
+            pool: self.pool.clone(),
+        });
+        Some(crate::routes::router(state))
+    }
+
+    fn migrations(&self) -> Vec<Migration> {
+        crate::schema::migrations()
+    }
+
+    fn on_start(&self, _ctx: &AppContext) -> ExtResult<()> {
+        tracing::info!("build: self-build extension started");
+        Ok(())
+    }
+
+    fn health(&self) -> Health {
+        match self.pool.get() {
+            Ok(conn) => {
+                let ok = conn
+                    .query_row("SELECT COUNT(*) FROM build_history", [], |r| {
+                        r.get::<_, i64>(0)
+                    })
+                    .is_ok();
+                if ok {
+                    Health::Ok
+                } else {
+                    Health::Degraded {
+                        reason: "build_history table inaccessible".into(),
+                    }
+                }
+            }
+            Err(e) => Health::Down {
+                reason: format!("pool error: {e}"),
+            },
+        }
+    }
+
+    fn metrics(&self) -> Vec<Metric> {
+        let conn = match self.pool.get() {
+            Ok(c) => c,
+            Err(_) => return vec![],
+        };
+        let mut metrics = Vec::new();
+        if let Ok(n) = conn.query_row("SELECT COUNT(*) FROM build_history", [], |r| {
+            r.get::<_, f64>(0)
+        }) {
+            metrics.push(Metric {
+                name: "build.total".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        if let Ok(n) = conn.query_row(
+            "SELECT COUNT(*) FROM build_history WHERE status='succeeded'",
+            [],
+            |r| r.get::<_, f64>(0),
+        ) {
+            metrics.push(Metric {
+                name: "build.succeeded".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        if let Ok(n) = conn.query_row(
+            "SELECT COUNT(*) FROM build_history WHERE status='deployed'",
+            [],
+            |r| r.get::<_, f64>(0),
+        ) {
+            metrics.push(Metric {
+                name: "build.deployed".into(),
+                value: n,
+                labels: vec![],
+            });
+        }
+        metrics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_has_correct_id() {
+        let ext = BuildExtension::default();
+        let m = ext.manifest();
+        assert_eq!(m.id, "convergio-build");
+        assert_eq!(m.provides.len(), 2);
+    }
+
+    #[test]
+    fn migrations_are_returned() {
+        let ext = BuildExtension::default();
+        let migs = ext.migrations();
+        assert_eq!(migs.len(), 1);
+    }
+
+    #[test]
+    fn health_ok_with_memory_pool() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+        let ext = BuildExtension::new(pool);
+        assert!(matches!(ext.health(), Health::Ok));
+    }
+
+    #[test]
+    fn metrics_with_empty_db() {
+        let pool = convergio_db::pool::create_memory_pool().unwrap();
+        let conn = pool.get().unwrap();
+        for m in crate::schema::migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        drop(conn);
+        let ext = BuildExtension::new(pool);
+        let m = ext.metrics();
+        assert_eq!(m.len(), 3);
+        assert_eq!(m[0].value, 0.0);
+    }
+}

--- a/daemon/crates/convergio-build/src/lib.rs
+++ b/daemon/crates/convergio-build/src/lib.rs
@@ -1,0 +1,14 @@
+//! convergio-build — Self-build: the daemon builds, tests, and deploys itself.
+//!
+//! Provides endpoints to trigger cargo check/test/build, track build history,
+//! and deploy new binaries with automatic launchd restart.
+
+pub mod builder;
+pub mod deployer;
+pub mod ext;
+pub mod routes;
+pub mod schema;
+pub mod types;
+
+pub use ext::BuildExtension;
+pub use types::{BuildError, BuildResult};

--- a/daemon/crates/convergio-build/src/routes.rs
+++ b/daemon/crates/convergio-build/src/routes.rs
@@ -1,0 +1,178 @@
+//! HTTP routes for self-build operations.
+
+use crate::builder;
+use crate::types::{BuildRecord, BuildStatus};
+use axum::extract::{Path, Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use convergio_db::pool::ConnPool;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Shared state for build routes.
+#[derive(Clone)]
+pub struct BuildState {
+    pub pool: ConnPool,
+}
+
+/// Build the self-build router.
+pub fn router(state: Arc<BuildState>) -> Router {
+    Router::new()
+        .route("/api/build/self", post(trigger_build))
+        .route("/api/build/status/{id}", get(build_status))
+        .route("/api/build/history", get(build_history))
+        .route("/api/build/deploy/{id}", post(deploy_build))
+        .route("/api/build/rollback", post(rollback_build))
+        .with_state(state)
+}
+
+/// POST /api/build/self — Trigger a new self-build.
+async fn trigger_build(State(st): State<Arc<BuildState>>) -> Json<Value> {
+    let commit = builder::current_commit();
+    let build_id = match builder::create_build(&st.pool, &commit) {
+        Ok(id) => id,
+        Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
+    };
+
+    let pool = st.pool.clone();
+    let id = build_id.clone();
+
+    // Run build in background task
+    tokio::spawn(async move {
+        run_build_pipeline(pool, id).await;
+    });
+
+    Json(json!({
+        "ok": true,
+        "build_id": build_id,
+        "commit": commit,
+        "status": "queued"
+    }))
+}
+
+/// Background build pipeline: check → test → build → update DB.
+async fn run_build_pipeline(pool: ConnPool, build_id: String) {
+    let start = Instant::now();
+    let workspace = builder::workspace_root();
+
+    // Mark as building
+    let _ = builder::update_status(&pool, &build_id, BuildStatus::Building);
+
+    // Run build (blocking — offload to spawn_blocking)
+    let ws = workspace.clone();
+    let result = tokio::task::spawn_blocking(move || builder::run_build(&ws)).await;
+
+    let duration = start.elapsed().as_secs_f64();
+    let commit = builder::current_commit();
+
+    match result {
+        Ok(Ok((test_count, binary_hash, binary_size))) => {
+            let record = BuildRecord {
+                id: build_id.clone(),
+                status: BuildStatus::Succeeded,
+                commit_hash: commit,
+                test_count: Some(test_count),
+                binary_hash: Some(binary_hash),
+                binary_size: Some(binary_size),
+                started_at: String::new(),
+                completed_at: None,
+                error: None,
+                duration_secs: Some(duration),
+            };
+            let _ = builder::complete_build(&pool, &build_id, &record);
+            tracing::info!(build_id, duration, test_count, "self-build succeeded");
+        }
+        Ok(Err(e)) => {
+            let record = BuildRecord {
+                id: build_id.clone(),
+                status: BuildStatus::Failed,
+                commit_hash: commit,
+                test_count: None,
+                binary_hash: None,
+                binary_size: None,
+                started_at: String::new(),
+                completed_at: None,
+                error: Some(e.to_string()),
+                duration_secs: Some(duration),
+            };
+            let _ = builder::complete_build(&pool, &build_id, &record);
+            tracing::error!(build_id, error = %e, "self-build failed");
+        }
+        Err(e) => {
+            tracing::error!(build_id, error = %e, "self-build task panicked");
+        }
+    }
+}
+
+/// GET /api/build/status/:id — Get build status.
+async fn build_status(State(st): State<Arc<BuildState>>, Path(id): Path<String>) -> Json<Value> {
+    match builder::get_build(&st.pool, &id) {
+        Ok(rec) => Json(json!({"ok": true, "build": rec})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+#[derive(Deserialize)]
+struct HistoryQuery {
+    #[serde(default = "default_limit")]
+    limit: i64,
+}
+
+fn default_limit() -> i64 {
+    20
+}
+
+/// GET /api/build/history — List recent builds.
+async fn build_history(
+    State(st): State<Arc<BuildState>>,
+    Query(q): Query<HistoryQuery>,
+) -> Json<Value> {
+    match builder::list_builds(&st.pool, q.limit) {
+        Ok(builds) => Json(json!({"ok": true, "builds": builds})),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+/// POST /api/build/deploy/:id — Deploy a successful build.
+async fn deploy_build(State(st): State<Arc<BuildState>>, Path(id): Path<String>) -> Json<Value> {
+    // Verify build succeeded
+    let record = match builder::get_build(&st.pool, &id) {
+        Ok(r) => r,
+        Err(e) => return Json(json!({"ok": false, "error": e.to_string()})),
+    };
+    if record.status != BuildStatus::Succeeded {
+        return Json(json!({
+            "ok": false,
+            "error": format!("build status is '{}', must be 'succeeded'", record.status)
+        }));
+    }
+
+    let workspace = builder::workspace_root();
+    match crate::deployer::deploy(&workspace) {
+        Ok(backup) => {
+            let _ = builder::update_status(&st.pool, &id, BuildStatus::Deployed);
+            Json(json!({
+                "ok": true,
+                "deployed": true,
+                "backup": backup.to_string_lossy(),
+                "note": "daemon will restart via launchd"
+            }))
+        }
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}
+
+/// POST /api/build/rollback — Rollback to previous binary.
+async fn rollback_build(State(_st): State<Arc<BuildState>>) -> Json<Value> {
+    let workspace = builder::workspace_root();
+    match crate::deployer::rollback(&workspace) {
+        Ok(()) => Json(json!({
+            "ok": true,
+            "rolled_back": true,
+            "note": "daemon will restart with previous binary"
+        })),
+        Err(e) => Json(json!({"ok": false, "error": e.to_string()})),
+    }
+}

--- a/daemon/crates/convergio-build/src/schema.rs
+++ b/daemon/crates/convergio-build/src/schema.rs
@@ -1,0 +1,57 @@
+//! DB migrations for the build module.
+
+use convergio_types::extension::Migration;
+
+pub fn migrations() -> Vec<Migration> {
+    vec![Migration {
+        version: 1,
+        description: "build history tracking table",
+        up: "\
+CREATE TABLE IF NOT EXISTS build_history (
+    id            TEXT PRIMARY KEY,
+    status        TEXT NOT NULL DEFAULT 'queued',
+    commit_hash   TEXT NOT NULL,
+    test_count    INTEGER,
+    binary_hash   TEXT,
+    binary_size   INTEGER,
+    started_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at  TEXT,
+    error         TEXT,
+    duration_secs REAL
+);
+CREATE INDEX IF NOT EXISTS idx_build_history_date
+    ON build_history(started_at);
+CREATE INDEX IF NOT EXISTS idx_build_history_status
+    ON build_history(status);",
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrations_apply_to_sqlite() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        for m in migrations() {
+            conn.execute_batch(m.up).unwrap();
+        }
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' \
+                 AND name = 'build_history'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn migrations_have_sequential_versions() {
+        let migs = migrations();
+        for (i, m) in migs.iter().enumerate() {
+            assert_eq!(m.version, (i + 1) as u32);
+        }
+    }
+}

--- a/daemon/crates/convergio-build/src/types.rs
+++ b/daemon/crates/convergio-build/src/types.rs
@@ -1,0 +1,78 @@
+//! Types and DTOs for the build module.
+
+use serde::{Deserialize, Serialize};
+
+/// Build status lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildStatus {
+    Queued,
+    Building,
+    Testing,
+    Compiling,
+    Succeeded,
+    Failed,
+    Deployed,
+}
+
+impl std::fmt::Display for BuildStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Queued => write!(f, "queued"),
+            Self::Building => write!(f, "building"),
+            Self::Testing => write!(f, "testing"),
+            Self::Compiling => write!(f, "compiling"),
+            Self::Succeeded => write!(f, "succeeded"),
+            Self::Failed => write!(f, "failed"),
+            Self::Deployed => write!(f, "deployed"),
+        }
+    }
+}
+
+impl BuildStatus {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "queued" => Self::Queued,
+            "building" => Self::Building,
+            "testing" => Self::Testing,
+            "compiling" => Self::Compiling,
+            "succeeded" => Self::Succeeded,
+            "deployed" => Self::Deployed,
+            _ => Self::Failed,
+        }
+    }
+}
+
+/// A build record stored in the database.
+#[derive(Debug, Clone, Serialize)]
+pub struct BuildRecord {
+    pub id: String,
+    pub status: BuildStatus,
+    pub commit_hash: String,
+    pub test_count: Option<i64>,
+    pub binary_hash: Option<String>,
+    pub binary_size: Option<i64>,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub error: Option<String>,
+    pub duration_secs: Option<f64>,
+}
+
+/// Error type for build operations.
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    #[error("db: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("pool: {0}")]
+    Pool(String),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("build failed: {0}")]
+    BuildFailed(String),
+    #[error("deploy failed: {0}")]
+    DeployFailed(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+}
+
+pub type BuildResult<T> = std::result::Result<T, BuildError>;

--- a/daemon/crates/convergio-cli/src/cli_build.rs
+++ b/daemon/crates/convergio-cli/src/cli_build.rs
@@ -1,0 +1,186 @@
+// Self-build CLI subcommands — triggers daemon self-build via HTTP API.
+
+use crate::cli_error::CliError;
+use clap::Subcommand;
+
+#[derive(Debug, Subcommand)]
+pub enum BuildCommands {
+    /// Trigger a self-build (check + test + release build)
+    #[command(name = "self")]
+    Trigger {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Check build status by ID
+    Status {
+        /// Build ID to check
+        build_id: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// List recent builds
+    History {
+        /// Max number of builds to show
+        #[arg(long, default_value = "20")]
+        limit: i64,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Deploy a successful build (binary swap + restart)
+    Deploy {
+        /// Build ID to deploy
+        build_id: String,
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+    /// Rollback to previous binary
+    Rollback {
+        /// Human-readable output instead of JSON
+        #[arg(long)]
+        human: bool,
+        /// Daemon API base URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        api_url: String,
+    },
+}
+
+pub async fn handle(cmd: BuildCommands) -> Result<(), CliError> {
+    match cmd {
+        BuildCommands::Trigger { human, api_url } => {
+            let body = serde_json::json!({});
+            post_and_print(&format!("{api_url}/api/build/self"), &body, human).await
+        }
+        BuildCommands::Status {
+            build_id,
+            human,
+            api_url,
+        } => fetch_and_print(&format!("{api_url}/api/build/status/{build_id}"), human).await,
+        BuildCommands::History {
+            limit,
+            human,
+            api_url,
+        } => fetch_and_print(&format!("{api_url}/api/build/history?limit={limit}"), human).await,
+        BuildCommands::Deploy {
+            build_id,
+            human,
+            api_url,
+        } => {
+            let body = serde_json::json!({});
+            post_and_print(
+                &format!("{api_url}/api/build/deploy/{build_id}"),
+                &body,
+                human,
+            )
+            .await
+        }
+        BuildCommands::Rollback { human, api_url } => {
+            let body = serde_json::json!({});
+            post_and_print(&format!("{api_url}/api/build/rollback"), &body, human).await
+        }
+    }
+}
+
+async fn fetch_and_print(url: &str, human: bool) -> Result<(), CliError> {
+    let resp = reqwest::get(url)
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let status = resp.status();
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    print_value(&val, human);
+    if !status.is_success() {
+        return Err(CliError::NotFound("API returned non-success status".into()));
+    }
+    Ok(())
+}
+
+async fn post_and_print(url: &str, body: &serde_json::Value, human: bool) -> Result<(), CliError> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error connecting to daemon: {e}")))?;
+    let status = resp.status();
+    let val: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| CliError::ApiCallFailed(format!("error parsing response: {e}")))?;
+    print_value(&val, human);
+    if !status.is_success() {
+        return Err(CliError::NotFound("API returned non-success status".into()));
+    }
+    Ok(())
+}
+
+fn print_value(val: &serde_json::Value, human: bool) {
+    if human {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+        );
+    } else {
+        println!("{val}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_trigger_variant_exists() {
+        let cmd = BuildCommands::Trigger {
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BuildCommands::Trigger { .. }));
+    }
+
+    #[test]
+    fn build_status_variant_exists() {
+        let cmd = BuildCommands::Status {
+            build_id: "abc-123".to_string(),
+            human: true,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BuildCommands::Status { .. }));
+    }
+
+    #[test]
+    fn build_deploy_variant_exists() {
+        let cmd = BuildCommands::Deploy {
+            build_id: "abc-123".to_string(),
+            human: false,
+            api_url: "http://localhost:8420".to_string(),
+        };
+        assert!(matches!(cmd, BuildCommands::Deploy { .. }));
+    }
+
+    #[test]
+    fn build_history_url_format() {
+        let api_url = "http://localhost:8420";
+        let limit = 10;
+        let url = format!("{api_url}/api/build/history?limit={limit}");
+        assert_eq!(url, "http://localhost:8420/api/build/history?limit=10");
+    }
+}

--- a/daemon/crates/convergio-cli/src/cli_commands.rs
+++ b/daemon/crates/convergio-cli/src/cli_commands.rs
@@ -3,9 +3,9 @@
 // are NOT included here — they live in the daemon binary.
 
 use crate::{
-    cli_agent, cli_bus, cli_capability, cli_channel, cli_checkpoint, cli_delegation, cli_domain,
-    cli_kb, cli_kernel, cli_lock, cli_memory, cli_ops, cli_org, cli_plan, cli_project, cli_reap,
-    cli_repo, cli_review, cli_run, cli_skill, cli_task, cli_voice, cli_wave, cli_who,
+    cli_agent, cli_build, cli_bus, cli_capability, cli_channel, cli_checkpoint, cli_delegation,
+    cli_domain, cli_kb, cli_kernel, cli_lock, cli_memory, cli_ops, cli_org, cli_plan, cli_project,
+    cli_reap, cli_repo, cli_review, cli_run, cli_skill, cli_task, cli_voice, cli_wave, cli_who,
     cli_workspace,
 };
 use clap::Subcommand;
@@ -189,6 +189,11 @@ pub enum Commands {
     Alert {
         #[command(subcommand)]
         command: cli_ops::AlertCommands,
+    },
+    #[command(about = "Self-build: build, test, deploy the daemon")]
+    Build {
+        #[command(subcommand)]
+        command: cli_build::BuildCommands,
     },
     #[command(about = "Open API documentation in browser")]
     Api,

--- a/daemon/crates/convergio-cli/src/dispatch.rs
+++ b/daemon/crates/convergio-cli/src/dispatch.rs
@@ -4,10 +4,11 @@
 use crate::cli_commands::Commands;
 use crate::cli_error::CliError;
 use crate::{
-    cli_agent_format, cli_ask, cli_audit, cli_audit_project, cli_bus, cli_capability, cli_channel,
-    cli_chat, cli_checkpoint, cli_delegation, cli_domain, cli_kb, cli_kernel, cli_launch, cli_lock,
-    cli_memory, cli_ops, cli_org, cli_plan, cli_project, cli_reap, cli_repo, cli_review, cli_run,
-    cli_setup, cli_skill, cli_status, cli_task, cli_voice, cli_wave, cli_who, cli_workspace,
+    cli_agent_format, cli_ask, cli_audit, cli_audit_project, cli_build, cli_bus, cli_capability,
+    cli_channel, cli_chat, cli_checkpoint, cli_delegation, cli_domain, cli_kb, cli_kernel,
+    cli_launch, cli_lock, cli_memory, cli_ops, cli_org, cli_plan, cli_project, cli_reap, cli_repo,
+    cli_review, cli_run, cli_setup, cli_skill, cli_status, cli_task, cli_voice, cli_wave, cli_who,
+    cli_workspace,
 };
 use std::process::ExitCode;
 
@@ -101,6 +102,7 @@ pub async fn dispatch(command: Commands) -> ExitCode {
             crate::cli_api_list::print_api_list();
             ExitCode::SUCCESS
         }
+        Commands::Build { command } => exit_on_err(cli_build::handle(command).await),
         Commands::Cleanup => exit_on_err(crate::cli_cleanup::handle().await),
         Commands::Claude {
             name,

--- a/daemon/crates/convergio-cli/src/lib.rs
+++ b/daemon/crates/convergio-cli/src/lib.rs
@@ -22,6 +22,7 @@ pub mod cli_api_list;
 pub mod cli_ask;
 pub mod cli_audit;
 pub mod cli_audit_project;
+pub mod cli_build;
 pub mod cli_bus;
 pub mod cli_bus_ask;
 pub mod cli_bus_org;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -60,6 +60,7 @@ fn register_extensions(
             pool.clone(),
         )),
         Arc::new(convergio_scheduler::SchedulerExtension::new(pool.clone())),
+        Arc::new(convergio_build::BuildExtension::new(pool.clone())),
     ]
 }
 


### PR DESCRIPTION
## Summary
- New crate `convergio-build`: the daemon can build, test, and deploy itself
- 5 HTTP endpoints: trigger build, check status, history, deploy, rollback
- CLI: `cvg build self`, `cvg build status`, `cvg build history`, `cvg build deploy`
- Extension wired in main.rs (21 extensions total), 15 new tests
- Build pipeline: `cargo check` → `cargo test` → `cargo build --release` (async)
- Deploy: binary backup → swap → launchd restart, with rollback support

## Architecture
- `builder.rs`: cargo pipeline execution, DB tracking, binary hashing
- `deployer.rs`: binary swap + launchd restart + rollback
- `routes.rs`: HTTP handlers with async build task
- `ext.rs`: Extension trait impl with health/metrics
- `schema.rs`: `build_history` table

## Test plan
- [x] `cargo check --workspace` — zero errors, zero warnings
- [x] `cargo test --workspace` — 990 tests pass (was 971, +19)
- [x] `cargo fmt --all` — formatted
- [ ] Smoke test: `curl -X POST http://localhost:8420/api/build/self`

🤖 Generated with [Claude Code](https://claude.com/claude-code)