### PR TITLE
feat: Fase 49 — harness engineering (baseline, Thor separato, one-feature)

### DIFF
--- a/daemon/crates/convergio-agent-runtime/src/harness.rs
+++ b/daemon/crates/convergio-agent-runtime/src/harness.rs
@@ -1,0 +1,120 @@
+//! Harness engineering templates — baseline test, TASK.md header, init.sh.
+//!
+//! Implements the Anthropic harness pattern (adapted for Convergio):
+//! - Baseline test before every session
+//! - One feature at a time
+//! - Agent reads from DB, not static files
+//! - Thor uses a separate model for evaluation
+
+use crate::types::{RuntimeError, RuntimeResult};
+use std::path::Path;
+
+/// Write init.sh baseline test script to the worktree.
+/// Agent MUST run this before starting work. If it fails, fix first.
+pub fn write_baseline_script(workspace: &Path) -> RuntimeResult<()> {
+    let path = workspace.join("init.sh");
+    std::fs::write(&path, BASELINE_SCRIPT)
+        .map_err(|e| RuntimeError::Internal(format!("write init.sh: {e}")))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&path)
+            .map_err(|e| RuntimeError::Internal(format!("metadata init.sh: {e}")))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms)
+            .map_err(|e| RuntimeError::Internal(format!("chmod init.sh: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Resolve the model for Thor evaluation (separate from coding agent).
+/// Defaults to Sonnet — different from the typical Opus coding tier.
+pub fn thor_model() -> String {
+    std::env::var("CONVERGIO_THOR_MODEL").unwrap_or_else(|_| "claude-sonnet-4-6".to_string())
+}
+
+/// Header prepended to every TASK.md — delegation rules + harness rules.
+pub const DELEGATION_HEADER: &str = "\
+# REGOLE OPERATIVE (leggere PRIMA di iniziare)
+
+## STEP 0: Baseline test (OBBLIGATORIO)
+Prima di qualsiasi lavoro, esegui:
+```bash
+bash init.sh
+```
+Se fallisce, FIXA IL BASELINE prima di iniziare. Non lavorare su una base rotta.
+
+## UNA feature alla volta
+Lavora su UNA SOLA feature per sessione. Testala. Committala. Non tentare
+di fare 5 cose in parallelo. Una feature = un commit = un risultato verificabile.
+
+## Leggi dal DB, non da file .md
+Il daemon ha un DB con plans/tasks/evidence/context. Usa la context API:
+```bash
+curl http://localhost:8420/api/agents/context/{agent_id}
+```
+NON leggere stato da file .md statici — il DB e' la source of truth.
+
+## Risparmia token — DELEGA il lavoro meccanico
+Tu sei il COORDINATORE. Non scrivere codice meccanico direttamente.
+Per ogni task >50 righe che non richiede decisioni architetturali:
+```bash
+cd <worktree> && gh copilot --model claude-opus-4-6
+```
+
+## Regole
+- Leggi AGENTS.md per tutte le regole
+- Worktree isolato, max 250 righe/file
+- cargo check + test + fmt prima di commit
+- Loop chiuso: chi produce input? chi consuma output? l'utente lo vede?
+- NO squash merge (repo setting: solo merge commit)";
+
+const BASELINE_SCRIPT: &str = r#"#!/bin/bash
+# Baseline test — run BEFORE starting any work.
+# If this fails, fix the baseline first. Do NOT start new work on a broken base.
+set -e
+
+echo "=== Baseline: cargo check ==="
+cd daemon && cargo check --workspace
+
+echo "=== Baseline: cargo test ==="
+cargo test --workspace
+
+echo "=== Baseline: daemon health ==="
+curl -sf http://localhost:8420/api/health || echo "WARN: daemon not reachable (ok if not running locally)"
+
+echo "=== Baseline PASSED ==="
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn write_baseline_creates_init_sh() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_baseline_script(tmp.path()).unwrap();
+        let init = tmp.path().join("init.sh");
+        assert!(init.exists());
+        let content = fs::read_to_string(init).unwrap();
+        assert!(content.contains("cargo check"));
+        assert!(content.contains("cargo test"));
+        assert!(content.contains("Baseline PASSED"));
+    }
+
+    #[test]
+    fn delegation_header_has_harness_rules() {
+        assert!(DELEGATION_HEADER.contains("UNA feature alla volta"));
+        assert!(DELEGATION_HEADER.contains("init.sh"));
+        assert!(DELEGATION_HEADER.contains("context API"));
+    }
+
+    #[test]
+    fn thor_model_defaults_to_sonnet() {
+        if std::env::var("CONVERGIO_THOR_MODEL").is_err() {
+            assert!(thor_model().contains("sonnet"));
+        }
+    }
+}

--- a/daemon/crates/convergio-agent-runtime/src/lib.rs
+++ b/daemon/crates/convergio-agent-runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub mod context;
 pub mod context_routes;
 pub mod delegation;
 pub mod ext;
+pub mod harness;
 pub mod heartbeat;
 pub mod monitor_helpers;
 pub mod reaper;

--- a/daemon/crates/convergio-agent-runtime/src/spawner.rs
+++ b/daemon/crates/convergio-agent-runtime/src/spawner.rs
@@ -52,36 +52,23 @@ pub fn create_worktree(repo_root: &Path, name: &str) -> RuntimeResult<PathBuf> {
     Ok(wt_path)
 }
 
-/// Write task instructions to a file the agent will read.
-/// Prepends delegation rules to save tokens.
+/// Write task instructions and baseline script to the worktree.
+/// Prepends delegation rules and harness engineering rules.
 pub fn write_instructions(workspace: &Path, instructions: &str) -> RuntimeResult<PathBuf> {
+    use crate::harness;
     let path = workspace.join("TASK.md");
     let content = format!(
-        "{DELEGATION_HEADER}\n\n---\n\n{instructions}",
-        DELEGATION_HEADER = DELEGATION_HEADER
+        "{header}\n\n---\n\n{instructions}",
+        header = harness::DELEGATION_HEADER
     );
-    std::fs::write(&path, content)
+    std::fs::write(&path, &content)
         .map_err(|e| RuntimeError::Internal(format!("write TASK.md: {e}")))?;
+
+    // Write baseline test script (Fase 49: harness engineering)
+    harness::write_baseline_script(workspace)?;
+
     Ok(path)
 }
-
-const DELEGATION_HEADER: &str = "\
-# REGOLE OPERATIVE (leggere PRIMA di iniziare)
-
-## Risparmia token — DELEGA il lavoro meccanico
-Tu sei il COORDINATORE. Non scrivere codice meccanico direttamente.
-Per ogni task >50 righe che non richiede decisioni architetturali:
-```bash
-cd <worktree> && gh copilot --model claude-opus-4-6
-```
-Tu decidi COSA fare. Copilot fa il lavoro. Tu verifichi il risultato.
-
-## Regole
-- Leggi AGENTS.md per tutte le regole
-- Worktree isolato, max 250 righe/file
-- cargo check + test + fmt prima di commit
-- Loop chiuso: chi produce input? chi consuma output? l'utente lo vede?
-- NO squash merge (repo setting: solo merge commit)";
 
 /// Spawn the agent process in the workspace.
 /// `instruction_file` overrides the default "TASK.md" prompt target.
@@ -219,12 +206,16 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn write_instructions_creates_file() {
+    fn write_instructions_creates_task_and_init() {
         let tmp = tempfile::tempdir().unwrap();
         let path = write_instructions(tmp.path(), "Test task").unwrap();
         assert!(path.exists());
         let content = fs::read_to_string(path).unwrap();
         assert!(content.contains("Test task"));
+        assert!(content.contains("UNA feature alla volta"));
+        // init.sh also created
+        let init = tmp.path().join("init.sh");
+        assert!(init.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `init.sh` baseline script in every agent worktree (cargo check + test + health)
- TASK.md enforces: baseline first, one feature at a time, read from DB not .md files
- `thor_model()` returns CONVERGIO_THOR_MODEL env (defaults to Sonnet, separate from Opus)
- Extracted to `harness.rs` to keep spawner.rs under 250 lines

## Test plan
- [x] `cargo check --workspace` — zero errors
- [x] `cargo test --workspace` — 993 tests pass (+3)
- [x] Both files under 250 lines (spawner: 240, harness: 120)

🤖 Generated with [Claude Code](https://claude.com/claude-code)